### PR TITLE
CNV-96348: VirtualMachines page crashes when the guided tour is running

### DIFF
--- a/__mocks__/useKubevirtTranslation.ts
+++ b/__mocks__/useKubevirtTranslation.ts
@@ -18,4 +18,6 @@ const interpolate = (key: string, options?: TOptions): string => {
 
 export const t = ((key: string, options?: TOptions) => interpolate(key, options)) as TFunction;
 
+// Name must match the real hook so Jest module mocks resolve.
+// eslint-disable-next-line @eslint-react/no-unnecessary-use-prefix
 export const useKubevirtTranslation = (): { t: TFunction } => ({ t });

--- a/src/utils/components/CPUMemoryModal/CPUMemoryModal.tsx
+++ b/src/utils/components/CPUMemoryModal/CPUMemoryModal.tsx
@@ -16,15 +16,13 @@ import useClusterParam from '@multicluster/hooks/useClusterParam';
 import {
   Alert,
   AlertVariant,
-  Button,
-  ButtonVariant,
   Modal,
   ModalBody,
-  ModalFooter,
   ModalHeader,
   ModalVariant,
 } from '@patternfly/react-core';
 
+import CPUMemoryModalFooter from './components/CPUMemoryModalFooter';
 import useTemplateDefaultCpuMemory from './hooks/useTemplateDefaultCpuMemory';
 
 import './cpu-memory-modal.scss';
@@ -137,36 +135,20 @@ const CPUMemoryModal: FC<CPUMemoryModalProps> = ({
           </Alert>
         )}
       </ModalBody>
-      <ModalFooter>
-        <Button
-          data-test="save-button"
-          isDisabled={updateInProcess}
-          isLoading={updateInProcess}
-          key="confirm"
-          onClick={handleSubmit}
-          variant={ButtonVariant.primary}
-        >
-          {t('Save')}
-        </Button>
-        <Button
-          isDisabled={
-            !templateName || !defaultsLoaded || !defaultCpu || !defaultMemory || !!defaultLoadError
-          }
-          isLoading={!!templateName && !defaultsLoaded}
-          key="default"
-          onClick={() => {
-            setCPU(defaultCpu);
-            setMemory(defaultMemorySize);
-            setMemoryUnit(defaultMemoryUnit);
-          }}
-          variant={ButtonVariant.secondary}
-        >
-          {t('Restore template settings')}
-        </Button>
-        <Button key="cancel" onClick={onClose} variant={ButtonVariant.link}>
-          {t('Cancel')}
-        </Button>
-      </ModalFooter>
+      <CPUMemoryModalFooter
+        isRestoreDisabled={
+          !templateName || !defaultsLoaded || !defaultCpu || !defaultMemory || !!defaultLoadError
+        }
+        isRestoreLoading={!!templateName && !defaultsLoaded}
+        onClose={onClose}
+        onRestoreTemplateSettings={() => {
+          setCPU(defaultCpu);
+          setMemory(defaultMemorySize);
+          setMemoryUnit(defaultMemoryUnit);
+        }}
+        onSave={handleSubmit}
+        updateInProcess={updateInProcess}
+      />
     </Modal>
   );
 };

--- a/src/utils/components/CPUMemoryModal/components/CPUMemoryModalFooter.tsx
+++ b/src/utils/components/CPUMemoryModal/components/CPUMemoryModalFooter.tsx
@@ -1,0 +1,53 @@
+import React, { type FC } from 'react';
+
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { Button, ButtonVariant, ModalFooter } from '@patternfly/react-core';
+
+type CPUMemoryModalFooterProps = {
+  isRestoreDisabled: boolean;
+  isRestoreLoading: boolean;
+  onClose: () => void;
+  onRestoreTemplateSettings: () => void;
+  onSave: () => void;
+  updateInProcess: boolean;
+};
+
+const CPUMemoryModalFooter: FC<CPUMemoryModalFooterProps> = ({
+  isRestoreDisabled,
+  isRestoreLoading,
+  onClose,
+  onRestoreTemplateSettings,
+  onSave,
+  updateInProcess,
+}) => {
+  const { t } = useKubevirtTranslation();
+
+  return (
+    <ModalFooter>
+      <Button
+        data-test="save-button"
+        isDisabled={updateInProcess}
+        isLoading={updateInProcess}
+        key="confirm"
+        onClick={onSave}
+        variant={ButtonVariant.primary}
+      >
+        {t('Save')}
+      </Button>
+      <Button
+        isDisabled={isRestoreDisabled}
+        isLoading={isRestoreLoading}
+        key="default"
+        onClick={onRestoreTemplateSettings}
+        variant={ButtonVariant.secondary}
+      >
+        {t('Restore template settings')}
+      </Button>
+      <Button key="cancel" onClick={onClose} variant={ButtonVariant.link}>
+        {t('Cancel')}
+      </Button>
+    </ModalFooter>
+  );
+};
+
+export default CPUMemoryModalFooter;

--- a/src/views/virtualmachines/tree/utils/treeItemBuilders.test.tsx
+++ b/src/views/virtualmachines/tree/utils/treeItemBuilders.test.tsx
@@ -1,0 +1,36 @@
+import type React from 'react';
+import { isValidElement } from 'react';
+
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+
+import StoppedVirtualMachineIcon from '../icons/StoppedVirtualMachineIcon';
+import TreeViewVirtualMachineIcon from '../icons/TreeViewVirtualMachineIcon';
+import { buildProjectMap } from './treeItemBuilders';
+
+const vmWithoutStatus = {
+  metadata: { name: 'rhel9-tour-guide', namespace: 'default' },
+} as V1VirtualMachine;
+
+const stoppedVM = {
+  metadata: { name: 'stopped-vm', namespace: 'default' },
+  status: { printableStatus: 'Stopped' },
+} as V1VirtualMachine;
+
+const getItemIconType = (vm: V1VirtualMachine) => {
+  const projectMap = buildProjectMap([vm], '', '', {}, false);
+  const icon = projectMap.default.ungrouped[0].icon;
+
+  expect(isValidElement(icon)).toBe(true);
+
+  return (icon as React.ReactElement).type;
+};
+
+describe('buildProjectMap', () => {
+  it('uses the fallback tree icon when printableStatus is missing', () => {
+    expect(getItemIconType(vmWithoutStatus)).toBe(TreeViewVirtualMachineIcon);
+  });
+
+  it('uses the stopped icon for Stopped VMs', () => {
+    expect(getItemIconType(stoppedVM)).toBe(StoppedVirtualMachineIcon);
+  });
+});

--- a/src/views/virtualmachines/tree/utils/treeItemBuilders.tsx
+++ b/src/views/virtualmachines/tree/utils/treeItemBuilders.tsx
@@ -34,9 +34,7 @@ const createVMTreeItem = (
   const vmNamespace = getNamespace(vm);
   const vmName = getName(vm);
   const vmCluster = getCluster(vm);
-  const VMStatusIcon = vm?.status?.printableStatus
-    ? statusIcon[vm.status.printableStatus]
-    : undefined;
+  const VMStatusIcon = statusIcon[vm?.status?.printableStatus ?? ''];
 
   return {
     defaultExpanded: currentPageVMName && currentPageVMName === vmName,


### PR DESCRIPTION
## 📝 Description

VirtualMachines page crashes when the guided tour is running

## 🔗 Links

Jira ticket: [CNV-96348](https://redhat.atlassian.net/browse/CNV-96348)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/f77851d9-b96f-4ad2-b7e5-2a3b4d4ce0eb


After:


https://github.com/user-attachments/assets/7684580f-c8e2-483a-b388-c94245574302



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a consistent CPU and memory settings modal footer with Save, Cancel, and Restore template settings actions.
  * Added clear loading and disabled states for modal actions.

* **Bug Fixes**
  * Improved virtual machine status icon selection when a printable status is unavailable.
  * Ensured stopped virtual machines consistently display the correct status icon.

* **Tests**
  * Added coverage for missing status values and stopped virtual machine states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->