### PR TITLE
CNV-96218: VM wizard - reset bootable volume on preference change

### DIFF
--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/components/OperatingSystemTileGroup/OperatingSystemTileGroup.tsx
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/components/OperatingSystemTileGroup/OperatingSystemTileGroup.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { useWatch } from 'react-hook-form';
 
 import useIsWindowsSupportedArchitecture from '@kubevirt-utils/hooks/useIsWindowsSupportedArchitecture';
@@ -6,12 +6,13 @@ import { Split, SplitItem } from '@patternfly/react-core';
 import { useVMWizard } from '@virtualmachines/wizard/state/vm-wizard-context/VMWizardContext';
 import { CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA } from '@virtualmachines/wizard/state/vm-wizard-form/consts';
 import { OperatingSystemType } from '@virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/utils/constants';
+import { resetBootableVolumeFields } from '@virtualmachines/wizard/utils/utils';
 
 import OperatingSystemTile from './components/OperatingSystemTile/OperatingSystemTile';
 
 const OperatingSystemTileGroup: FC = () => {
-  const { control, setValue } = useVMWizard();
-  const operatingSystemType = useWatch({
+  const { control, getValues, setValue } = useVMWizard();
+  const operatingSystemType: OperatingSystemType = useWatch({
     control,
     name: CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.OPERATING_SYSTEM_TYPE,
   });
@@ -28,11 +29,12 @@ const OperatingSystemTileGroup: FC = () => {
       {osTypes.map((osType) => (
         <SplitItem key={osType}>
           <OperatingSystemTile
+            isSelected={operatingSystemType === osType}
             onClick={() => {
               setValue(CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.OPERATING_SYSTEM_TYPE, osType);
               setValue(CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.PREFERENCE, null);
+              resetBootableVolumeFields(getValues, setValue);
             }}
-            isSelected={operatingSystemType === osType}
             operatingSystem={osType}
           />
         </SplitItem>

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/components/PreferenceSelectMenu/PreferenceSelectMenu.tsx
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/components/PreferenceSelectMenu/PreferenceSelectMenu.tsx
@@ -1,7 +1,7 @@
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 import { Controller, useWatch } from 'react-hook-form';
 
-import { PreferenceOption } from '@kubevirt-utils/components/AddBootableVolumeModal/types';
+import { type PreferenceOption } from '@kubevirt-utils/components/AddBootableVolumeModal/types';
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -13,12 +13,13 @@ import {
   CREATE_VM_FORM_FIELDS_VM_DATA,
 } from '@virtualmachines/wizard/state/vm-wizard-form/consts';
 import usePreferenceSelectOptions from '@virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/components/PreferenceSelectMenu/hooks/usePreferenceSelectOptions/usePreferenceSelectOptions';
+import { resetBootableVolumeFields } from '@virtualmachines/wizard/utils/utils';
 
 import './PreferenceSelectMenu.scss';
 
 const PreferenceSelectMenu: FC = () => {
   const { t } = useKubevirtTranslation();
-  const { control } = useVMWizard();
+  const { control, getValues, setValue } = useVMWizard();
   const [cluster, project, operatingSystemType] = useWatch({
     control,
     name: [
@@ -54,17 +55,20 @@ const PreferenceSelectMenu: FC = () => {
         <Loading />
       ) : (
         <Controller
+          control={control}
+          name={CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.PREFERENCE}
           render={({ field: { onChange, value } }) => {
             return (
               <FormPFSelect
-                onSelect={(_, selectedValue) => {
-                  onChange(selectedValue as PreferenceOption);
-                }}
                 className="pf-v6-u-mt-md"
                 isDisabled={noPreferences}
+                onSelect={(_event, selectedValue) => {
+                  onChange(selectedValue as PreferenceOption);
+                  resetBootableVolumeFields(getValues, setValue);
+                }}
                 placeholder={placeholderText}
-                selected={value?.name || ''}
-                selectedLabel={value?.name || placeholderText}
+                selected={(value?.name as string) || ''}
+                selectedLabel={(value?.name as string) || placeholderText}
                 toggleProps={{ isFullWidth: true }}
               >
                 {preferences?.map((pref) => (
@@ -75,8 +79,6 @@ const PreferenceSelectMenu: FC = () => {
               </FormPFSelect>
             );
           }}
-          control={control}
-          name={CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.PREFERENCE}
         />
       )}
     </FormGroup>

--- a/src/views/virtualmachines/wizard/utils/utils.ts
+++ b/src/views/virtualmachines/wizard/utils/utils.ts
@@ -1,9 +1,10 @@
-import { TFunction } from 'i18next';
-import { UseFormGetValues, UseFormSetValue } from 'react-hook-form';
+import { type UseFormGetValues, type UseFormSetValue } from 'react-hook-form';
+import { type TFunction } from 'i18next';
 
 import { getInstanceTypeFromVolume } from '@kubevirt-utils/components/AddBootableVolumeModal/utils';
-
+import { cancelAllWizardPendingUploads } from '@kubevirt-utils/hooks/useUploadProgressToast';
 import { getDiskSize } from '@kubevirt-utils/resources/bootableresources/selectors';
+import { setCustomizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
 import CloneIcon from '@virtualmachines/wizard/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/components/CreationMethodTile/components/CloneIcon';
 import { InstanceTypeIcon } from '@virtualmachines/wizard/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/components/CreationMethodTile/components/InstanceTypeIcon';
 import TemplateIcon from '@virtualmachines/wizard/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/components/CreationMethodTile/components/TemplateIcon';
@@ -12,20 +13,18 @@ import {
   INSTANCE_TYPE_FLOW,
   TEMPLATE_FLOW,
   VMCreationMethod,
-  VMWizardStep,
+  type VMWizardStep,
 } from '@virtualmachines/wizard/utils/constants';
 
-import { cancelAllWizardPendingUploads } from '@kubevirt-utils/hooks/useUploadProgressToast';
-import { setCustomizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
 import {
   CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA,
   CREATE_VM_FORM_FIELDS_STEP_NAVIGATION,
 } from '../state/vm-wizard-form/consts';
-import { VMWizardFormValues } from '../state/vm-wizard-form/types';
+import { type VMWizardFormValues } from '../state/vm-wizard-form/types';
 import {
-  ApplySelectedBootableVolumeToForm,
-  VMCreationMethodCardDetails,
-  VMCreationMethodConfig,
+  type ApplySelectedBootableVolumeToForm,
+  type VMCreationMethodCardDetails,
+  type VMCreationMethodConfig,
 } from './types';
 
 const VM_CREATION_METHOD_MAPPER: Record<VMCreationMethod, VMCreationMethodConfig> = {
@@ -67,11 +66,11 @@ export const getVMCreationMethodDetails = (
   t: TFunction,
 ): VMCreationMethodCardDetails => VM_CREATION_METHOD_MAPPER[creationMethod].cardDetails(t);
 
-export const isCloneCreationMethod = (creationMethod: VMCreationMethod) =>
+export const isCloneCreationMethod = (creationMethod: VMCreationMethod): boolean =>
   creationMethod === VMCreationMethod.CLONE;
-export const isTemplateCreationMethod = (creationMethod: VMCreationMethod) =>
+export const isTemplateCreationMethod = (creationMethod: VMCreationMethod): boolean =>
   creationMethod === VMCreationMethod.TEMPLATE;
-export const isInstanceTypeCreationMethod = (creationMethod: VMCreationMethod) =>
+export const isInstanceTypeCreationMethod = (creationMethod: VMCreationMethod): boolean =>
   creationMethod === VMCreationMethod.INSTANCE_TYPE;
 
 export const applySelectedBootableVolumeToForm = ({
@@ -101,11 +100,28 @@ export const applySelectedBootableVolumeToForm = ({
   });
 };
 
+export const resetBootableVolumeFields = (
+  getValues: UseFormGetValues<VMWizardFormValues>,
+  setValue: UseFormSetValue<VMWizardFormValues>,
+): void => {
+  setValue(CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.ROOT, {
+    ...getValues(CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.ROOT),
+    customDiskSize: '',
+    dvSource: null,
+    pvcSource: null,
+    selectedBootableVolume: null,
+    selectedInstanceType: null,
+    selectedSeries: '',
+    selectedSize: '',
+    volumeSnapshotSource: null,
+  });
+};
+
 export const markStepVisited = (
   stepId: string,
   getValues: UseFormGetValues<VMWizardFormValues>,
   setValue: UseFormSetValue<VMWizardFormValues>,
-) => {
+): void => {
   const visitedSteps = getValues(CREATE_VM_FORM_FIELDS_STEP_NAVIGATION.VISITED_STEPS);
   if (visitedSteps.has(stepId)) {
     return;
@@ -116,7 +132,7 @@ export const markStepVisited = (
   setValue(CREATE_VM_FORM_FIELDS_STEP_NAVIGATION.VISITED_STEPS, nextVisitedSteps);
 };
 
-export const clearVMPendingUploadsAndSignal = () => {
+export const clearVMPendingUploadsAndSignal = (): void => {
   setCustomizeWizardVMSignal(null);
   cancelAllWizardPendingUploads();
 };


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

**BUG:** In VM wizard, when user selects a bootable volume (e.g. `rhel10`), then selects a different preference (e.g. `fedora`), the selected bootable volume stays `rhel10`. The created VM will have `rhel10` preference.

- This is because Preference name is taken from: 1. selected bootable volume 2. selected preference `getLabel(selectedBootableVolume, DEFAULT_PREFERENCE_LABEL) || preference?.name`

It is also a bad UX, because user doesn't see that the `rhel10` bootable volume is still selected.
___
**FIX:** Reset bootable volume selection (and also instance type selection) on a Preference change.

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-96218

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/ae9a1ed5-acfb-4dc6-8e80-8238bb44f185



After:


https://github.com/user-attachments/assets/794ed4ad-4a9d-4ef0-abc8-1fe939f66e54




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Selecting a guest operating system or preference now clears incompatible bootable-volume and instance-type selections.
  * Remaining wizard form information is preserved when selections are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->