### PR TITLE
CNV-96253: fix switch layout in Project dropdown

### DIFF
--- a/src/utils/components/ClusterProjectDropdown/Dropdown/Dropdown.scss
+++ b/src/utils/components/ClusterProjectDropdown/Dropdown/Dropdown.scss
@@ -54,8 +54,4 @@
   &__menu-content {
     max-height: 50vh;
   }
-
-  &__system-switch {
-    padding: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--md);
-  }
 }

--- a/src/utils/components/ClusterProjectDropdown/Dropdown/Dropdown.tsx
+++ b/src/utils/components/ClusterProjectDropdown/Dropdown/Dropdown.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useState } from 'react';
 
 import { useClickOutside } from '@kubevirt-utils/hooks/useClickOutside/useClickOutside';
-import { Menu, MenuContent, Popper, Tooltip } from '@patternfly/react-core';
+import { Divider, Menu, MenuContent, Popper, Tooltip } from '@patternfly/react-core';
 
 import DropdownGroup from './DropdownGroup';
 import DropdownMenuToggle from './DropdownMenuToggle';
@@ -9,10 +9,10 @@ import Filter from './Filter';
 import NoResults from './NoResults';
 import ShowSystemNamespacesSwitch from './ShowSystemNamespacesSwitch';
 import type { DropdownConfig, DropdownProps } from './types';
-export type { DropdownConfig };
 import { useDropdownCallbacks } from './useDropdownCallbacks';
 import { useDropdownOptions } from './useDropdownOptions';
 import { useFilteredOptions } from './useFilteredOptions';
+export type { DropdownConfig };
 
 import './Dropdown.scss';
 
@@ -108,15 +108,16 @@ const Dropdown = <T,>({
                 onFilterChange={setFilterText}
               />
             </div>
+            <Divider />
             {showSystemToggle && (
-              <div role="none">
+              <>
                 <ShowSystemNamespacesSwitch
-                  cssPrefix={config.cssPrefix}
                   hasSystemNamespaces={showSystemToggle.hasSystemItems}
                   isChecked={showSystemToggle.show}
                   onChange={showSystemToggle.onChange}
                 />
-              </div>
+                <Divider />
+              </>
             )}
             <MenuContent className={`${config.cssPrefix}__menu-content`} maxMenuHeight="60vh">
               {filteredOptions.length === 0 &&
@@ -130,6 +131,7 @@ const Dropdown = <T,>({
                   isFavorites
                   options={filteredFavorites}
                   selectedKey={selectedItem}
+                  showBottomDivider={filteredOptions.length > 0}
                 />
               )}
               <DropdownGroup

--- a/src/utils/components/ClusterProjectDropdown/Dropdown/DropdownGroup.tsx
+++ b/src/utils/components/ClusterProjectDropdown/Dropdown/DropdownGroup.tsx
@@ -1,9 +1,9 @@
-import React, { FC, JSX } from 'react';
+import React, { type FC, type JSX } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Divider, MenuGroup, MenuItem, MenuList, TooltipPosition } from '@patternfly/react-core';
 
-import { DropdownConfig, DropdownOption } from './types';
+import { type DropdownConfig, type DropdownOption } from './types';
 
 type DropdownGroupProps = {
   config: DropdownConfig;
@@ -11,6 +11,7 @@ type DropdownGroupProps = {
   isFavorites?: boolean;
   options: DropdownOption[];
   selectedKey: string;
+  showBottomDivider?: boolean;
 };
 
 const DropdownGroup: FC<DropdownGroupProps> = ({
@@ -19,6 +20,7 @@ const DropdownGroup: FC<DropdownGroupProps> = ({
   isFavorites,
   options,
   selectedKey,
+  showBottomDivider = false,
 }): JSX.Element | null => {
   const { t } = useKubevirtTranslation();
   const label = isFavorites ? t('Favorites') : config.itemsLabel;
@@ -27,7 +29,6 @@ const DropdownGroup: FC<DropdownGroupProps> = ({
 
   return (
     <>
-      <Divider />
       <MenuGroup label={label}>
         <MenuList>
           {options.map((option) => {
@@ -37,6 +38,12 @@ const DropdownGroup: FC<DropdownGroupProps> = ({
             const hasTooltip = !!option.tooltip;
             return (
               <MenuItem
+                isAriaDisabled={option.disabled && hasTooltip}
+                isDisabled={option.disabled && !hasTooltip}
+                isFavorited={isFavorite}
+                isSelected={selectedKey === option.key}
+                itemId={option.key}
+                key={option.key}
                 tooltipProps={
                   option.tooltip
                     ? {
@@ -45,12 +52,6 @@ const DropdownGroup: FC<DropdownGroupProps> = ({
                       }
                     : undefined
                 }
-                isAriaDisabled={option.disabled && hasTooltip}
-                isDisabled={option.disabled && !hasTooltip}
-                isFavorited={isFavorite}
-                isSelected={selectedKey === option.key}
-                itemId={option.key}
-                key={option.key}
               >
                 {option.title}
               </MenuItem>
@@ -58,6 +59,7 @@ const DropdownGroup: FC<DropdownGroupProps> = ({
           })}
         </MenuList>
       </MenuGroup>
+      {showBottomDivider && <Divider />}
     </>
   );
 };

--- a/src/utils/components/ClusterProjectDropdown/Dropdown/NoResults.tsx
+++ b/src/utils/components/ClusterProjectDropdown/Dropdown/NoResults.tsx
@@ -1,9 +1,8 @@
-import React, { FC, MouseEvent } from 'react';
+import React, { type FC, type MouseEvent } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   Button,
-  Divider,
   EmptyState,
   EmptyStateActions,
   EmptyStateBody,
@@ -19,19 +18,16 @@ type NoResultsProps = {
 const NoResults: FC<NoResultsProps> = ({ noItemsFoundTitle, onClear }) => {
   const { t } = useKubevirtTranslation();
   return (
-    <>
-      <Divider />
-      <EmptyState headingLevel="h4" icon={SearchIcon} titleText={noItemsFoundTitle}>
-        <EmptyStateBody>{t('No results match the filter criteria.')}</EmptyStateBody>
-        <EmptyStateFooter>
-          <EmptyStateActions>
-            <Button onClick={onClear} variant="link">
-              {t('Clear filters')}
-            </Button>
-          </EmptyStateActions>
-        </EmptyStateFooter>
-      </EmptyState>
-    </>
+    <EmptyState headingLevel="h4" icon={SearchIcon} titleText={noItemsFoundTitle}>
+      <EmptyStateBody>{t('No results match the filter criteria.')}</EmptyStateBody>
+      <EmptyStateFooter>
+        <EmptyStateActions>
+          <Button onClick={onClear} variant="link">
+            {t('Clear filters')}
+          </Button>
+        </EmptyStateActions>
+      </EmptyStateFooter>
+    </EmptyState>
   );
 };
 

--- a/src/utils/components/ClusterProjectDropdown/Dropdown/ShowSystemNamespacesSwitch.tsx
+++ b/src/utils/components/ClusterProjectDropdown/Dropdown/ShowSystemNamespacesSwitch.tsx
@@ -1,17 +1,15 @@
-import React, { FC, JSX } from 'react';
+import React, { type FC, type JSX } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Divider, Switch } from '@patternfly/react-core';
+import { MenuSearch, Switch } from '@patternfly/react-core';
 
 type ShowSystemNamespacesSwitchProps = {
-  cssPrefix: string;
   hasSystemNamespaces: boolean;
   isChecked: boolean;
   onChange: (isChecked: boolean) => void;
 };
 
 const ShowSystemNamespacesSwitch: FC<ShowSystemNamespacesSwitchProps> = ({
-  cssPrefix,
   hasSystemNamespaces,
   isChecked,
   onChange,
@@ -23,21 +21,17 @@ const ShowSystemNamespacesSwitch: FC<ShowSystemNamespacesSwitchProps> = ({
   }
 
   return (
-    <>
-      <Divider />
-      <div className={`${cssPrefix}__system-switch`}>
-        <Switch
-          onChange={(_event, checked) => {
-            _event.preventDefault();
-            _event.stopPropagation();
-            onChange(checked);
-          }}
-          id={`${cssPrefix}-show-system-switch`}
-          isChecked={isChecked}
-          label={t('Show default projects')}
-        />
-      </div>
-    </>
+    <MenuSearch>
+      <Switch
+        id="show-system-namespaces-switch"
+        isChecked={isChecked}
+        label={t('Show default projects')}
+        onChange={(_event, checked) => {
+          _event.stopPropagation();
+          onChange(checked);
+        }}
+      />
+    </MenuSearch>
   );
 };
 

--- a/src/utils/components/ProjectDropdown/ProjectDropdown.tsx
+++ b/src/utils/components/ProjectDropdown/ProjectDropdown.tsx
@@ -11,6 +11,7 @@ import { isSystemNamespace } from '@kubevirt-utils/resources/namespace/helper';
 import { getName } from '@kubevirt-utils/resources/shared';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { Divider } from '@patternfly/react-core';
 
 type ProjectDropdownProps = {
   bookmarkCluster?: string;
@@ -95,12 +96,14 @@ const ProjectDropdown: FC<ProjectDropdownProps> = ({
     }
 
     return (
-      <ShowSystemNamespacesSwitch
-        cssPrefix="co-namespace-dropdown"
-        hasSystemNamespaces={hasSystemNamespaces}
-        isChecked={showSystemNamespaces}
-        onChange={onShowSystemNamespacesChange}
-      />
+      <>
+        <ShowSystemNamespacesSwitch
+          hasSystemNamespaces={hasSystemNamespaces}
+          isChecked={showSystemNamespaces}
+          onChange={onShowSystemNamespacesChange}
+        />
+        <Divider />
+      </>
     );
   }, [hasSystemNamespaces, onShowSystemNamespacesChange, showSystemLoaded, showSystemNamespaces]);
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes switch layout in Project dropdown
- wrap in `MenuSearch`
- `Divider` is always shown under the switch

Also fixes the switch not toggling on the first click
- by removing `_event.preventDefault()`

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-96253

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/e9cdabf0-b498-4f2d-b076-3779b1aca516

After:


https://github.com/user-attachments/assets/de044141-4738-4f2d-8c2e-d19840636251




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Improvements**
  - Refined cluster and project dropdown layouts with clearer separators between sections.
  - Updated favorite and filtered option groups to display dividers only when appropriate.
  - Simplified the empty-results display for a cleaner dropdown experience.
  - Improved system namespace toggle interactions within dropdown menus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->