### PR TITLE
CNV-96225: fix VM search empty state text

### DIFF
--- a/src/views/search/searchLanguage/filtersToSearchText.test.ts
+++ b/src/views/search/searchLanguage/filtersToSearchText.test.ts
@@ -1,4 +1,4 @@
-import { KubevirtFilterState } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
+import { type KubevirtFilterState } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 
 import { filtersToSearchText } from './filtersToSearchText';
 
@@ -50,6 +50,12 @@ describe('filtersToSearchText', () => {
       expect(filtersToSearchText(f({ status: ['Running', '!Stopped'] }), ['status'])).toBe(
         'status:Running -status:Stopped',
       );
+    });
+
+    it('should keep mixed include and exclude as separate search-language tokens', () => {
+      expect(
+        filtersToSearchText(f({ os: ['RHEL', '!Fedora'], status: ['!Stopped'] }), ['status', 'os']),
+      ).toBe('-status:Stopped os:RHEL -os:Fedora');
     });
   });
 

--- a/src/views/virtualmachines/list/components/VirtualMachineFilteredEmptyState/VirtualMachineFilteredEmptyState.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineFilteredEmptyState/VirtualMachineFilteredEmptyState.tsx
@@ -1,7 +1,7 @@
-import React, { FC, RefObject } from 'react';
+import React, { type FC, type RefObject } from 'react';
 import { Trans } from 'react-i18next';
 
-import { KubevirtFilterState } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
+import { type KubevirtFilterState } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   Button,
@@ -13,8 +13,7 @@ import {
   EmptyStateVariant,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
-
-import { buildFilterQueryString } from './utils';
+import { filtersToSearchText } from '@search/searchLanguage/filtersToSearchText';
 
 type VirtualMachineFilteredEmptyStateProps = {
   clearAllFilters: () => void;
@@ -29,7 +28,7 @@ const VirtualMachineFilteredEmptyState: FC<VirtualMachineFilteredEmptyStateProps
 }) => {
   const { t } = useKubevirtTranslation();
 
-  const queryString = buildFilterQueryString(filters);
+  const queryString = filtersToSearchText(filters, Object.keys(filters));
 
   if (!queryString) return null;
 

--- a/src/views/virtualmachines/list/components/VirtualMachineFilteredEmptyState/utils.ts
+++ b/src/views/virtualmachines/list/components/VirtualMachineFilteredEmptyState/utils.ts
@@ -1,8 +1,0 @@
-import { KubevirtFilterState } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
-
-export const buildFilterQueryString = (filters: KubevirtFilterState): string =>
-  Object.entries(filters)
-    .filter(([, values]) => !isEmpty(values))
-    .map(([key, values]) => `${key}:${values.join(',')}`)
-    .join(' ');


### PR DESCRIPTION

<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Use the search language syntax in the VM search empty state text.

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-96225

## 🎥 Demo
Before:
<img width="1923" height="1108" alt="Screenshot 2026-08-31 at 17 53 46" src="https://github.com/user-attachments/assets/3455e514-0cc6-4bd7-9ef5-b2ce606a9f08" />


After:
<img width="1923" height="1108" alt="Screenshot 2026-08-31 at 17 47 07" src="https://github.com/user-attachments/assets/dcd483f2-249b-4755-b1c9-059d874ea475" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the filtered empty state to display active filter queries consistently.
  - Corrected serialization of mixed included and excluded filter values, preserving the expected search-token order.
- **Tests**
  - Added coverage for multiple filters containing both included and excluded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->