### PR TITLE
CNV-87871: add Playwright test for VM NAD hot-swap pending changes

### DIFF
--- a/playwright/src/components/vm/vm-configuration-component.ts
+++ b/playwright/src/components/vm/vm-configuration-component.ts
@@ -1,4 +1,5 @@
 import PageCommons from '@/page-objects/page-commons';
+import { getPendingStatusMessageLocator } from '@/utils/pending-changes-locator';
 import { TestTimeouts } from '@/utils/test-config';
 import type { Page } from '@playwright/test';
 
@@ -14,10 +15,7 @@ export default class VmConfigurationComponent extends PageCommons {
 
   private readonly _headlessCheckbox = this.locator('input[id="headless-mode"]');
 
-  private readonly _isTextPendingChangesTextRestartRequired = this.page
-    .getByText('Pending changes')
-    .or(this.page.getByText('Restart required'))
-    .or(this.page.getByText('Migration required'));
+  private readonly _pendingStatusMessage = getPendingStatusMessageLocator(this.page);
 
   private readonly _restoreTemplateSettingsBtn = this.locator(
     'button:has-text("Restore template settings")',
@@ -679,7 +677,7 @@ export default class VmConfigurationComponent extends PageCommons {
   }
 
   async waitForPendingChanges(timeout = 60000): Promise<boolean> {
-    const pendingLocator = this._isTextPendingChangesTextRestartRequired;
+    const pendingLocator = this._pendingStatusMessage;
     try {
       await pendingLocator
         .first()
@@ -695,7 +693,7 @@ export default class VmConfigurationComponent extends PageCommons {
   }
 
   async waitForPendingChangesToDisappear(timeout = 60000): Promise<boolean> {
-    const pendingLocator = this._isTextPendingChangesTextRestartRequired;
+    const pendingLocator = this._pendingStatusMessage;
     try {
       await pendingLocator
         .first()

--- a/playwright/src/components/vm/vm-configuration-component.ts
+++ b/playwright/src/components/vm/vm-configuration-component.ts
@@ -14,9 +14,10 @@ export default class VmConfigurationComponent extends PageCommons {
 
   private readonly _headlessCheckbox = this.locator('input[id="headless-mode"]');
 
-  private readonly _isTextPendingChangesTextRestartRequired = this.locator(
-    ':is(:text("Pending changes"), :text("Restart required"), :text("Migration required"))',
-  );
+  private readonly _isTextPendingChangesTextRestartRequired = this.page
+    .getByText('Pending changes')
+    .or(this.page.getByText('Restart required'))
+    .or(this.page.getByText('Migration required'));
 
   private readonly _restoreTemplateSettingsBtn = this.locator(
     'button:has-text("Restore template settings")',

--- a/playwright/src/components/vm/vm-configuration-component.ts
+++ b/playwright/src/components/vm/vm-configuration-component.ts
@@ -15,7 +15,7 @@ export default class VmConfigurationComponent extends PageCommons {
   private readonly _headlessCheckbox = this.locator('input[id="headless-mode"]');
 
   private readonly _isTextPendingChangesTextRestartRequired = this.locator(
-    ':is(:text("Pending changes"), :text("Restart required"))',
+    ':is(:text("Pending changes"), :text("Restart required"), :text("Migration required"))',
   );
 
   private readonly _restoreTemplateSettingsBtn = this.locator(

--- a/playwright/src/components/vm/vm-configuration-network-component.ts
+++ b/playwright/src/components/vm/vm-configuration-network-component.ts
@@ -4,7 +4,7 @@
 
 import BaseComponent from '@/components/shared/base-component';
 import { TestTimeouts } from '@/utils/test-config';
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 export default class VmConfigurationNetworkComponent extends BaseComponent {
   private readonly _configurationNetworkSubTab = this.testId('vm-configuration-network');
@@ -18,11 +18,11 @@ export default class VmConfigurationNetworkComponent extends BaseComponent {
     super(page);
   }
 
-  private nicActionsKebab(nicName: string) {
+  private nicActionsKebab(nicName: string): Locator {
     return this.testId(`nic-actions-${nicName}`);
   }
 
-  private nicNetworkCell(nicName: string) {
+  private nicNetworkCell(nicName: string): Locator {
     return this.testId(`nic-network-${nicName}`);
   }
 
@@ -82,8 +82,8 @@ export default class VmConfigurationNetworkComponent extends BaseComponent {
   async verifyNicDisplaysNad(nicName: string, expectedNadName: string): Promise<boolean> {
     try {
       await this.navigateToConfigurationNetwork();
-      const text = await this.getNicNetworkName(nicName);
-      return text.includes(expectedNadName);
+      const text = (await this.getNicNetworkName(nicName)).trim();
+      return text === expectedNadName.trim();
     } catch {
       return false;
     }

--- a/playwright/src/components/vm/vm-configuration-network-component.ts
+++ b/playwright/src/components/vm/vm-configuration-network-component.ts
@@ -1,0 +1,102 @@
+/**
+ * Configuration → Network tab: NIC row actions, NAD select, pending-changes alert.
+ */
+
+import BaseComponent from '@/components/shared/base-component';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+export default class VmConfigurationNetworkComponent extends BaseComponent {
+  private readonly _configurationNetworkSubTab = this.testId('vm-configuration-network');
+  private readonly _configurationTab = this.testId('horizontal-link-Configuration');
+  private readonly _editNicModal = this.testId('dialog-modal');
+  private readonly _nadSelectInput = this.testId('select-nad-input');
+  private readonly _nadSelectToggle = this.testId('select-nad');
+  private readonly _pendingChangesAlert = this.testId('pending-changes-alert');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  private nicActionsKebab(nicName: string) {
+    return this.testId(`nic-actions-${nicName}`);
+  }
+
+  private nicNetworkCell(nicName: string) {
+    return this.testId(`nic-network-${nicName}`);
+  }
+
+  async changeNicNetworkAttachment(nicName: string, nadName: string): Promise<void> {
+    await this.navigateToConfigurationNetwork();
+
+    const kebab = this.nicActionsKebab(nicName);
+    await kebab.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(kebab);
+
+    const editItem = this.testId('network-interface-edit');
+    await editItem.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.robustClick(editItem);
+
+    await this._editNicModal.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+
+    await this._nadSelectToggle.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(this._nadSelectToggle);
+
+    await this._nadSelectInput.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this._nadSelectInput.fill(nadName);
+
+    const nadOption = this.testId(`network-option-${nadName}`);
+    await nadOption.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+    await this.robustClick(nadOption);
+
+    await this.robustClick(this._editNicModal.getByTestId('save-button'));
+    await this._editNicModal.waitFor({
+      state: 'hidden',
+      timeout: TestTimeouts.ELEMENT_WAIT,
+    });
+  }
+
+  async getNicNetworkName(nicName: string): Promise<string> {
+    const cell = this.nicNetworkCell(nicName);
+    await cell.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    return (await cell.textContent())?.trim() ?? '';
+  }
+
+  async navigateToConfigurationNetwork(): Promise<void> {
+    await this.navigateToTab(this._configurationTab);
+    await this.navigateToTab(this._configurationNetworkSubTab);
+  }
+
+  async verifyNicDisplaysNad(nicName: string, expectedNadName: string): Promise<boolean> {
+    try {
+      await this.navigateToConfigurationNetwork();
+      const text = await this.getNicNetworkName(nicName);
+      return text.includes(expectedNadName);
+    } catch {
+      return false;
+    }
+  }
+
+  async waitForPendingChangesAlert(
+    timeout: number = TestTimeouts.PENDING_CHANGES,
+  ): Promise<boolean> {
+    try {
+      await this._pendingChangesAlert.first().waitFor({ state: 'visible', timeout });
+      return this._pendingChangesAlert.first().isVisible();
+    } catch {
+      return false;
+    }
+  }
+}

--- a/playwright/src/components/vm/vm-configuration-network-component.ts
+++ b/playwright/src/components/vm/vm-configuration-network-component.ts
@@ -10,7 +10,7 @@ export default class VmConfigurationNetworkComponent extends BaseComponent {
   private readonly _configurationNetworkSubTab = this.testId('vm-configuration-network');
   private readonly _configurationTab = this.testId('horizontal-link-Configuration');
   private readonly _editNicModal = this.testId('dialog-modal');
-  private readonly _nadSelectInput = this.testId('select-nad-input');
+  private readonly _nadSelectInput = this.testId('select-nad-input').locator('input');
   private readonly _nadSelectToggle = this.testId('select-nad');
   private readonly _pendingChangesAlert = this.testId('pending-changes-alert');
 

--- a/playwright/src/components/vm/vm-detail-config-components.ts
+++ b/playwright/src/components/vm/vm-detail-config-components.ts
@@ -318,9 +318,10 @@ export class VirtualMachineDetailConfigurationComponent extends BaseComponent {
   private readonly _dataVolumeDetails = this.locator('text=DataVolume details');
   private readonly _evictionStrategyElement = this.testId('eviction-strategy');
   private readonly _headlessCheckbox = this.locator('input[id="headless-mode"]');
-  private readonly _isTextPendingChangesTextRestartRequired = this.locator(
-    ':is(:text("Pending changes"), :text("Restart required"), :text("Migration required"))',
-  );
+  private readonly _isTextPendingChangesTextRestartRequired = this.page
+    .getByText('Pending changes')
+    .or(this.page.getByText('Restart required'))
+    .or(this.page.getByText('Migration required'));
   private readonly _restoreTemplateSettingsBtn = this.locator(
     'button:has-text("Restore template settings")',
   );

--- a/playwright/src/components/vm/vm-detail-config-components.ts
+++ b/playwright/src/components/vm/vm-detail-config-components.ts
@@ -4,6 +4,7 @@
  */
 
 import BaseComponent from '@/components/shared/base-component';
+import { getPendingStatusMessageLocator } from '@/utils/pending-changes-locator';
 import { TestTimeouts } from '@/utils/test-config';
 import type { Page } from '@playwright/test';
 
@@ -318,10 +319,7 @@ export class VirtualMachineDetailConfigurationComponent extends BaseComponent {
   private readonly _dataVolumeDetails = this.locator('text=DataVolume details');
   private readonly _evictionStrategyElement = this.testId('eviction-strategy');
   private readonly _headlessCheckbox = this.locator('input[id="headless-mode"]');
-  private readonly _isTextPendingChangesTextRestartRequired = this.page
-    .getByText('Pending changes')
-    .or(this.page.getByText('Restart required'))
-    .or(this.page.getByText('Migration required'));
+  private readonly _pendingStatusMessage = getPendingStatusMessageLocator(this.page);
   private readonly _restoreTemplateSettingsBtn = this.locator(
     'button:has-text("Restore template settings")',
   );
@@ -932,7 +930,7 @@ export class VirtualMachineDetailConfigurationComponent extends BaseComponent {
   }
 
   async waitForPendingChanges(timeout = 60000): Promise<boolean> {
-    const pendingLocator = this._isTextPendingChangesTextRestartRequired;
+    const pendingLocator = this._pendingStatusMessage;
     try {
       await pendingLocator
         .first()
@@ -948,7 +946,7 @@ export class VirtualMachineDetailConfigurationComponent extends BaseComponent {
   }
 
   async waitForPendingChangesToDisappear(timeout = 60000): Promise<boolean> {
-    const pendingLocator = this._isTextPendingChangesTextRestartRequired;
+    const pendingLocator = this._pendingStatusMessage;
     try {
       await pendingLocator
         .first()

--- a/playwright/src/components/vm/vm-detail-config-components.ts
+++ b/playwright/src/components/vm/vm-detail-config-components.ts
@@ -319,7 +319,7 @@ export class VirtualMachineDetailConfigurationComponent extends BaseComponent {
   private readonly _evictionStrategyElement = this.testId('eviction-strategy');
   private readonly _headlessCheckbox = this.locator('input[id="headless-mode"]');
   private readonly _isTextPendingChangesTextRestartRequired = this.locator(
-    ':is(:text("Pending changes"), :text("Restart required"))',
+    ':is(:text("Pending changes"), :text("Restart required"), :text("Migration required"))',
   );
   private readonly _restoreTemplateSettingsBtn = this.locator(
     'button:has-text("Restore template settings")',

--- a/playwright/src/components/vm/vm-detail-console-components.ts
+++ b/playwright/src/components/vm/vm-detail-console-components.ts
@@ -545,9 +545,10 @@ export class VirtualMachineDetailDiagnosticsComponent extends BaseComponent {
   private readonly _inputIdSimpleFileFilename = this.locator('input[id="simple-file-filename"]');
   private readonly _inputInput = this.locator('input[aria-label="Input"]');
   private readonly _inputSearchInput = this.locator('input[aria-label="Search input"]');
-  private readonly _isTextPendingChangesTextRestartRequired = this.locator(
-    ':is(:text("Pending changes"), :text("Restart required"), :text("Migration required"))',
-  );
+  private readonly _isTextPendingChangesTextRestartRequired = this.page
+    .getByText('Pending changes')
+    .or(this.page.getByText('Restart required'))
+    .or(this.page.getByText('Migration required'));
   private readonly _last5Minutes = this.locator('text=Last 5 minutes');
   private readonly _lunReservation = this.locator('#lun-reservation');
   private readonly _migrationMenu = this.testId('migration-menu');

--- a/playwright/src/components/vm/vm-detail-console-components.ts
+++ b/playwright/src/components/vm/vm-detail-console-components.ts
@@ -545,10 +545,6 @@ export class VirtualMachineDetailDiagnosticsComponent extends BaseComponent {
   private readonly _inputIdSimpleFileFilename = this.locator('input[id="simple-file-filename"]');
   private readonly _inputInput = this.locator('input[aria-label="Input"]');
   private readonly _inputSearchInput = this.locator('input[aria-label="Search input"]');
-  private readonly _isTextPendingChangesTextRestartRequired = this.page
-    .getByText('Pending changes')
-    .or(this.page.getByText('Restart required'))
-    .or(this.page.getByText('Migration required'));
   private readonly _last5Minutes = this.locator('text=Last 5 minutes');
   private readonly _lunReservation = this.locator('#lun-reservation');
   private readonly _migrationMenu = this.testId('migration-menu');

--- a/playwright/src/components/vm/vm-detail-console-components.ts
+++ b/playwright/src/components/vm/vm-detail-console-components.ts
@@ -546,7 +546,7 @@ export class VirtualMachineDetailDiagnosticsComponent extends BaseComponent {
   private readonly _inputInput = this.locator('input[aria-label="Input"]');
   private readonly _inputSearchInput = this.locator('input[aria-label="Search input"]');
   private readonly _isTextPendingChangesTextRestartRequired = this.locator(
-    ':is(:text("Pending changes"), :text("Restart required"))',
+    ':is(:text("Pending changes"), :text("Restart required"), :text("Migration required"))',
   );
   private readonly _last5Minutes = this.locator('text=Last 5 minutes');
   private readonly _lunReservation = this.locator('#lun-reservation');

--- a/playwright/src/components/vm/vm-detail-storage-metrics-components.ts
+++ b/playwright/src/components/vm/vm-detail-storage-metrics-components.ts
@@ -1961,7 +1961,9 @@ export class VmStorageComponent extends BaseComponent {
   }
 
   async waitForPendingChangesToDisappear(timeout = 60000): Promise<boolean> {
-    const pendingLocator = this.locator(':is(:text("Pending changes"), :text("Restart required"))');
+    const pendingLocator = this.locator(
+      ':is(:text("Pending changes"), :text("Restart required"), :text("Migration required"))',
+    );
     try {
       await pendingLocator
         .first()

--- a/playwright/src/components/vm/vm-detail-storage-metrics-components.ts
+++ b/playwright/src/components/vm/vm-detail-storage-metrics-components.ts
@@ -1961,9 +1961,10 @@ export class VmStorageComponent extends BaseComponent {
   }
 
   async waitForPendingChangesToDisappear(timeout = 60000): Promise<boolean> {
-    const pendingLocator = this.locator(
-      ':is(:text("Pending changes"), :text("Restart required"), :text("Migration required"))',
-    );
+    const pendingLocator = this.page
+      .getByText('Pending changes')
+      .or(this.page.getByText('Restart required'))
+      .or(this.page.getByText('Migration required'));
     try {
       await pendingLocator
         .first()

--- a/playwright/src/components/vm/vm-detail-storage-metrics-components.ts
+++ b/playwright/src/components/vm/vm-detail-storage-metrics-components.ts
@@ -4,6 +4,7 @@
 
 import BaseComponent from '@/components/shared/base-component';
 import { DISK_NAMES } from '@/data-models';
+import { getPendingStatusMessageLocator } from '@/utils/pending-changes-locator';
 import { TestTimeouts } from '@/utils/test-config';
 import type { Page } from '@playwright/test';
 import { expect } from '@playwright/test';
@@ -1961,10 +1962,7 @@ export class VmStorageComponent extends BaseComponent {
   }
 
   async waitForPendingChangesToDisappear(timeout = 60000): Promise<boolean> {
-    const pendingLocator = this.page
-      .getByText('Pending changes')
-      .or(this.page.getByText('Restart required'))
-      .or(this.page.getByText('Migration required'));
+    const pendingLocator = getPendingStatusMessageLocator(this.page);
     try {
       await pendingLocator
         .first()

--- a/playwright/src/page-objects/vm/virtual-machine-detail-network-page.ts
+++ b/playwright/src/page-objects/vm/virtual-machine-detail-network-page.ts
@@ -1,3 +1,31 @@
+import VmConfigurationNetworkComponent from '@/components/vm/vm-configuration-network-component';
 import { VirtualMachineDetailNetworkComponent } from '@/components/vm/vm-detail-overview-scheduling-components';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
 
-export default class VirtualMachineDetailNetworkPage extends VirtualMachineDetailNetworkComponent {}
+export default class VirtualMachineDetailNetworkPage extends VirtualMachineDetailNetworkComponent {
+  private readonly configNetwork: VmConfigurationNetworkComponent;
+
+  constructor(page: Page) {
+    super(page);
+    this.configNetwork = new VmConfigurationNetworkComponent(page);
+  }
+
+  async changeNicNetworkAttachment(nicName: string, nadName: string): Promise<void> {
+    return this.configNetwork.changeNicNetworkAttachment(nicName, nadName);
+  }
+
+  async getNicNetworkName(nicName: string): Promise<string> {
+    return this.configNetwork.getNicNetworkName(nicName);
+  }
+
+  async verifyNicDisplaysNad(nicName: string, expectedNadName: string): Promise<boolean> {
+    return this.configNetwork.verifyNicDisplaysNad(nicName, expectedNadName);
+  }
+
+  async waitForPendingChangesAlert(
+    timeout: number = TestTimeouts.PENDING_CHANGES,
+  ): Promise<boolean> {
+    return this.configNetwork.waitForPendingChangesAlert(timeout);
+  }
+}

--- a/playwright/src/page-objects/vm/virtual-machine-detail-page.ts
+++ b/playwright/src/page-objects/vm/virtual-machine-detail-page.ts
@@ -100,59 +100,13 @@ export default class VirtualMachineDetailPage extends PageCommons {
 
   /**
    * Configuration → Network: row actions → Edit → change NetworkAttachmentDefinition (live NAD ref).
-   * @see STP hotpluggable-nad-ref P0 scenario.
    */
-  async changeConfigurationNetworkNicNad(
-    nicName: string,
-    nadMenuOptionText: string,
-  ): Promise<void> {
-    await this.navigateToConfigurationNetwork();
+  async changeConfigurationNetworkNicNad(nicName: string, nadName: string): Promise<void> {
+    return this.network.changeNicNetworkAttachment(nicName, nadName);
+  }
 
-    const nicRow = this.locator(`tr.pf-v6-c-table__tr:has-text("${nicName}")`);
-    await nicRow.waitFor({ state: 'visible', timeout: TestTimeouts.UI_VISIBILITY_QUICK });
-
-    const actionsBtn = nicRow.locator('.pf-v6-c-table__action button').first();
-    await actionsBtn.waitFor({
-      state: 'visible',
-      timeout: TestTimeouts.INSTANCE_TYPE_VERIFICATION,
-    });
-    await this.robustClick(actionsBtn);
-
-    const editItem = this.page
-      .locator('[role="menu"] [role="menuitem"], [role="menu"] button')
-      .filter({ hasText: /^Edit$/ });
-    await editItem.first().waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
-    await this.robustClick(editItem.first());
-
-    await this.page
-      .locator('h1')
-      .filter({ hasText: 'Edit network interface' })
-      .waitFor({ state: 'visible', timeout: TestTimeouts.INSTANCE_TYPE_VERIFICATION });
-
-    const modalScope = this.page
-      .locator('[role="dialog"], #tab-modal')
-      .filter({ hasText: 'Edit network interface' })
-      .first();
-    const nadSelectRoot = modalScope.getByTestId('network-attachment-definition-select');
-    await nadSelectRoot.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
-
-    const menuToggle = nadSelectRoot
-      .locator('button.pf-v6-c-menu-toggle__button, button[aria-label="Menu toggle"]')
-      .first();
-    await menuToggle.waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
-    await this.robustClick(menuToggle);
-
-    const nadOption = this.page
-      .locator('[role="menu"] button, [role="option"]')
-      .filter({ hasText: nadMenuOptionText });
-    await nadOption.first().waitFor({ state: 'visible', timeout: TestTimeouts.UI_DELAY_MEDIUM });
-    await this.robustClick(nadOption.first());
-
-    await this.clickSave();
-    await modalScope
-      .waitFor({ state: 'hidden', timeout: TestTimeouts.ELEMENT_WAIT })
-      .catch(() => undefined);
-    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  async getConfigurationNetworkNicName(nicName: string): Promise<string> {
+    return this.network.getNicNetworkName(nicName);
   }
 
   async changeMetricsTimeRange() {
@@ -847,22 +801,12 @@ export default class VirtualMachineDetailPage extends PageCommons {
   async verifyConfigurationDetails(vmName: string, expectedWorkload?: string): Promise<boolean> {
     return this.configuration.verifyConfigurationDetails(vmName, expectedWorkload);
   }
-  /** Returns true if the Configuration → Network table row for the NIC shows the expected NAD name in the third cell. */
+  /** Returns true if the Configuration → Network table row for the NIC shows the expected NAD name. */
   async verifyConfigurationNetworkNicDisplaysNad(
     nicName: string,
     expectedNadName: string,
   ): Promise<boolean> {
-    try {
-      await this.navigateToConfigurationNetwork();
-      const nicRow = this.locator(`tr.pf-v6-c-table__tr:has-text("${nicName}")`);
-      await nicRow.waitFor({ state: 'visible', timeout: TestTimeouts.UI_VISIBILITY_QUICK });
-      const networkCell = nicRow.locator('td').nth(2);
-      await networkCell.waitFor({ state: 'visible', timeout: TestTimeouts.UI_VISIBILITY_QUICK });
-      const text = (await networkCell.textContent())?.trim() ?? '';
-      return text.includes(expectedNadName);
-    } catch {
-      return false;
-    }
+    return this.network.verifyNicDisplaysNad(nicName, expectedNadName);
   }
   async verifyConsoleNotVisible(): Promise<boolean> {
     return this.console.verifyConsoleNotVisible();
@@ -1181,8 +1125,8 @@ export default class VirtualMachineDetailPage extends PageCommons {
     void namespace;
     await this.page.waitForTimeout(Math.min(TestTimeouts.NETWORK_DELAY, timeout));
   }
-  async waitForPendingChanges(timeout = 60000): Promise<boolean> {
-    return this.configuration.waitForPendingChanges(timeout);
+  async waitForPendingChanges(timeout: number = TestTimeouts.PENDING_CHANGES): Promise<boolean> {
+    return this.network.waitForPendingChangesAlert(timeout);
   }
   async waitForPendingChangesToDisappear(timeout = 60000): Promise<boolean> {
     return this.configuration.waitForPendingChangesToDisappear(timeout);

--- a/playwright/src/utils/pending-changes-locator.ts
+++ b/playwright/src/utils/pending-changes-locator.ts
@@ -1,0 +1,7 @@
+import type { Locator, Page } from '@playwright/test';
+
+export const PENDING_STATUS_MESSAGE_PATTERN =
+  /Pending changes|Restart required|Migration required/;
+
+export const getPendingStatusMessageLocator = (page: Page): Locator =>
+  page.getByText(PENDING_STATUS_MESSAGE_PATTERN);

--- a/playwright/src/utils/test-setup-helpers.ts
+++ b/playwright/src/utils/test-setup-helpers.ts
@@ -283,6 +283,56 @@ export async function createBridgeNetworkAttachmentDefinition(
 }
 
 /**
+ * Appends a bridge Multus NIC to a VirtualMachine spec.
+ * Safe to call on a running VM (hot-plug add); the UI then lists the interface for NAD edit.
+ */
+export async function attachBridgeNetworkInterface(
+  client: RequestContextClient,
+  vmName: string,
+  namespace: string,
+  nicName: string,
+  nadName: string,
+): Promise<void> {
+  await client.patchVirtualMachine(namespace, vmName, [
+    {
+      op: 'add',
+      path: '/spec/template/spec/domain/devices/interfaces/-',
+      value: {
+        bridge: {},
+        model: 'virtio',
+        name: nicName,
+      },
+    },
+    {
+      op: 'add',
+      path: '/spec/template/spec/networks/-',
+      value: {
+        multus: { networkName: nadName },
+        name: nicName,
+      },
+    },
+  ]);
+}
+
+export function getVmMultusNetworkName(
+  vm: KubernetesResource | null,
+  nicName: string,
+): string | undefined {
+  const spec = vm?.spec as
+    | {
+        template?: {
+          spec?: {
+            networks?: Array<{ name?: string; multus?: { networkName?: string } }>;
+          };
+        };
+      }
+    | undefined;
+
+  return spec?.template?.spec?.networks?.find((network) => network.name === nicName)?.multus
+    ?.networkName;
+}
+
+/**
  * Sets project-level KubeVirt network annotations on a Namespace.
  * Always writes both annotation keys; omitted/undefined values are cleared via
  * JSON merge-patch nulls so configs can be replaced cleanly.

--- a/playwright/src/utils/test-setup-helpers.ts
+++ b/playwright/src/utils/test-setup-helpers.ts
@@ -283,6 +283,47 @@ export async function createBridgeNetworkAttachmentDefinition(
 }
 
 /**
+ * Creates a VM with a KubeVirt emptyDisk and no bootable volume.
+ * Skipping DataSource clones / container image pulls makes the VM much more
+ * likely to reach Running in CI.
+ */
+export async function createVmWithEmptyDisk(
+  client: RequestContextClient,
+  vmName: string,
+  namespace: string,
+  startVm = true,
+): Promise<void> {
+  await client.createVirtualMachine(namespace, {
+    apiVersion: 'kubevirt.io/v1',
+    kind: 'VirtualMachine',
+    metadata: { name: vmName, namespace },
+    spec: {
+      runStrategy: startVm ? 'Always' : 'Halted',
+      template: {
+        spec: {
+          domain: {
+            cpu: { cores: 1 },
+            devices: {
+              disks: [{ bootOrder: 1, disk: { bus: 'virtio' }, name: 'emptydisk' }],
+              interfaces: [{ masquerade: {}, name: 'default' }],
+            },
+            memory: { guest: '1Gi' },
+          },
+          networks: [{ name: 'default', pod: {} }],
+          terminationGracePeriodSeconds: 0,
+          volumes: [{ emptyDisk: { capacity: '1Gi' }, name: 'emptydisk' }],
+        },
+      },
+    },
+  });
+  client.trackResource('VirtualMachine', vmName, namespace);
+  const exists = await client.waitForVmExists(vmName, namespace);
+  if (!exists) {
+    throw new Error(`Empty-disk VM ${vmName} was not created in namespace ${namespace}`);
+  }
+}
+
+/**
  * Appends a bridge Multus NIC to a VirtualMachine spec.
  * Safe to call on a running VM (hot-plug add); the UI then lists the interface for NAD edit.
  */

--- a/playwright/tests/tier1/virtualmachines/vm-tabs/vm-network-nad-swap.spec.md
+++ b/playwright/tests/tier1/virtualmachines/vm-tabs/vm-network-nad-swap.spec.md
@@ -1,0 +1,83 @@
+# Software Test Description (STD): VM NAD Hot-Swap Pending Changes
+
+## 1. Project Overview
+
+- **Project Name:** KubeVirt UI — Playwright E2E Tests
+- **Feature Area:** Tier1 — VM tabs (Configuration → Network)
+- **Latest version:** CNV 5.1.0
+- **Latest update:** 2026-09-03
+- **Document Status:** Approved
+
+## 2. Introduction
+
+### 2.1 Purpose
+
+Verify that editing a running VM's bridge NIC NetworkAttachmentDefinition (NAD) from
+Configuration → Network shows the pending-changes / migration-required alert and updates the VM
+spec, while the network table continues to show the runtime NAD until migration applies the
+change.
+
+### 2.2 Scope
+
+- **In-Scope:** Hot-plugged bridge Multus NIC on a running VM; Configuration → Network Edit NAD
+  select; pending-changes alert; VM spec `multus.networkName` update; runtime vs desired NAD
+  display in the network table.
+- **Out-of-Scope:** Completing live migration after NAD swap; OVN overlay NAD types; pod
+  networking; NIC delete flow (covered elsewhere).
+
+## 3. Test Environment & Prerequisites
+
+- **Environment:** OpenShift with CNV operator installed; Playwright `Tier1` project (admin
+  credentials).
+- **Configuration:** Hot-cluster E2E (`@admin-only`). Requires Multus bridge NAD support.
+- **Initial Setup:** Each test creates a namespace, two bridge NADs, and a running VM with an
+  empty disk (no DataSource clone). A bridge Multus NIC is attached via API patch. Created
+  resources are tracked via `apiClient.trackResource(...)` for automatic cleanup.
+
+---
+
+## 4. Test Case Definitions
+
+**Spec file:** `tests/tier1/virtualmachines/vm-tabs/vm-network-nad-swap.spec.ts`
+**Describe:** `VM NAD hot-swap` — **Tags:** `@tier1`, `@admin-only`
+**Allure:** suite `VM NAD hot-swap`, feature `Tier 1`
+
+---
+
+### `001`: Swap a running VM NIC NAD and show pending changes
+
+- **Objective:** After changing a hot-plugged bridge NIC to a different NAD, the UI shows a
+  pending-changes alert, the VM spec references the target NAD, and the network table still shows
+  the runtime (source) NAD until migration.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-87871
+- **Pre-conditions:** VM reaches Running state; bridge NIC is attached with source NAD
+- **Tags:** `@admin-only`
+
+| Step | Action                                                            | Expected Result                                                 |
+| :--- | :---------------------------------------------------------------- | :-------------------------------------------------------------- |
+| 1    | Create two bridge NADs and a running empty-disk VM in a namespace | VM is Running; resources are tracked for cleanup                |
+| 2    | Attach a bridge Multus NIC using the source NAD                   | NIC row appears under Configuration → Network with source NAD   |
+| 3    | Open Configuration → Network and edit the NIC to the target NAD   | Edit modal saves; NAD select accepts the target option          |
+| 4    | Observe pending-changes / migration-required alert                | Alert is visible on the Configuration → Network view            |
+| 5    | Check the NIC network column and VM spec `multus.networkName`     | Table shows runtime (source) NAD; VM spec references target NAD |
+
+---
+
+## 5. Requirements Traceability Matrix
+
+| Jira Ticket | Test Case ID | Coverage Type    | Status    |
+| ----------- | ------------ | ---------------- | --------- |
+| CNV-87871   | `001`        | Feature coverage | Automated |
+
+**Coverage Type values:**
+
+- `Feature coverage` — test validates a feature delivered by the ticket
+- `Bugfix regression guard` — test asserts the specific bug fixed by the ticket does not regress
+- `Functional smoke` — test validates baseline behavior; no specific Jira ticket drives it
+
+## 6. Approvals
+
+- **Prepared By:** Test automation / QE
+- **Reviewed By:** Gal Kremer
+- **Approval Signature:** Gal Kremer

--- a/playwright/tests/tier1/virtualmachines/vm-tabs/vm-network-nad-swap.spec.ts
+++ b/playwright/tests/tier1/virtualmachines/vm-tabs/vm-network-nad-swap.spec.ts
@@ -68,14 +68,7 @@ test.describe(SUITE, { tag: [T1_TAG, ADMIN_ONLY_TAG] }, () => {
       await vmDetailPage.changeConfigurationNetworkNicNad(NIC_NAME, targetNad);
     });
 
-    await test.step('Pending changes alert and new NAD are visible', async () => {
-      await expect
-        .poll(async () => vmDetailPage.getConfigurationNetworkNicName(NIC_NAME), {
-          message: `NIC ${NIC_NAME} should show target NAD ${targetNad} after swap`,
-          timeout: utils.TestTimeouts.ELEMENT_WAIT,
-        })
-        .toContain(targetNad);
-
+    await test.step('Pending changes alert and updated VM spec are visible', async () => {
       const pendingVisible = await vmDetailPage.waitForPendingChanges(
         utils.TestTimeouts.PENDING_CHANGES,
       );
@@ -83,6 +76,14 @@ test.describe(SUITE, { tag: [T1_TAG, ADMIN_ONLY_TAG] }, () => {
         pendingVisible,
         'Configuration Network should show a pending-changes or migration-required alert after NAD swap',
       ).toBe(true);
+
+      // Network column shows the runtime NAD until migration applies the spec change.
+      await expect
+        .poll(async () => vmDetailPage.getConfigurationNetworkNicName(NIC_NAME), {
+          message: `NIC ${NIC_NAME} should still show runtime NAD ${sourceNad} until migration`,
+          timeout: utils.TestTimeouts.ELEMENT_WAIT,
+        })
+        .toContain(sourceNad);
 
       await expect
         .poll(

--- a/playwright/tests/tier1/virtualmachines/vm-tabs/vm-network-nad-swap.spec.ts
+++ b/playwright/tests/tier1/virtualmachines/vm-tabs/vm-network-nad-swap.spec.ts
@@ -18,7 +18,7 @@ const SUITE = 'VM NAD hot-swap';
 const NIC_NAME = 'nic-nad-swap';
 
 test.describe(SUITE, { tag: [T1_TAG, ADMIN_ONLY_TAG] }, () => {
-  test.beforeEach(async ({ utils }) => {
+  test.beforeEach(async ({ utils }): Promise<void> => {
     await utils.withAllure({
       suite: SUITE,
       feature: T1,

--- a/playwright/tests/tier1/virtualmachines/vm-tabs/vm-network-nad-swap.spec.ts
+++ b/playwright/tests/tier1/virtualmachines/vm-tabs/vm-network-nad-swap.spec.ts
@@ -9,6 +9,7 @@ import { expect, test } from '@/fixtures/vm-tabs-fixture';
 import {
   attachBridgeNetworkInterface,
   createBridgeNetworkAttachmentDefinition,
+  createVmWithEmptyDisk,
   getVmMultusNetworkName,
   setupTestNamespace,
 } from '@/utils/test-setup-helpers';
@@ -42,23 +43,7 @@ test.describe(SUITE, { tag: [T1_TAG, ADMIN_ONLY_TAG] }, () => {
       await createBridgeNetworkAttachmentDefinition(apiClient, sourceNad, namespace);
       await createBridgeNetworkAttachmentDefinition(apiClient, targetNad, namespace);
 
-      await apiClient.createVmFromTemplate(
-        utils.TEMPLATE_METADATA_NAMES.RHEL9,
-        vmName,
-        namespace,
-        'openshift',
-        false,
-      );
-      apiClient.trackResource('VirtualMachine', vmName, namespace);
-
-      const created = await apiClient.verifyVmCreated(
-        vmName,
-        namespace,
-        utils.TestTimeouts.VM_BOOTUP,
-      );
-      expect(created.exists, 'VM should exist before start').toBe(true);
-
-      await apiClient.startVm(namespace, vmName);
+      await createVmWithEmptyDisk(apiClient, vmName, namespace);
       await utils.waitForVirtualMachineReady(
         apiClient,
         vmName,

--- a/playwright/tests/tier1/virtualmachines/vm-tabs/vm-network-nad-swap.spec.ts
+++ b/playwright/tests/tier1/virtualmachines/vm-tabs/vm-network-nad-swap.spec.ts
@@ -1,0 +1,116 @@
+import {
+  ADMIN_ONLY_TAG,
+  NETWORKING_TAG_LABEL,
+  T1,
+  T1_TAG,
+  VM_TABS_TAG,
+} from '@/data-models/allure-constants';
+import { expect, test } from '@/fixtures/vm-tabs-fixture';
+import {
+  attachBridgeNetworkInterface,
+  createBridgeNetworkAttachmentDefinition,
+  getVmMultusNetworkName,
+  setupTestNamespace,
+} from '@/utils/test-setup-helpers';
+
+const SUITE = 'VM NAD hot-swap';
+const NIC_NAME = 'nic-nad-swap';
+
+test.describe(SUITE, { tag: [T1_TAG, ADMIN_ONLY_TAG] }, () => {
+  test.beforeEach(async ({ utils }) => {
+    await utils.withAllure({
+      suite: SUITE,
+      feature: T1,
+      tags: [T1_TAG, VM_TABS_TAG, NETWORKING_TAG_LABEL, ADMIN_ONLY_TAG],
+    });
+  });
+
+  test('swaps a running VM NIC NAD and shows pending changes', async ({
+    apiClient,
+    vmTreePage,
+    vmDetailPage,
+    utils,
+  }) => {
+    test.setTimeout(utils.TestTimeouts.TEST_PENDING_CHANGES);
+
+    const namespace = await setupTestNamespace(apiClient, 'nad-swap');
+    const sourceNad = utils.generateRandomNadName('src');
+    const targetNad = utils.generateRandomNadName('dst');
+    const vmName = utils.generateRandomVmName('nad-swap');
+
+    await test.step('Create NADs and a running VM', async () => {
+      await createBridgeNetworkAttachmentDefinition(apiClient, sourceNad, namespace);
+      await createBridgeNetworkAttachmentDefinition(apiClient, targetNad, namespace);
+
+      await apiClient.createVmFromTemplate(
+        utils.TEMPLATE_METADATA_NAMES.RHEL9,
+        vmName,
+        namespace,
+        'openshift',
+        false,
+      );
+      apiClient.trackResource('VirtualMachine', vmName, namespace);
+
+      const created = await apiClient.verifyVmCreated(
+        vmName,
+        namespace,
+        utils.TestTimeouts.VM_BOOTUP,
+      );
+      expect(created.exists, 'VM should exist before start').toBe(true);
+
+      await apiClient.startVm(namespace, vmName);
+      await utils.waitForVirtualMachineReady(
+        apiClient,
+        vmName,
+        namespace,
+        utils.TestTimeouts.VM_BOOTUP,
+      );
+
+      await attachBridgeNetworkInterface(apiClient, vmName, namespace, NIC_NAME, sourceNad);
+    });
+
+    await test.step('Edit the NIC network to the second NAD', async () => {
+      await vmTreePage.navigateToVmViaTreeView(namespace, vmName);
+      await vmDetailPage.navigateToConfigurationNetwork();
+
+      await expect
+        .poll(async () => vmDetailPage.getConfigurationNetworkNicName(NIC_NAME), {
+          message: `NIC ${NIC_NAME} should show source NAD ${sourceNad} before swap`,
+          timeout: utils.TestTimeouts.ELEMENT_WAIT,
+        })
+        .toContain(sourceNad);
+
+      await vmDetailPage.changeConfigurationNetworkNicNad(NIC_NAME, targetNad);
+    });
+
+    await test.step('Pending changes alert and new NAD are visible', async () => {
+      await expect
+        .poll(async () => vmDetailPage.getConfigurationNetworkNicName(NIC_NAME), {
+          message: `NIC ${NIC_NAME} should show target NAD ${targetNad} after swap`,
+          timeout: utils.TestTimeouts.ELEMENT_WAIT,
+        })
+        .toContain(targetNad);
+
+      const pendingVisible = await vmDetailPage.waitForPendingChanges(
+        utils.TestTimeouts.PENDING_CHANGES,
+      );
+      expect(
+        pendingVisible,
+        'Configuration Network should show a pending-changes or migration-required alert after NAD swap',
+      ).toBe(true);
+
+      await expect
+        .poll(
+          async () => {
+            const vm = await apiClient.getVirtualMachine(namespace, vmName);
+            return getVmMultusNetworkName(vm, NIC_NAME) ?? '';
+          },
+          {
+            message: `VM spec for ${NIC_NAME} should reference target NAD ${targetNad}`,
+            timeout: utils.TestTimeouts.ELEMENT_WAIT,
+          },
+        )
+        .toContain(targetNad);
+    });
+  });
+});

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/buildNetworkOptions.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/buildNetworkOptions.tsx
@@ -75,12 +75,12 @@ export const buildNetworkSelectOptions = ({
       label: displayedValue,
       optionProps: {
         children: (
-          <>
+          <span data-test={`network-option-${name}`}>
             {displayedValue}{' '}
             <Label isCompact>
               {getNadType(nad)} {t('Binding')}
             </Label>
-          </>
+          </span>
         ),
         key: value,
       },

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/buildNetworkOptions.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/buildNetworkOptions.tsx
@@ -75,7 +75,7 @@ export const buildNetworkSelectOptions = ({
       label: displayedValue,
       optionProps: {
         children: (
-          <span data-test={`network-option-${name}`}>
+          <span data-test={`network-option-${value}`}>
             {displayedValue}{' '}
             <Label isCompact>
               {getNadType(nad)} {t('Binding')}

--- a/src/utils/components/PendingChanges/PendingChangesAlert/PendingChangesAlert.tsx
+++ b/src/utils/components/PendingChanges/PendingChangesAlert/PendingChangesAlert.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react';
+import React, { type FC, type ReactNode } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Alert, AlertVariant } from '@patternfly/react-core';
@@ -24,12 +24,13 @@ export const PendingChangesAlert: FC<PendingChangesAlertProps> = ({
   return (
     <Alert
       className="pending-changes-alert"
+      data-test="pending-changes-alert"
       isExpandable={isExpandable}
       isInline
-      title={title || t('Pending changes')}
+      title={title ?? t('Pending changes')}
       variant={isWarning ? AlertVariant.warning : AlertVariant.info}
     >
-      {warningMsg || children}
+      {warningMsg ?? children}
     </Alert>
   );
 };

--- a/src/utils/components/SelectTypeahead/SelectTypeahead.tsx
+++ b/src/utils/components/SelectTypeahead/SelectTypeahead.tsx
@@ -70,6 +70,7 @@ const SelectTypeahead: FC<SelectTypeaheadProps> = ({
       <TextInputGroup isPlain>
         <TextInputGroupMain
           autoComplete="off"
+          data-test={dataTestId ? `${dataTestId}-input` : undefined}
           icon={<SearchIcon />}
           innerRef={textInputRef}
           onChange={onTextInputChange}

--- a/src/utils/components/toggles/KebabToggle.tsx
+++ b/src/utils/components/toggles/KebabToggle.tsx
@@ -3,8 +3,10 @@ import React, { type ReactElement, type Ref } from 'react';
 import { MenuToggle, type MenuToggleElement, type MenuToggleProps } from '@patternfly/react-core';
 import { EllipsisVIcon } from '@patternfly/react-icons';
 
+type KebabToggleProps = MenuToggleProps & { 'data-test'?: string };
+
 const KebabToggle =
-  (props: MenuToggleProps & { 'data-test'?: string }) =>
+  (props: KebabToggleProps) =>
   (toggleRef: Ref<MenuToggleElement>): ReactElement => (
     <MenuToggle data-test="kebab-button" {...props} ref={toggleRef} variant="plain">
       <EllipsisVIcon />

--- a/src/utils/components/toggles/KebabToggle.tsx
+++ b/src/utils/components/toggles/KebabToggle.tsx
@@ -4,7 +4,7 @@ import { MenuToggle, type MenuToggleElement, type MenuToggleProps } from '@patte
 import { EllipsisVIcon } from '@patternfly/react-icons';
 
 const KebabToggle =
-  (props: MenuToggleProps) =>
+  (props: MenuToggleProps & { 'data-test'?: string }) =>
   (toggleRef: Ref<MenuToggleElement>): ReactElement => (
     <MenuToggle data-test="kebab-button" {...props} ref={toggleRef} variant="plain">
       <EllipsisVIcon />

--- a/src/utils/components/toggles/KebabToggle.tsx
+++ b/src/utils/components/toggles/KebabToggle.tsx
@@ -1,12 +1,14 @@
-import React, { Ref } from 'react';
+import React, { type ReactElement, type Ref } from 'react';
 
-import { MenuToggle, MenuToggleElement, MenuToggleProps } from '@patternfly/react-core';
+import { MenuToggle, type MenuToggleElement, type MenuToggleProps } from '@patternfly/react-core';
 import { EllipsisVIcon } from '@patternfly/react-icons';
 
-const KebabToggle = (props: MenuToggleProps) => (toggleRef: Ref<MenuToggleElement>) => (
-  <MenuToggle {...props} data-test="kebab-button" ref={toggleRef} variant="plain">
-    <EllipsisVIcon />
-  </MenuToggle>
-);
+const KebabToggle =
+  (props: MenuToggleProps) =>
+  (toggleRef: Ref<MenuToggleElement>): ReactElement => (
+    <MenuToggle data-test="kebab-button" {...props} ref={toggleRef} variant="plain">
+      <EllipsisVIcon />
+    </MenuToggle>
+  );
 
 export default KebabToggle;

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceActions.tsx
@@ -1,36 +1,25 @@
 /* eslint-disable */
 import React, { FC, useState } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import ConfirmActionMessage from '@kubevirt-utils/components/ConfirmActionMessage/ConfirmActionMessage';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
-import { deleteNetworkInterface } from '@kubevirt-utils/components/NetworkInterfaceModal/utils/helpers';
-import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import KebabToggle from '@kubevirt-utils/components/toggles/KebabToggle';
 import useFQDN from '@kubevirt-utils/hooks/useFQDN/useFQDN';
 import useIsFQDNEnabled from '@kubevirt-utils/hooks/useFQDN/useIsFQDNEnabled';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
+import { type NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
 import { getNetworkInterface } from '@kubevirt-utils/resources/vm/utils/network/selectors';
 import { NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
 import { getContentScrollableElement } from '@kubevirt-utils/utils/utils';
-import {
-  Alert,
-  AlertVariant,
-  ButtonVariant,
-  Dropdown,
-  DropdownItem,
-  DropdownList,
-  Tooltip,
-} from '@patternfly/react-core';
+import { Dropdown, DropdownItem, DropdownList, Tooltip } from '@patternfly/react-core';
 import { CopyIcon } from '@patternfly/react-icons';
 import {
   getConfigInterfaceStateFromVM,
   setNetworkInterfaceState,
 } from '@virtualmachines/details/tabs/configuration/network/utils/utils';
-import { isRunning } from '@virtualmachines/utils';
 
 import VirtualMachinesEditNetworkInterfaceModal from '../modal/VirtualMachinesEditNetworkInterfaceModal';
+import NetworkInterfaceDeleteModal from './NetworkInterfaceDeleteModal';
 
 type NetworkInterfaceActionsProps = {
   isAutoAttached?: boolean;
@@ -48,18 +37,12 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const deleteBtnText = t('Delete');
-
-  const isHotPlugNIC = Boolean(nicPresentation?.iface?.bridge);
-
   const interfaceState = getConfigInterfaceStateFromVM(vm, nicName);
-
   const isInterfaceMissing = !getNetworkInterface(vm, nicName);
-
   const fqdn = useFQDN(nicName, vm);
   const isFQDNEnabled = useIsFQDNEnabled();
 
-  const onEditModalOpen = () => {
+  const onEditModalOpen = (): void => {
     createModal(({ isOpen, onClose }) => (
       <VirtualMachinesEditNetworkInterfaceModal
         isOpen={isOpen}
@@ -71,51 +54,33 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
     setIsDropdownOpen(false);
   };
 
-  const onDeleteModalOpen = () => {
+  const onDeleteModalOpen = (): void => {
     createModal(({ isOpen, onClose }) => (
-      <TabModal<V1VirtualMachine>
-        headerText={t('Delete NIC?')}
+      <NetworkInterfaceDeleteModal
+        isHotPlugNIC={Boolean(nicPresentation?.iface?.bridge)}
         isOpen={isOpen}
+        nicName={nicName}
+        nicPresentation={nicPresentation}
         onClose={onClose}
-        onSubmit={() => deleteNetworkInterface(vm, nicName, nicPresentation)}
-        submitBtnText={deleteBtnText}
-        submitBtnVariant={ButtonVariant.danger}
-      >
-        <span>
-          {isRunning(vm) && isHotPlugNIC && (
-            <Alert
-              title={t(
-                'Deleting a network interface is supported only on VirtualMachines that were created in versions greater than 4.13.',
-              )}
-              component={'h6'}
-              isInline
-              variant={AlertVariant.warning}
-            />
-          )}
-          <br />
-          <ConfirmActionMessage
-            obj={{ metadata: { name: nicName, namespace: vm?.metadata?.namespace } }}
-          />
-        </span>
-      </TabModal>
+        vm={vm}
+      />
     ));
     setIsDropdownOpen(false);
   };
 
-  const onToggle = () => setIsDropdownOpen((prevIsOpen) => !prevIsOpen);
-
   const dropdown = (
     <Dropdown
-      toggle={KebabToggle({
-        id: `nic-actions-${nicName}`,
-        isDisabled: interfaceState === NetworkInterfaceState.ABSENT || isInterfaceMissing,
-        isExpanded: isDropdownOpen,
-        onClick: onToggle,
-      })}
       isOpen={isDropdownOpen}
       onOpenChange={setIsDropdownOpen}
       onSelect={() => setIsDropdownOpen(false)}
       popperProps={{ appendTo: getContentScrollableElement, position: 'right' }}
+      toggle={KebabToggle({
+        'data-test': `nic-actions-${nicName}`,
+        id: `nic-actions-${nicName}`,
+        isDisabled: interfaceState === NetworkInterfaceState.ABSENT || isInterfaceMissing,
+        isExpanded: isDropdownOpen,
+        onClick: () => setIsDropdownOpen((prevIsOpen) => !prevIsOpen),
+      })}
     >
       <DropdownList>
         {interfaceState === NetworkInterfaceState.DOWN && (
@@ -143,12 +108,10 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
             {t('Copy FQDN')}
           </DropdownItem>
         )}
-        <DropdownItem key="network-interface-edit" onClick={onEditModalOpen}>
+        <DropdownItem data-test="network-interface-edit" onClick={onEditModalOpen}>
           {t('Edit')}
         </DropdownItem>
-        <DropdownItem key="network-interface-delete" onClick={onDeleteModalOpen}>
-          {deleteBtnText}
-        </DropdownItem>
+        <DropdownItem onClick={onDeleteModalOpen}>{t('Delete')}</DropdownItem>
       </DropdownList>
     </Dropdown>
   );

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceDeleteModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceDeleteModal.tsx
@@ -1,0 +1,61 @@
+import React, { type FC } from 'react';
+
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import ConfirmActionMessage from '@kubevirt-utils/components/ConfirmActionMessage/ConfirmActionMessage';
+import { deleteNetworkInterface } from '@kubevirt-utils/components/NetworkInterfaceModal/utils/helpers';
+import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { type NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
+import { Alert, AlertVariant, ButtonVariant } from '@patternfly/react-core';
+import { isRunning } from '@virtualmachines/utils';
+
+type NetworkInterfaceDeleteModalProps = {
+  isHotPlugNIC: boolean;
+  isOpen: boolean;
+  nicName: string;
+  nicPresentation: NetworkPresentation;
+  onClose: () => void;
+  vm: V1VirtualMachine;
+};
+
+const NetworkInterfaceDeleteModal: FC<NetworkInterfaceDeleteModalProps> = ({
+  isHotPlugNIC,
+  isOpen,
+  nicName,
+  nicPresentation,
+  onClose,
+  vm,
+}) => {
+  const { t } = useKubevirtTranslation();
+  const deleteBtnText = t('Delete');
+
+  return (
+    <TabModal<V1VirtualMachine>
+      headerText={t('Delete NIC?')}
+      isOpen={isOpen}
+      onClose={onClose}
+      onSubmit={() => deleteNetworkInterface(vm, nicName, nicPresentation)}
+      submitBtnText={deleteBtnText}
+      submitBtnVariant={ButtonVariant.danger}
+    >
+      <span>
+        {isRunning(vm) && isHotPlugNIC && (
+          <Alert
+            component={'h6'}
+            isInline
+            title={t(
+              'Deleting a network interface is supported only on VirtualMachines that were created in versions greater than 4.13.',
+            )}
+            variant={AlertVariant.warning}
+          />
+        )}
+        <br />
+        <ConfirmActionMessage
+          obj={{ metadata: { name: nicName, namespace: vm?.metadata?.namespace } }}
+        />
+      </span>
+    </TabModal>
+  );
+};
+
+export default NetworkInterfaceDeleteModal;

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceDeleteModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/list/NetworkInterfaceDeleteModal.tsx
@@ -2,11 +2,12 @@ import React, { type FC } from 'react';
 
 import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ConfirmActionMessage from '@kubevirt-utils/components/ConfirmActionMessage/ConfirmActionMessage';
+import DeleteModal from '@kubevirt-utils/components/DeleteModal/DeleteModal';
 import { deleteNetworkInterface } from '@kubevirt-utils/components/NetworkInterfaceModal/utils/helpers';
-import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { type NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
-import { Alert, AlertVariant, ButtonVariant } from '@patternfly/react-core';
+import { Alert, AlertVariant } from '@patternfly/react-core';
 import { isRunning } from '@virtualmachines/utils';
 
 type NetworkInterfaceDeleteModalProps = {
@@ -27,34 +28,33 @@ const NetworkInterfaceDeleteModal: FC<NetworkInterfaceDeleteModalProps> = ({
   vm,
 }) => {
   const { t } = useKubevirtTranslation();
-  const deleteBtnText = t('Delete');
+  const namespace = getNamespace(vm);
 
   return (
-    <TabModal<V1VirtualMachine>
+    <DeleteModal
+      body={
+        <>
+          {isRunning(vm) && isHotPlugNIC && (
+            <Alert
+              className="pf-v6-u-mb-md"
+              component={'h6'}
+              isInline
+              title={t(
+                'Deleting a network interface is supported only on VirtualMachines that were created in versions greater than 4.13.',
+              )}
+              variant={AlertVariant.warning}
+            />
+          )}
+          <ConfirmActionMessage obj={{ metadata: { name: nicName, namespace } }} />
+        </>
+      }
       headerText={t('Delete NIC?')}
       isOpen={isOpen}
+      obj={vm}
       onClose={onClose}
-      onSubmit={() => deleteNetworkInterface(vm, nicName, nicPresentation)}
-      submitBtnText={deleteBtnText}
-      submitBtnVariant={ButtonVariant.danger}
-    >
-      <span>
-        {isRunning(vm) && isHotPlugNIC && (
-          <Alert
-            component={'h6'}
-            isInline
-            title={t(
-              'Deleting a network interface is supported only on VirtualMachines that were created in versions greater than 4.13.',
-            )}
-            variant={AlertVariant.warning}
-          />
-        )}
-        <br />
-        <ConfirmActionMessage
-          obj={{ metadata: { name: nicName, namespace: vm?.metadata?.namespace } }}
-        />
-      </span>
-    </TabModal>
+      onDeleteSubmit={() => deleteNetworkInterface(vm, nicName, nicPresentation)}
+      shouldRedirect={false}
+    />
   );
 };
 


### PR DESCRIPTION
## 📝 Description

Adds a Playwright Tier 1 test for swapping a running VM NIC's NetworkAttachmentDefinition from Configuration → Network → Edit, then asserting:

- the NIC row shows the new NAD
- the pending-changes / migration-required alert is visible
- the VM spec was updated

Also adds `data-test` IDs for the pending-changes alert, NIC kebab, Edit action, NAD options, and typeahead input so the test locates UI by test IDs instead of CSS classes.

## 🔗 Links

- https://redhat.atlassian.net/browse/CNV-87871
- Epic: https://redhat.atlassian.net/browse/CNV-82742

## 🎥 Demo

QE E2E coverage; no visual UI behavior change beyond automation IDs.

## Test plan

- [ ] `npx playwright test playwright/tests/tier1/virtualmachines/vm-tabs/vm-network-nad-swap.spec.ts --project=Tier1 --workers=1`
- [ ] Confirm Configuration → Network Edit still opens and NAD select works
- [ ] Confirm pending-changes alert still appears after a live NAD change


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for changing a running VM’s network attachment between bridge networks.
  * Added clearer network-interface deletion confirmation, including warnings for running VMs.
  * Improved network selectors and configuration feedback.

* **Bug Fixes**
  * Pending-status indicators now recognize “Migration required” alongside existing statuses.
  * Preserved intentionally empty alert titles and messages.

* **Tests**
  * Added coverage for hot-swapping a VM network interface and verifying the resulting configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->