### PR TITLE
CNV-96228: close clone modal on success and show a toast

### DIFF
--- a/src/utils/components/CloneVMModal/CloneVMModal.tsx
+++ b/src/utils/components/CloneVMModal/CloneVMModal.tsx
@@ -12,6 +12,7 @@ import {
 } from '@kubevirt-utils/extensions/telemetry/utils/property-constants';
 import { logVMActionPerformed } from '@kubevirt-utils/extensions/telemetry/vm-actions';
 import { logVMCloned } from '@kubevirt-utils/extensions/telemetry/vm-storage';
+import useKubevirtToast from '@kubevirt-utils/hooks/useKubevirtToast';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useNameValidation } from '@kubevirt-utils/hooks/useNameValidation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
@@ -40,6 +41,7 @@ type CloneVMModalProps = {
 
 const CloneVMModal: FC<CloneVMModalProps> = ({ headerText, isOpen, onClose, source }) => {
   const { t } = useKubevirtTranslation();
+  const { addSuccessToast } = useKubevirtToast();
   const namespace = getNamespace(source);
   const name = getName(source);
 
@@ -99,8 +101,14 @@ const CloneVMModal: FC<CloneVMModalProps> = ({ headerText, isOpen, onClose, sour
       if (isVM(source)) {
         logVMActionPerformed(TELEMETRY_VM_ACTION.CLONE, source);
       }
+      addSuccessToast({
+        title: t(
+          'Clone completed. The cloned virtual machine may take some time to appear in the list.',
+        ),
+      });
+      onClose();
     }
-  }, [isCloneSucceeded, source]);
+  }, [addSuccessToast, isCloneSucceeded, onClose, source, t]);
 
   return (
     <TabModal
@@ -114,21 +122,14 @@ const CloneVMModal: FC<CloneVMModalProps> = ({ headerText, isOpen, onClose, sour
       modalVariant={ModalVariant.medium}
       obj={source}
       onClose={onClose}
-      onSubmit={async () => {
-        if (isCloneSucceeded) {
-          onClose();
-          return;
-        }
-        return sendCloneRequest();
-      }}
+      onSubmit={sendCloneRequest}
       shouldWrapInForm
-      submitBtnText={getSubmitBtnText(isCloneSucceeded, isCloneInProgress, isVM(source), t)}
+      submitBtnText={getSubmitBtnText(isCloneInProgress, isVM(source), t)}
     >
       <CloneStatusAlerts
         cloneFailureMessage={cloneFailureMessage}
         isCloneFailed={isCloneFailed}
         isCloneInProgress={isCloneInProgress}
-        isCloneSucceeded={isCloneSucceeded}
       />
       <NameInput
         autoFocus

--- a/src/utils/components/CloneVMModal/components/CloneStatusAlerts.tsx
+++ b/src/utils/components/CloneVMModal/components/CloneStatusAlerts.tsx
@@ -8,14 +8,12 @@ type CloneStatusAlertsProps = {
   cloneFailureMessage: string | undefined;
   isCloneFailed: boolean;
   isCloneInProgress: boolean;
-  isCloneSucceeded: boolean;
 };
 
 const CloneStatusAlerts: FC<CloneStatusAlertsProps> = ({
   cloneFailureMessage,
   isCloneFailed,
   isCloneInProgress,
-  isCloneSucceeded,
 }) => {
   const { t } = useKubevirtTranslation();
 
@@ -34,15 +32,6 @@ const CloneStatusAlerts: FC<CloneStatusAlertsProps> = ({
               'The operation could not be completed. Please try again or contact your administrator.',
             )}
         </Alert>
-      )}
-      {isCloneSucceeded && (
-        <Alert
-          isInline
-          title={t(
-            'Clone completed. The cloned virtual machine may take some time to appear in the list.',
-          )}
-          variant={AlertVariant.success}
-        />
       )}
     </>
   );

--- a/src/utils/components/CloneVMModal/utils/getSubmitBtnText.ts
+++ b/src/utils/components/CloneVMModal/utils/getSubmitBtnText.ts
@@ -1,14 +1,6 @@
 import { type TFunction } from 'i18next';
 
-const getSubmitBtnText = (
-  isCloneSucceeded: boolean,
-  isCloneLoading: boolean,
-  isVMSource: boolean,
-  t: TFunction,
-): string => {
-  if (isCloneSucceeded) {
-    return t('Close');
-  }
+const getSubmitBtnText = (isCloneLoading: boolean, isVMSource: boolean, t: TFunction): string => {
   if (isCloneLoading) {
     return t('Cloning');
   }


### PR DESCRIPTION
## 📝 Description

When creating a VirtualMachine from a snapshot (or cloning a VM), a successful clone left the modal open with two Close buttons. On success the modal now closes immediately and the completion message is shown as a toast.

## 🔗 Links

- https://issues.redhat.com/browse/CNV-96228

## 🎥 Demo


**BEFORE**

https://github.com/user-attachments/assets/73f1cfbd-e6f1-4da8-b2e5-b75b8d96b627


**AFTER**


https://github.com/user-attachments/assets/ff326361-84a5-4f7b-ae52-5f69bed1eb93



## Test plan

- [ ] Create a VM snapshot, then **Create VirtualMachine** from the snapshot kebab
- [ ] Wait until cloning succeeds: modal closes and a success toast appears
- [ ] Confirm only one Close button while cloning is in progress (cancel is labeled Close)
- [ ] Confirm clone-from-VM uses the same success toast + auto-close


Made with [Cursor](https://cursor.com)