### PR TITLE
CNV-96227: validate snapshot deadline as positive integer

### DIFF
--- a/src/utils/components/SnapshotModal/SnapshotFormFields/SnapshotDeadlineFormField.tsx
+++ b/src/utils/components/SnapshotModal/SnapshotFormFields/SnapshotDeadlineFormField.tsx
@@ -1,4 +1,10 @@
-import React, { Dispatch, FC, FormEvent, SetStateAction, useState } from 'react';
+import React, {
+  type Dispatch,
+  type FC,
+  type FormEvent,
+  type SetStateAction,
+  useState,
+} from 'react';
 
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -34,16 +40,17 @@ const SnapshotDeadlineFormField: FC<SnapshotDeadlineFormFieldProps> = ({
 
   const [deadlineError, setDeadlineError] = useState(undefined);
 
-  const handleDeadlineChange = (value: string, event: FormEvent<HTMLInputElement>) => {
-    event.preventDefault();
+  const handleDeadlineChange = (_event: FormEvent<HTMLInputElement>, value: string): void => {
     const error = validateSnapshotDeadline(t, value);
     setIsError(!!error);
     setDeadlineError(error);
     setDeadline(value);
   };
 
-  const handleDeadlineUnitChange = (value: deadlineUnits, event: FormEvent<HTMLSelectElement>) => {
-    event.preventDefault();
+  const handleDeadlineUnitChange = (
+    _event: FormEvent<HTMLSelectElement>,
+    value: deadlineUnits,
+  ): void => {
     setDeadlineUnit(value);
   };
 
@@ -55,17 +62,15 @@ const SnapshotDeadlineFormField: FC<SnapshotDeadlineFormFieldProps> = ({
         <GridItem span={8}>
           <TextInput
             id="deadline"
-            onChange={(event, value: string) => handleDeadlineChange(value, event)}
+            inputMode="numeric"
+            onChange={handleDeadlineChange}
             type="text"
+            validated={validated}
             value={deadline}
           />
         </GridItem>
         <GridItem span={4}>
-          <FormSelect
-            id="deadline-unit"
-            onChange={(event, value: deadlineUnits) => handleDeadlineUnitChange(value, event)}
-            value={deadlineUnit}
-          >
+          <FormSelect id="deadline-unit" onChange={handleDeadlineUnitChange} value={deadlineUnit}>
             {Object.entries(deadlineUnits).map(([key, value]) => (
               <FormSelectOption key={key} label={`${key} (${value})`} value={value} />
             ))}

--- a/src/utils/components/SnapshotModal/SnapshotFormFields/tests/SnapshotDeadlineFormField.test.tsx
+++ b/src/utils/components/SnapshotModal/SnapshotFormFields/tests/SnapshotDeadlineFormField.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { deadlineUnits } from '@virtualmachines/details/tabs/snapshots/utils/consts';
 
 import SnapshotDeadlineFormField from '../SnapshotDeadlineFormField';
@@ -47,4 +47,17 @@ describe('SnapshotDeadlineFormField', () => {
       expect(optionLabels.some((l) => l.includes(labelPart) && l.includes(valuePart))).toBe(true);
     },
   );
+
+  it('should show validation error and disable submit for scientific notation (regression: CNV-96227)', () => {
+    const setIsError = jest.fn();
+
+    render(<SnapshotDeadlineFormField {...defaultProps} setIsError={setIsError} />);
+
+    fireEvent.change(screen.getByRole('textbox', { name: /deadline/i }), {
+      target: { value: '1e1' },
+    });
+
+    expect(screen.getByText('Deadline must be a number')).toBeInTheDocument();
+    expect(setIsError).toHaveBeenLastCalledWith(true);
+  });
 });

--- a/src/views/virtualmachines/details/tabs/snapshots/utils/helpers.test.ts
+++ b/src/views/virtualmachines/details/tabs/snapshots/utils/helpers.test.ts
@@ -1,0 +1,38 @@
+import { type TFunction } from 'i18next';
+
+import { validateSnapshotDeadline } from './helpers';
+
+const t = ((key: string) => key) as TFunction;
+
+describe('validateSnapshotDeadline', () => {
+  it('should allow empty deadline', () => {
+    expect(validateSnapshotDeadline(t, '')).toBeUndefined();
+    expect(validateSnapshotDeadline(t, undefined)).toBeUndefined();
+  });
+
+  it('should allow positive integers', () => {
+    expect(validateSnapshotDeadline(t, '1')).toBeUndefined();
+    expect(validateSnapshotDeadline(t, '3600')).toBeUndefined();
+  });
+
+  it('should reject zero', () => {
+    expect(validateSnapshotDeadline(t, '0')).toBe('Deadline must be greater than 0');
+  });
+
+  it('should reject non-numeric strings', () => {
+    expect(validateSnapshotDeadline(t, 'abc')).toBe('Deadline must be a number');
+  });
+
+  it('should reject scientific notation (regression: CNV-96227)', () => {
+    expect(validateSnapshotDeadline(t, '1e1')).toBe('Deadline must be a number');
+    expect(validateSnapshotDeadline(t, '1E10')).toBe('Deadline must be a number');
+  });
+
+  it('should reject decimal values', () => {
+    expect(validateSnapshotDeadline(t, '1.5')).toBe('Deadline must be a number');
+  });
+
+  it('should reject negative values', () => {
+    expect(validateSnapshotDeadline(t, '-1')).toBe('Deadline must be a number');
+  });
+});

--- a/src/views/virtualmachines/details/tabs/snapshots/utils/helpers.ts
+++ b/src/views/virtualmachines/details/tabs/snapshots/utils/helpers.ts
@@ -1,13 +1,13 @@
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineRestoreModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineSnapshotModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import {
-  V1beta1VirtualMachineRestore,
-  V1beta1VirtualMachineSnapshot,
-  V1VirtualMachine,
-  V1VolumeSnapshotStatus,
+  type V1beta1VirtualMachineRestore,
+  type V1beta1VirtualMachineSnapshot,
+  type V1VirtualMachine,
+  type V1VolumeSnapshotStatus,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { VolumeRestorePolicy } from '@kubevirt-utils/components/SnapshotModal/utils/constants';
 import { getName } from '@kubevirt-utils/resources/shared';
@@ -16,7 +16,10 @@ import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 export const getVolumeSnapshotStatusesPartition = (
   volumeSnapshotStatuses: V1VolumeSnapshotStatus[],
-) => {
+): {
+  supportedVolumes: V1VolumeSnapshotStatus[];
+  unsupportedVolumes: V1VolumeSnapshotStatus[];
+} => {
   const supportedVolumes = volumeSnapshotStatuses?.filter((status) => status?.enabled);
   const unsupportedVolumes = volumeSnapshotStatuses?.filter((status) => !status?.enabled);
   return {
@@ -25,7 +28,12 @@ export const getVolumeSnapshotStatusesPartition = (
   };
 };
 
-export const getVolumeSnapshotStatusesPartitionPerVM = (vms: V1VirtualMachine[]) =>
+export const getVolumeSnapshotStatusesPartitionPerVM = (
+  vms: V1VirtualMachine[],
+): {
+  supportedVolumes: Record<string, V1VolumeSnapshotStatus[]>;
+  unsupportedVolumes: Record<string, V1VolumeSnapshotStatus[]>;
+} =>
   vms.reduce<{
     supportedVolumes: Record<string, V1VolumeSnapshotStatus[]>;
     unsupportedVolumes: Record<string, V1VolumeSnapshotStatus[]>;
@@ -50,9 +58,11 @@ export const getVolumeSnapshotStatusesPartitionPerVM = (vms: V1VirtualMachine[])
     { supportedVolumes: {}, unsupportedVolumes: {} },
   );
 
+const POSITIVE_INTEGER_PATTERN = /^\d+$/;
+
 export const validateSnapshotDeadline = (t: TFunction, deadline: string): string => {
   if (deadline?.length > 0) {
-    if (!Number(deadline)) {
+    if (!POSITIVE_INTEGER_PATTERN.test(deadline)) {
       return t('Deadline must be a number');
     }
     if (Number(deadline) <= 0) {
@@ -91,7 +101,7 @@ export const getVMRestoreSnapshotResource = (
     metadata: {
       name: `restore-${snapshot.metadata.name}-${new Date().getTime()}`,
       namespace: snapshot.metadata.namespace,
-      ownerReferences: [...(snapshot.metadata.ownerReferences || [])],
+      ownerReferences: [...(snapshot.metadata.ownerReferences ?? [])],
     },
     spec: {
       target: {


### PR DESCRIPTION
## 📝 Description

Fixes invalid snapshot deadline input validation in the Take snapshot modal.

The Deadline field previously accepted values like `1e1` because JavaScript's `Number()` treats scientific notation as valid. KubeVirt's admission webhook rejects these values at submit time with a backend error.

This change:
- Validates deadline input as a positive integer string (digits only)
- Highlights the input as invalid and disables Save when validation fails
- Aligns `handleDeadlineChange` with PatternFly's `(event, value)` handler signature

## 🔗 Links

Jira: https://issues.redhat.com/browse/CNV-96227

## 🎥 Demo

Before:

Invalid values such as `1e1` passed client-side validation and failed on submit with an admission webhook error.

After:

Invalid values are rejected in the UI with "Deadline must be a number", the input shows an error state, and Save remains disabled.

https://github.com/user-attachments/assets/f9f0ccaa-c81c-46ee-b76b-705b054c3426



## Test plan

- [x] Unit tests for `validateSnapshotDeadline` (including `1e1` regression)
- [x] Component test for `SnapshotDeadlineFormField` validation behavior
- [ ] Manual: open Take snapshot modal, enter `1e1` in Deadline, confirm error state and disabled Save
- [ ] Manual: enter a valid value like `30`, confirm Save is enabled

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved snapshot deadline validation to accept only positive whole numbers.
  - Invalid values—including scientific notation, decimals, negative numbers, zero, non-numeric text, and empty input—now display a validation error.
  - Snapshot deadline fields now provide clearer validation feedback and use an appropriate numeric input mode.
  - Snapshot restore ownership handling now preserves explicitly provided values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->