### PR TITLE
CNV-96226: Review and create tab in Clone flow is disabled until vm is selected

### DIFF
--- a/src/views/virtualmachines/wizard/state/vm-wizard-context/VMWizardContext.tsx
+++ b/src/views/virtualmachines/wizard/state/vm-wizard-context/VMWizardContext.tsx
@@ -16,7 +16,7 @@ export const VMWizardProvider: FC<VMWizardProviderProps> = ({ children }) => {
   const { cluster, hubClusterError, isLoadingHubCluster, namespace } = useWizardInitialValues();
 
   const methods = useForm<VMWizardFormValues>({
-    defaultValues: createInitialVMWizardFormValues({ cluster, namespace }),
+    defaultValues: createInitialVMWizardFormValues({ cluster, project: namespace }),
   });
 
   useEffect(() => (): void => clearVMPendingUploadsAndSignal(), []);

--- a/src/views/virtualmachines/wizard/state/vm-wizard-form/consts.ts
+++ b/src/views/virtualmachines/wizard/state/vm-wizard-form/consts.ts
@@ -1,15 +1,19 @@
-import { FieldPath } from 'react-hook-form';
+import { type FieldPath } from 'react-hook-form';
 
 import {
-  CreateInitialVMWizardFormValuesArgs,
-  VMWizardFormValues,
+  type CreateInitialVMWizardFormValuesArgs,
+  type VMWizardFormValues,
 } from '@virtualmachines/wizard/state/vm-wizard-form/types';
 import { OperatingSystemType } from '@virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/utils/constants';
 import { VMCreationMethod, VMWizardStep } from '@virtualmachines/wizard/utils/constants';
 
 export const createInitialVMWizardFormValues = ({
   cluster,
-  namespace,
+  creationMethod,
+  description,
+  folder,
+  name,
+  project,
 }: CreateInitialVMWizardFormValuesArgs): VMWizardFormValues => ({
   instanceTypeData: {
     customDiskSize: '',
@@ -37,12 +41,12 @@ export const createInitialVMWizardFormValues = ({
   },
   vmData: {
     autoLabelsMerged: false,
-    cluster,
-    creationMethod: VMCreationMethod.INSTANCE_TYPE,
-    description: '',
-    folder: '',
-    name: undefined,
-    project: namespace,
+    cluster: cluster ?? '',
+    creationMethod: creationMethod ?? VMCreationMethod.INSTANCE_TYPE,
+    description: description ?? '',
+    folder: folder ?? '',
+    name: name ?? undefined,
+    project: project ?? '',
     selectedTemplate: null,
   },
 });

--- a/src/views/virtualmachines/wizard/state/vm-wizard-form/types.ts
+++ b/src/views/virtualmachines/wizard/state/vm-wizard-form/types.ts
@@ -1,16 +1,16 @@
-import { V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
-import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { PreferenceOption } from '@kubevirt-utils/components/AddBootableVolumeModal/types';
-import { VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
-import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
-import { Template } from '@kubevirt-utils/resources/template';
-import { OperatingSystemType } from '@virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/utils/constants';
-import { VMCreationMethod } from '@virtualmachines/wizard/utils/constants';
+import { type V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type PreferenceOption } from '@kubevirt-utils/components/AddBootableVolumeModal/types';
+import { type VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
+import { type BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
+import { type Template } from '@kubevirt-utils/resources/template';
+import { type OperatingSystemType } from '@virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/utils/constants';
+import { type VMCreationMethod } from '@virtualmachines/wizard/utils/constants';
 
 export type SelectedInstanceType = { name: string; namespace: null | string };
 
 /** VM identity, placement, and provisioning choices collected across wizard steps. */
-type VMWizardVirtualMachineData = {
+export type VMWizardVirtualMachineData = {
   autoLabelsMerged: boolean;
   cluster: string;
   creationMethod: VMCreationMethod;
@@ -58,7 +58,4 @@ export type VMWizardFormValues = {
   vmData: VMWizardVirtualMachineData;
 };
 
-export type CreateInitialVMWizardFormValuesArgs = {
-  cluster: string;
-  namespace: string;
-};
+export type CreateInitialVMWizardFormValuesArgs = Partial<VMWizardVirtualMachineData>;

--- a/src/views/virtualmachines/wizard/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/CreationMethodTileGroup.tsx
+++ b/src/views/virtualmachines/wizard/steps/DeploymentDetailsStep/components/CreationMethodTileGroup/CreationMethodTileGroup.tsx
@@ -1,19 +1,47 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { useWatch } from 'react-hook-form';
 
 import { Flex, FlexItem } from '@patternfly/react-core';
-
 import { useVMWizard } from '@virtualmachines/wizard/state/vm-wizard-context/VMWizardContext';
-import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/wizard/state/vm-wizard-form/consts';
+import {
+  CREATE_VM_FORM_FIELDS_VM_DATA,
+  createInitialVMWizardFormValues,
+} from '@virtualmachines/wizard/state/vm-wizard-form/consts';
+import { type VMWizardVirtualMachineData } from '@virtualmachines/wizard/state/vm-wizard-form/types';
 import { VMCreationMethod } from '@virtualmachines/wizard/utils/constants';
+import { clearVMPendingUploadsAndSignal } from '@virtualmachines/wizard/utils/utils';
 
 import CreationMethodTile from './components/CreationMethodTile/CreationMethodTile';
 
 import './CreationMethodTileGroup.scss';
 
 const CreationMethodTileGroup: FC = () => {
-  const { control, setValue } = useVMWizard();
-  const creationMethod = useWatch({ control, name: CREATE_VM_FORM_FIELDS_VM_DATA.CREATION_METHOD });
+  const { control, getValues, reset } = useVMWizard();
+  const creationMethod: VMCreationMethod = useWatch({
+    control,
+    name: CREATE_VM_FORM_FIELDS_VM_DATA.CREATION_METHOD,
+  });
+
+  const handleCreationMethodChange = (selectedCreationMethod: VMCreationMethod): void => {
+    if (selectedCreationMethod === creationMethod) {
+      return;
+    }
+
+    const { cluster, description, folder, name, project }: Partial<VMWizardVirtualMachineData> =
+      getValues(CREATE_VM_FORM_FIELDS_VM_DATA.ROOT);
+
+    clearVMPendingUploadsAndSignal();
+    reset(
+      createInitialVMWizardFormValues({
+        cluster,
+        creationMethod: selectedCreationMethod,
+        description,
+        folder,
+        name,
+        project,
+      }),
+    );
+  };
 
   return (
     <Flex
@@ -26,11 +54,9 @@ const CreationMethodTileGroup: FC = () => {
         (method) => (
           <FlexItem className="vm-creation-method-tile-group__item" key={method}>
             <CreationMethodTile
-              setSelectedCreationMethod={(selectedCreationMethod) =>
-                setValue(CREATE_VM_FORM_FIELDS_VM_DATA.CREATION_METHOD, selectedCreationMethod)
-              }
               creationMethod={method}
               isChecked={creationMethod === method}
+              setSelectedCreationMethod={handleCreationMethodChange}
             />
           </FlexItem>
         ),


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Resets form fields (except for location and name fields) when changing creation method in order to match available steps to the current creation method
## 🔗 Links

Jira ticket: https://redhat.atlassian.net/browse/CNV-96226
## 🎥 Demo

before:

https://github.com/user-attachments/assets/b28a61af-3ffd-480c-9310-72c03d5e51ee


after:

https://github.com/user-attachments/assets/764604ae-b185-456d-89a1-29dc2bf50055



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Switching the virtual machine creation method now preserves the selected cluster, project, name, description, and folder.
  - Changing the creation method now resets the form consistently and clears pending file uploads.
  - Virtual machine wizard fields now retain provided values while applying appropriate defaults for missing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->