### PR TITLE
CNV-96598: [release-4.21] Upgrade multicluster-sdk to 0.10.4 for cluster-proxy fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@patternfly/react-tokens": "6.2.2",
         "@patternfly/react-topology": "6.2.0",
         "@preact/signals-react": "^2.0.1",
-        "@stolostron/multicluster-sdk": "^0.10.1",
+        "@stolostron/multicluster-sdk": "^0.10.4",
         "@xterm/addon-clipboard": "^0.1.0",
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
@@ -6459,9 +6459,9 @@
       }
     },
     "node_modules/@stolostron/multicluster-sdk": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@stolostron/multicluster-sdk/-/multicluster-sdk-0.10.3.tgz",
-      "integrity": "sha512-KwA5ebcFKlvoIYNSWSgODF6GmbGDPUTRlFiGCV8hB1Ms9MISgfr7jJ29jt22kwxVyYN2m1JgsVriDodpHvGw7w==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@stolostron/multicluster-sdk/-/multicluster-sdk-0.10.4.tgz",
+      "integrity": "sha512-SGADgxwj2YXn3rMH0LPxQYQtTreIub9zoqAXT1w5konZlIIPqEO9hEi7cnLQy1q7Jryr2kooOfKD/7evtcnCnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apollo/client": "3.14.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@patternfly/react-tokens": "6.2.2",
     "@patternfly/react-topology": "6.2.0",
     "@preact/signals-react": "^2.0.1",
-    "@stolostron/multicluster-sdk": "^0.10.1",
+    "@stolostron/multicluster-sdk": "^0.10.4",
     "@xterm/addon-clipboard": "^0.1.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",


### PR DESCRIPTION
## Summary
- Upgrades `@stolostron/multicluster-sdk` from `^0.10.1` to `^0.10.4` to reduce cluster-proxy load from the Fleet Virtualization console plugin
- Addresses Fleet Virtualization UI instability in large ACM environments where the cluster-proxy addon becomes overloaded ([ACM-40348](https://redhat.atlassian.net/browse/ACM-40348))

## Jira
- [CNV-96598](https://redhat.atlassian.net/browse/CNV-96598)

## Test plan
- [ ] Verify Fleet Virtualization UI loads VM pages without cluster-proxy errors in a large ACM environment
- [ ] Confirm CI passes (lint, type-check, unit tests)

Made with [Cursor](https://cursor.com)