### PR TITLE
[Release-5.0] CNV-96347: VirtualMachines page crashes when the guided tour is running

### DIFF
--- a/src/views/virtualmachines/tree/utils/treeItemBuilders.test.tsx
+++ b/src/views/virtualmachines/tree/utils/treeItemBuilders.test.tsx
@@ -1,0 +1,36 @@
+import type React from 'react';
+import { isValidElement } from 'react';
+
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+
+import StoppedVirtualMachineIcon from '../icons/StoppedVirtualMachineIcon';
+import TreeViewVirtualMachineIcon from '../icons/TreeViewVirtualMachineIcon';
+import { buildProjectMap } from './treeItemBuilders';
+
+const vmWithoutStatus = {
+  metadata: { name: 'rhel9-tour-guide', namespace: 'default' },
+} as V1VirtualMachine;
+
+const stoppedVM = {
+  metadata: { name: 'stopped-vm', namespace: 'default' },
+  status: { printableStatus: 'Stopped' },
+} as V1VirtualMachine;
+
+const getItemIconType = (vm: V1VirtualMachine) => {
+  const projectMap = buildProjectMap([vm], '', '', {}, false);
+  const icon = projectMap.default.ungrouped[0].icon;
+
+  expect(isValidElement(icon)).toBe(true);
+
+  return (icon as React.ReactElement).type;
+};
+
+describe('buildProjectMap', () => {
+  it('uses the fallback tree icon when printableStatus is missing', () => {
+    expect(getItemIconType(vmWithoutStatus)).toBe(TreeViewVirtualMachineIcon);
+  });
+
+  it('uses the stopped icon for Stopped VMs', () => {
+    expect(getItemIconType(stoppedVM)).toBe(StoppedVirtualMachineIcon);
+  });
+});

--- a/src/views/virtualmachines/tree/utils/treeItemBuilders.tsx
+++ b/src/views/virtualmachines/tree/utils/treeItemBuilders.tsx
@@ -34,9 +34,7 @@ const createVMTreeItem = (
   const vmNamespace = getNamespace(vm);
   const vmName = getName(vm);
   const vmCluster = getCluster(vm);
-  const VMStatusIcon = vm?.status?.printableStatus
-    ? statusIcon[vm.status.printableStatus]
-    : undefined;
+  const VMStatusIcon = statusIcon[vm?.status?.printableStatus ?? ''];
 
   return {
     defaultExpanded: currentPageVMName && currentPageVMName === vmName,


### PR DESCRIPTION
## 📝 Description

While the guided tour is running, VirtualMachines fails with "Something wrong happened" instead of showing the VM list and tree.

## 🔗 Links

Jira ticket: [CNV-96347](https://redhat.atlassian.net/browse/CNV-96347)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/7f0a8732-3431-4a3d-8610-2a0e2763f9a4


After:

https://github.com/user-attachments/assets/86c70583-ca7e-4591-8fda-ad6f290baa22

