### PR TITLE
CNV-96397: A new VM wizard cancels all pending uploads

### DIFF
--- a/.prettierignorecode
+++ b/.prettierignorecode
@@ -15,6 +15,8 @@ ci-scripts/hot-cluster/helm/**/templates/
 # Playwright artifacts
 .playwright-mcp/
 test-results/
+allure-results/
+playwright/.auth/
 
 # Ignore Claude Code local settings
 .claude/settings.local.json

--- a/src/utils/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
+++ b/src/utils/components/AddBootableVolumeModal/AddBootableVolumeModal.tsx
@@ -23,6 +23,7 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
   lockedPreference,
   onClose,
   onCreateVolume,
+  onUploadStart,
 }) => {
   const navigate = useNavigate();
   const { t } = useKubevirtTranslation();
@@ -54,6 +55,7 @@ const AddBootableVolumeModal: FC<AddBootableVolumeModalProps> = ({
           dataSource,
           onClose,
           onCreateVolume,
+          onUploadStart,
           sourceType,
           t,
           uploadData,

--- a/src/utils/components/AddBootableVolumeModal/bootableVolumeSources.ts
+++ b/src/utils/components/AddBootableVolumeModal/bootableVolumeSources.ts
@@ -88,6 +88,7 @@ export const createBootableVolumeFromUpload = async (
   draftDataSource: V1beta1DataSource,
   uploadData: ({ dataVolume, file }: UploadDataProps) => Promise<void>,
   t: TFunction,
+  onUploadStart?: (uploadKey: string) => void,
 ) => {
   const { isIso, uploadFile } = bootableVolume || {};
   const updatedNameBootableVolume = produce(bootableVolume, (draft) => {
@@ -115,6 +116,8 @@ export const createBootableVolumeFromUpload = async (
   const volumeName = getName(dataSourceToCreate);
   const volumeNamespace = getNamespace(dataSourceToCreate);
   const uploadKey = getBootableVolumeUploadKey(volumeNamespace, volumeName);
+
+  onUploadStart?.(uploadKey);
 
   await uploadData({
     dataVolume: bootableVolumeToCreate,

--- a/src/utils/components/AddBootableVolumeModal/createBootableVolume.ts
+++ b/src/utils/components/AddBootableVolumeModal/createBootableVolume.ts
@@ -19,6 +19,7 @@ const getBootableVolumePromise = ({
   arch,
   bootableVolume,
   dataSource,
+  onUploadStart,
   sourceType,
   t,
   uploadData,
@@ -26,6 +27,7 @@ const getBootableVolumePromise = ({
   arch?: string;
   bootableVolume: AddBootableVolumeState;
   dataSource: V1beta1DataSource;
+  onUploadStart?: (uploadKey: string) => void;
   sourceType: DROPDOWN_FORM_SELECTION;
   t: TFunction;
   uploadData: ({ dataVolume, file }: UploadDataProps) => Promise<void>;
@@ -47,6 +49,7 @@ const getBootableVolumePromise = ({
         draftDataSource,
         uploadData,
         t,
+        onUploadStart,
       ),
     [DROPDOWN_FORM_SELECTION.USE_EXISTING_PVC]: () =>
       createPVCBootableVolume(bootableVolume, bootableVolumeNamespace, draftDataSource),
@@ -62,13 +65,21 @@ const getBootableVolumePromise = ({
 };
 
 export const createBootableVolume: CreateBootableVolumeType =
-  ({ bootableVolume, onCreateVolume, sourceType, t, uploadData }) =>
+  ({ bootableVolume, onCreateVolume, onUploadStart, sourceType, t, uploadData }) =>
   async (dataSource: V1beta1DataSource) => {
     const architectures = bootableVolume?.architectures;
 
     if (!isEmpty(architectures)) {
       const dataSourcePromises = architectures?.map((arch) =>
-        getBootableVolumePromise({ arch, bootableVolume, dataSource, sourceType, t, uploadData }),
+        getBootableVolumePromise({
+          arch,
+          bootableVolume,
+          dataSource,
+          onUploadStart,
+          sourceType,
+          t,
+          uploadData,
+        }),
       );
 
       const newDataSources = await Promise.all(dataSourcePromises);
@@ -81,6 +92,7 @@ export const createBootableVolume: CreateBootableVolumeType =
     const dataSourceWithoutArch = await getBootableVolumePromise({
       bootableVolume,
       dataSource,
+      onUploadStart,
       sourceType,
       t,
       uploadData,

--- a/src/utils/components/AddBootableVolumeModal/types.ts
+++ b/src/utils/components/AddBootableVolumeModal/types.ts
@@ -26,6 +26,7 @@ export type AddBootableVolumeModalProps = {
   lockedPreference?: PreferenceOption;
   onClose: () => void;
   onCreateVolume?: (createdVolume: BootableVolume) => void;
+  onUploadStart?: (uploadKey: string) => void;
 };
 
 export type AddBootableVolumeState = {
@@ -72,6 +73,7 @@ export type SubmitAddBootableVolumeParams = {
   dataSource: V1beta1DataSource;
   onClose: () => void;
   onCreateVolume?: (createdVolume: BootableVolume) => void;
+  onUploadStart?: (uploadKey: string) => void;
   sourceType: DROPDOWN_FORM_SELECTION;
   t: TFunction;
   uploadData: (props: UploadDataProps) => Promise<void>;
@@ -86,6 +88,7 @@ export type HandleAddBootableVolumeModalCloseParams = {
 export type CreateBootableVolumeType = (input: {
   bootableVolume: AddBootableVolumeState;
   onCreateVolume?: (createdVolume: BootableVolume) => void;
+  onUploadStart?: (uploadKey: string) => void;
   sourceType: DROPDOWN_FORM_SELECTION;
   t: TFunction;
   uploadData: ({ dataVolume, file }: UploadDataProps) => Promise<void>;

--- a/src/utils/components/AddBootableVolumeModal/utils.ts
+++ b/src/utils/components/AddBootableVolumeModal/utils.ts
@@ -90,6 +90,7 @@ export const submitAddBootableVolume = async ({
   dataSource,
   onClose,
   onCreateVolume,
+  onUploadStart,
   sourceType,
   t,
   uploadData,
@@ -102,6 +103,7 @@ export const submitAddBootableVolume = async ({
   const createVolume = createBootableVolume({
     bootableVolume,
     onCreateVolume,
+    onUploadStart,
     sourceType,
     t,
     uploadData,

--- a/src/utils/hooks/useUploadProgressToast/cancel/cancelPendingVmUploads.test.ts
+++ b/src/utils/hooks/useUploadProgressToast/cancel/cancelPendingVmUploads.test.ts
@@ -23,14 +23,12 @@ const createVm = (): V1VirtualMachine => ({
 
 describe('cancelPendingVmUploads', () => {
   const cancelUploadsForVm = jest.fn().mockResolvedValue(undefined);
-  const cancelAllPendingUploads = jest.fn().mockResolvedValue(undefined);
 
   beforeEach(() => {
     jest.clearAllMocks();
     sessionStorage.clear();
     customizeWizardVMSignal.value = null;
     (useUploadProgressStore.getState as jest.Mock).mockReturnValue({
-      cancelAllPendingUploads,
       cancelUploadsForVm,
     });
   });
@@ -77,16 +75,27 @@ describe('cancelPendingVmUploads', () => {
 });
 
 describe('cancelAllWizardPendingUploads', () => {
-  const cancelAllPendingUploads = jest.fn().mockResolvedValue(undefined);
+  const cancelWizardPendingUploads = jest.fn().mockResolvedValue(undefined);
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (useUploadProgressStore.getState as jest.Mock).mockReturnValue({ cancelAllPendingUploads });
+    customizeWizardVMSignal.value = null;
+    (useUploadProgressStore.getState as jest.Mock).mockReturnValue({ cancelWizardPendingUploads });
   });
 
-  it('should cancel all pending uploads in the store', () => {
+  it('should cancel wizard-scoped pending uploads for the current wizard VM', () => {
+    const vm = createVm();
+    customizeWizardVMSignal.value = vm;
+
     cancelAllWizardPendingUploads();
 
-    expect(cancelAllPendingUploads).toHaveBeenCalledTimes(1);
+    expect(cancelWizardPendingUploads).toHaveBeenCalledTimes(1);
+    expect(cancelWizardPendingUploads).toHaveBeenCalledWith(vm, []);
+  });
+
+  it('should pass undefined when wizard VM is null', () => {
+    cancelAllWizardPendingUploads();
+
+    expect(cancelWizardPendingUploads).toHaveBeenCalledWith(undefined, []);
   });
 });

--- a/src/utils/hooks/useUploadProgressToast/cancel/cancelPendingVmUploads.ts
+++ b/src/utils/hooks/useUploadProgressToast/cancel/cancelPendingVmUploads.ts
@@ -1,10 +1,16 @@
 import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { customizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
-
-import { useUploadProgressStore } from '../uploadProgressStore';
+import {
+  customizeWizardVMSignal,
+  getCustomizeWizardVM,
+} from '@kubevirt-utils/signals/customizeWizardVMSignal';
+import {
+  getWizardBootableVolumeUploadKeys,
+  clearWizardBootableVolumeUploadKeys,
+} from '@kubevirt-utils/signals/wizardBootableVolumeKeysSignal';
 
 import { getUploadClusterForVm } from '../keys/uploadKeys';
+import { useUploadProgressStore } from '../uploadProgressStore';
 
 export const cancelPendingVmUploads = (vm?: V1VirtualMachine): Promise<void> => {
   const target = vm ?? customizeWizardVMSignal.value;
@@ -21,8 +27,13 @@ export const cancelPendingVmUploads = (vm?: V1VirtualMachine): Promise<void> => 
 };
 
 export const cancelAllWizardPendingUploads = (): void => {
+  const wizardVm = getCustomizeWizardVM();
+  const wizardBootableVolumeKeys = getWizardBootableVolumeUploadKeys();
+
+  clearWizardBootableVolumeUploadKeys();
+
   useUploadProgressStore
     .getState()
-    .cancelAllPendingUploads()
+    .cancelWizardPendingUploads(wizardVm ?? undefined, wizardBootableVolumeKeys)
     .catch(() => {});
 };

--- a/src/utils/hooks/useUploadProgressToast/cancel/cancelUpload.ts
+++ b/src/utils/hooks/useUploadProgressToast/cancel/cancelUpload.ts
@@ -1,10 +1,12 @@
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { cancelUploadPVC } from '@kubevirt-utils/hooks/useCDIUpload/utils';
 import { isK8sNotFoundError } from '@kubevirt-utils/resources/errorStatusChecks';
+import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 
 import { UPLOAD_PROGRESS_STATUS } from '../constants';
-import { collectVmScopedUploadKeys } from '../keys/uploadKeys';
-import { UploadEntry, UploadProgressStoreState } from '../types';
+import { collectVmScopedUploadKeys, getUploadClusterForVm } from '../keys/uploadKeys';
+import { type UploadEntry, type UploadProgressStoreState } from '../types';
 
 type StoreAccessor = () => UploadProgressStoreState;
 
@@ -108,12 +110,25 @@ export const performCancelUploadsForVm = async (
   await performCancelTrackedUploads(get, matchingKeys);
 };
 
-// Used when the VM creation wizard is closed. Cancels every in-progress upload, including
-// bootable-volume uploads that are not tied to a draft VM via vm-scoped keys.
-export const performCancelAllPendingUploads = async (get: StoreAccessor): Promise<void> => {
-  const pendingKeys = Object.entries(get().uploads)
-    .filter(([, upload]) => upload.status === UPLOAD_PROGRESS_STATUS.UPLOADING)
-    .map(([uploadKey]) => uploadKey);
+export const performCancelWizardPendingUploads = async (
+  get: StoreAccessor,
+  wizardVm?: V1VirtualMachine,
+  wizardBootableVolumeKeys?: string[],
+): Promise<void> => {
+  // Step 1: cancel VM-scoped uploads (vm-disk, vm-cdrom) tied to this wizard VM
+  if (wizardVm) {
+    const namespace = getNamespace(wizardVm);
+    const name = getName(wizardVm);
 
-  await performCancelTrackedUploads(get, pendingKeys);
+    if (namespace && name) {
+      await performCancelUploadsForVm(get, getUploadClusterForVm(wizardVm), namespace, name);
+    }
+  }
+
+  // Step 2: cancel bootable volume uploads registered during this wizard session
+  const pendingBootableKeys = (wizardBootableVolumeKeys ?? []).filter(
+    (key) => get().uploads[key]?.status === UPLOAD_PROGRESS_STATUS.UPLOADING,
+  );
+
+  await performCancelTrackedUploads(get, pendingBootableKeys);
 };

--- a/src/utils/hooks/useUploadProgressToast/keys/uploadKeys.test.ts
+++ b/src/utils/hooks/useUploadProgressToast/keys/uploadKeys.test.ts
@@ -1,8 +1,10 @@
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 
 import {
+  collectBootableVolumeUploadKeys,
   collectVmScopedUploadKeys,
   getBootableVolumeUploadKey,
+  getExportDiskUploadKey,
   getUploadClusterForVm,
   getVmCdromUploadKey,
   getVmCdromUploadKeyFromVm,
@@ -137,6 +139,32 @@ describe('uploadKeys', () => {
       expect(collectVmScopedUploadKeys(uploads, '', NAMESPACE, VM_NAME)).toEqual([
         emptyClusterUploadKey,
       ]);
+    });
+  });
+
+  describe('collectBootableVolumeUploadKeys', () => {
+    it('should collect only bootable-volume keys', () => {
+      const bootableVolumeUploadKey = getBootableVolumeUploadKey(
+        BOOTABLE_VOLUME_NAMESPACE,
+        BOOTABLE_VOLUME_NAME,
+      );
+      const diskUploadKey = getVmDiskUploadKey(CLUSTER, NAMESPACE, VM_NAME, DISK_NAME);
+      const exportDiskUploadKey = getExportDiskUploadKey(CLUSTER, NAMESPACE, 'export-pvc');
+      const uploads = {
+        [bootableVolumeUploadKey]: {},
+        [diskUploadKey]: {},
+        [exportDiskUploadKey]: {},
+      };
+
+      expect(collectBootableVolumeUploadKeys(uploads)).toEqual([bootableVolumeUploadKey]);
+    });
+
+    it('should return an empty array when there are no bootable-volume keys', () => {
+      const uploads = {
+        [getVmCdromUploadKey(CLUSTER, NAMESPACE, VM_NAME, CDROM_NAME)]: {},
+      };
+
+      expect(collectBootableVolumeUploadKeys(uploads)).toEqual([]);
     });
   });
 });

--- a/src/utils/hooks/useUploadProgressToast/keys/uploadKeys.ts
+++ b/src/utils/hooks/useUploadProgressToast/keys/uploadKeys.ts
@@ -98,3 +98,6 @@ export const collectVmScopedUploadKeys = (
     ),
   );
 };
+
+export const collectBootableVolumeUploadKeys = (uploads: Record<string, unknown>): string[] =>
+  Object.keys(uploads).filter((key) => key.startsWith(`${UPLOAD_KEY_PREFIX.bootableVolume}/`));

--- a/src/utils/hooks/useUploadProgressToast/types.ts
+++ b/src/utils/hooks/useUploadProgressToast/types.ts
@@ -1,8 +1,9 @@
-import { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 
-import { UPLOAD_STATUS, UploadError } from '@kubevirt-utils/hooks/useCDIUpload/types';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type UPLOAD_STATUS, type UploadError } from '@kubevirt-utils/hooks/useCDIUpload/types';
 
-import { UPLOAD_PROGRESS_STATUS } from './constants';
+import { type UPLOAD_PROGRESS_STATUS } from './constants';
 
 export type UploadProgressStatus =
   (typeof UPLOAD_PROGRESS_STATUS)[keyof typeof UPLOAD_PROGRESS_STATUS];
@@ -69,9 +70,12 @@ export type RegisterCdiUploadParams = {
 };
 
 export type UploadProgressStoreState = {
-  cancelAllPendingUploads: () => Promise<void>;
   cancelTrackedUpload: (uploadKey: string) => Promise<void>;
   cancelUploadsForVm: (cluster: string, namespace: string, vmName: string) => Promise<void>;
+  cancelWizardPendingUploads: (
+    wizardVm?: V1VirtualMachine,
+    wizardBootableVolumeKeys?: string[],
+  ) => Promise<void>;
   completeUpload: (uploadKey: string, options?: CompleteUploadOptions) => void;
   failUpload: (uploadKey: string, errorMessage: string) => void;
   getUpload: (uploadKey: string) => undefined | UploadEntry;

--- a/src/utils/hooks/useUploadProgressToast/uploadProgressStore.test.ts
+++ b/src/utils/hooks/useUploadProgressToast/uploadProgressStore.test.ts
@@ -1,11 +1,12 @@
 import { cancelUploadPVC } from '@kubevirt-utils/hooks/useCDIUpload/utils';
 
+import { UPLOAD_PROGRESS_STATUS } from './constants';
 import {
   getBootableVolumeUploadKey,
+  getExportDiskUploadKey,
   getVmCdromUploadKey,
   getVmDiskUploadKey,
 } from './keys/uploadKeys';
-import { UPLOAD_PROGRESS_STATUS } from './constants';
 import { useUploadProgressStore } from './uploadProgressStore';
 
 jest.mock('@kubevirt-utils/hooks/useCDIUpload/utils', () => ({
@@ -372,133 +373,104 @@ describe('useUploadProgressStore', () => {
     });
   });
 
-  describe('cancelAllPendingUploads', () => {
-    it('should cancel and remove all in-progress uploads', async () => {
-      const diskUploadKey = getVmDiskUploadKey(CLUSTER, NAMESPACE, VM_NAME, VM_DISK_NAME);
+  describe('cancelWizardPendingUploads', () => {
+    it('should cancel draft-VM and bootable-volume uploads without canceling other VM uploads', async () => {
+      const wizardDiskUploadKey = getVmDiskUploadKey(CLUSTER, NAMESPACE, VM_NAME, VM_DISK_NAME);
+      const wizardCdromUploadKey = getVmCdromUploadKey(CLUSTER, NAMESPACE, VM_NAME, CDROM_NAME);
+      const otherVmCdromUploadKey = getVmCdromUploadKey(
+        CLUSTER,
+        NAMESPACE,
+        OTHER_VM_NAME,
+        CDROM_NAME,
+      );
       const bootableVolumeUploadKey = getBootableVolumeUploadKey(
         BOOTABLE_VOLUME_NAMESPACE,
         BOOTABLE_VOLUME_NAME,
       );
-      const completedUploadKey = 'completed-upload-key';
-      const diskCancelUpload = jest.fn(async () => undefined);
-      const bootableCancelUpload = jest.fn(async () => undefined);
+      const exportDiskUploadKey = getExportDiskUploadKey(CLUSTER, NAMESPACE, 'export-pvc');
+      const wizardDiskCancel = jest.fn(async () => undefined);
+      const wizardCdromCancel = jest.fn(async () => undefined);
+      const otherVmCdromCancel = jest.fn(async () => undefined);
+      const bootableCancel = jest.fn(async () => undefined);
+      const exportDiskCancel = jest.fn(async () => undefined);
 
-      useUploadProgressStore.getState().startUpload(diskUploadKey, {
-        cancelUpload: diskCancelUpload,
+      useUploadProgressStore.getState().startUpload(wizardDiskUploadKey, {
+        cancelUpload: wizardDiskCancel,
+        fileName: FILE_IMAGE_ISO,
+      });
+      useUploadProgressStore.getState().startUpload(wizardCdromUploadKey, {
+        cancelUpload: wizardCdromCancel,
+        fileName: FILE_IMAGE_ISO,
+      });
+      useUploadProgressStore.getState().startUpload(otherVmCdromUploadKey, {
+        cancelUpload: otherVmCdromCancel,
         fileName: FILE_IMAGE_ISO,
       });
       useUploadProgressStore.getState().startUpload(bootableVolumeUploadKey, {
-        cancelUpload: bootableCancelUpload,
+        cancelUpload: bootableCancel,
         fileName: FILE_IMAGE_ISO,
       });
-      useUploadProgressStore.getState().startUpload(completedUploadKey, {
+      useUploadProgressStore.getState().startUpload(exportDiskUploadKey, {
+        cancelUpload: exportDiskCancel,
         fileName: FILE_IMAGE_ISO,
       });
-      useUploadProgressStore.getState().completeUpload(completedUploadKey);
 
-      await useUploadProgressStore.getState().cancelAllPendingUploads();
+      await useUploadProgressStore.getState().cancelWizardPendingUploads(
+        {
+          cluster: CLUSTER,
+          metadata: { name: VM_NAME, namespace: NAMESPACE },
+          spec: { template: {} },
+        },
+        [bootableVolumeUploadKey],
+      );
 
-      expect(diskCancelUpload).toHaveBeenCalledTimes(1);
-      expect(bootableCancelUpload).toHaveBeenCalledTimes(1);
-      expect(useUploadProgressStore.getState().getUpload(diskUploadKey)).toBeUndefined();
+      expect(wizardDiskCancel).toHaveBeenCalledTimes(1);
+      expect(wizardCdromCancel).toHaveBeenCalledTimes(1);
+      expect(bootableCancel).toHaveBeenCalledTimes(1);
+      expect(otherVmCdromCancel).not.toHaveBeenCalled();
+      expect(exportDiskCancel).not.toHaveBeenCalled();
+      expect(useUploadProgressStore.getState().getUpload(wizardDiskUploadKey)).toBeUndefined();
+      expect(useUploadProgressStore.getState().getUpload(wizardCdromUploadKey)).toBeUndefined();
       expect(useUploadProgressStore.getState().getUpload(bootableVolumeUploadKey)).toBeUndefined();
-      expect(useUploadProgressStore.getState().getUpload(completedUploadKey)?.status).toBe(
-        UPLOAD_PROGRESS_STATUS.SUCCESS,
+      expect(useUploadProgressStore.getState().getUpload(otherVmCdromUploadKey)?.status).toBe(
+        UPLOAD_PROGRESS_STATUS.UPLOADING,
+      );
+      expect(useUploadProgressStore.getState().getUpload(exportDiskUploadKey)?.status).toBe(
+        UPLOAD_PROGRESS_STATUS.UPLOADING,
       );
     });
 
-    it('should retain uploads when cancelUpload fails without a PVC fallback', async () => {
-      const failingUploadKey = getVmDiskUploadKey(CLUSTER, NAMESPACE, VM_NAME, VM_DISK_NAME);
-      const succeedingUploadKey = getBootableVolumeUploadKey(
+    it('should cancel bootable-volume uploads when no draft VM is provided', async () => {
+      const bootableVolumeUploadKey = getBootableVolumeUploadKey(
         BOOTABLE_VOLUME_NAMESPACE,
         BOOTABLE_VOLUME_NAME,
       );
-      const failingCancelUpload = jest.fn(async () => {
-        throw new Error(ERROR_CANCEL_FAILED);
-      });
-      const succeedingCancelUpload = jest.fn(async () => undefined);
-
-      useUploadProgressStore.getState().startUpload(failingUploadKey, {
-        cancelUpload: failingCancelUpload,
-        fileName: FILE_IMAGE_ISO,
-      });
-      useUploadProgressStore.getState().startUpload(succeedingUploadKey, {
-        cancelUpload: succeedingCancelUpload,
-        fileName: FILE_IMAGE_ISO,
-      });
-
-      await useUploadProgressStore.getState().cancelAllPendingUploads();
-
-      expect(failingCancelUpload).toHaveBeenCalledTimes(1);
-      expect(succeedingCancelUpload).toHaveBeenCalledTimes(1);
-      expect(cancelUploadPVC).not.toHaveBeenCalled();
-      expect(useUploadProgressStore.getState().getUpload(failingUploadKey)?.status).toBe(
-        UPLOAD_PROGRESS_STATUS.UPLOADING,
+      const otherVmCdromUploadKey = getVmCdromUploadKey(
+        CLUSTER,
+        NAMESPACE,
+        OTHER_VM_NAME,
+        CDROM_NAME,
       );
-      expect(useUploadProgressStore.getState().getUpload(succeedingUploadKey)).toBeUndefined();
-    });
+      const bootableCancel = jest.fn(async () => undefined);
+      const otherVmCdromCancel = jest.fn(async () => undefined);
 
-    it('should fall back to cancelUploadPVC when cancelUpload fails during cancelAllPendingUploads', async () => {
-      const uploadKey = getVmDiskUploadKey(CLUSTER, NAMESPACE, VM_NAME, VM_DISK_NAME);
-      const cancelUpload = jest.fn(async () => {
-        throw new Error(ERROR_CANCEL_FAILED);
+      useUploadProgressStore.getState().startUpload(bootableVolumeUploadKey, {
+        cancelUpload: bootableCancel,
+        fileName: FILE_IMAGE_ISO,
       });
-
-      useUploadProgressStore.getState().startUpload(uploadKey, {
-        cancelUpload,
-        dvCluster: CLUSTER,
-        dvName: DV_NAME,
-        dvNamespace: NAMESPACE,
+      useUploadProgressStore.getState().startUpload(otherVmCdromUploadKey, {
+        cancelUpload: otherVmCdromCancel,
         fileName: FILE_IMAGE_ISO,
       });
 
-      await useUploadProgressStore.getState().cancelAllPendingUploads();
+      await useUploadProgressStore
+        .getState()
+        .cancelWizardPendingUploads(undefined, [bootableVolumeUploadKey]);
 
-      expect(cancelUpload).toHaveBeenCalledTimes(1);
-      expect(cancelUploadPVC).toHaveBeenCalledWith(DV_NAME, NAMESPACE, CLUSTER);
-      expect(useUploadProgressStore.getState().getUpload(uploadKey)).toBeUndefined();
-    });
-
-    it('should remove upload when cancelUploadPVC throws 404 during cancelAllPendingUploads', async () => {
-      const uploadKey = getVmDiskUploadKey(CLUSTER, NAMESPACE, VM_NAME, VM_DISK_NAME);
-      const cancelUpload = jest.fn(async () => {
-        throw new Error(ERROR_CANCEL_FAILED);
-      });
-      (cancelUploadPVC as jest.Mock).mockRejectedValueOnce({ code: 404 });
-
-      useUploadProgressStore.getState().startUpload(uploadKey, {
-        cancelUpload,
-        dvCluster: CLUSTER,
-        dvName: DV_NAME,
-        dvNamespace: NAMESPACE,
-        fileName: FILE_IMAGE_ISO,
-      });
-
-      await useUploadProgressStore.getState().cancelAllPendingUploads();
-
-      expect(cancelUploadPVC).toHaveBeenCalledWith(DV_NAME, NAMESPACE, CLUSTER);
-      expect(useUploadProgressStore.getState().getUpload(uploadKey)).toBeUndefined();
-    });
-
-    it('should retain upload when cancelUploadPVC throws non-404 error during cancelAllPendingUploads', async () => {
-      const uploadKey = getVmDiskUploadKey(CLUSTER, NAMESPACE, VM_NAME, VM_DISK_NAME);
-      const cancelUpload = jest.fn(async () => {
-        throw new Error(ERROR_CANCEL_FAILED);
-      });
-      (cancelUploadPVC as jest.Mock).mockRejectedValueOnce({ code: 403 });
-
-      useUploadProgressStore.getState().startUpload(uploadKey, {
-        cancelUpload,
-        dvCluster: CLUSTER,
-        dvName: DV_NAME,
-        dvNamespace: NAMESPACE,
-        fileName: FILE_IMAGE_ISO,
-      });
-
-      await useUploadProgressStore.getState().cancelAllPendingUploads();
-
-      expect(cancelUploadPVC).toHaveBeenCalledWith(DV_NAME, NAMESPACE, CLUSTER);
-      expect(useUploadProgressStore.getState().getUpload(uploadKey)?.status).toBe(
+      expect(bootableCancel).toHaveBeenCalledTimes(1);
+      expect(otherVmCdromCancel).not.toHaveBeenCalled();
+      expect(useUploadProgressStore.getState().getUpload(bootableVolumeUploadKey)).toBeUndefined();
+      expect(useUploadProgressStore.getState().getUpload(otherVmCdromUploadKey)?.status).toBe(
         UPLOAD_PROGRESS_STATUS.UPLOADING,
       );
     });

--- a/src/utils/hooks/useUploadProgressToast/uploadProgressStore.ts
+++ b/src/utils/hooks/useUploadProgressToast/uploadProgressStore.ts
@@ -1,18 +1,19 @@
 import { create } from 'zustand';
 
 import {
-  performCancelAllPendingUploads,
   performCancelTrackedUpload,
   performCancelUploadsForVm,
+  performCancelWizardPendingUploads,
 } from './cancel/cancelUpload';
 import { UPLOAD_PROGRESS_STATUS } from './constants';
-import { UploadProgressStoreState } from './types';
+import { type UploadProgressStoreState } from './types';
 
 export const useUploadProgressStore = create<UploadProgressStoreState>((set, get) => ({
-  cancelAllPendingUploads: () => performCancelAllPendingUploads(get),
   cancelTrackedUpload: (uploadKey) => performCancelTrackedUpload(get, uploadKey),
   cancelUploadsForVm: (cluster, namespace, vmName) =>
     performCancelUploadsForVm(get, cluster, namespace, vmName),
+  cancelWizardPendingUploads: (wizardVm, wizardBootableVolumeKeys) =>
+    performCancelWizardPendingUploads(get, wizardVm, wizardBootableVolumeKeys),
   completeUpload: (uploadKey, options) =>
     set((state) => {
       const current = state.uploads[uploadKey];

--- a/src/utils/signals/wizardBootableVolumeKeysSignal.ts
+++ b/src/utils/signals/wizardBootableVolumeKeysSignal.ts
@@ -1,0 +1,14 @@
+import { signal } from '@preact/signals-react';
+
+const wizardBootableVolumeKeysSignal = signal<string[]>([]);
+
+export const addWizardBootableVolumeUploadKey = (uploadKey: string): void => {
+  wizardBootableVolumeKeysSignal.value = [...wizardBootableVolumeKeysSignal.value, uploadKey];
+};
+
+export const getWizardBootableVolumeUploadKeys = (): string[] =>
+  wizardBootableVolumeKeysSignal.value;
+
+export const clearWizardBootableVolumeUploadKeys = (): void => {
+  wizardBootableVolumeKeysSignal.value = [];
+};

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/components/AddBootableVolumeButton.tsx
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/components/AddBootableVolumeButton.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import AddBootableVolumeModal from '@kubevirt-utils/components/AddBootableVolumeModal/AddBootableVolumeModal';
 import { runningTourSignal } from '@kubevirt-utils/components/GuidedTour/utils/guidedTourSignals';
@@ -18,17 +18,18 @@ const AddBootableVolumeButton: FC<AddBootableVolumeButtonProps> = ({ loadError }
   const { t } = useKubevirtTranslation();
   useSignals();
   const { createModal } = useModal();
-  const { canCreate, lockedPreference, onCreateVolume } = useAddBootableVolume();
+  const { canCreate, lockedPreference, onCreateVolume, onUploadStart } = useAddBootableVolume();
 
   const isEnabled = runningTourSignal.value || (isEmpty(loadError) && canCreate);
 
-  const openAddBootableVolumeModal = () => {
+  const openAddBootableVolumeModal = (): void => {
     createModal((props) => (
       <AddBootableVolumeModal
         {...props}
         lockedPreference={lockedPreference}
         onClose={props.onClose}
         onCreateVolume={onCreateVolume}
+        onUploadStart={onUploadStart}
       />
     ));
   };

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/AddBootableVolumeLink/AddBootableVolumeLink.tsx
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/AddBootableVolumeLink/AddBootableVolumeLink.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import AddBootableVolumeModal from '@kubevirt-utils/components/AddBootableVolumeModal/AddBootableVolumeModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
@@ -21,28 +21,29 @@ const AddBootableVolumeLink: FC<AddBootableVolumeLinkProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
-  const { canCreate, lockedPreference, onCreateVolume } = useAddBootableVolume();
+  const { canCreate, lockedPreference, onCreateVolume, onUploadStart } = useAddBootableVolume();
 
-  const openAddBootableVolumeModal = () => {
+  const openAddBootableVolumeModal = (): void => {
     createModal((props) => (
       <AddBootableVolumeModal
         {...props}
         lockedPreference={lockedPreference}
         onClose={props.onClose}
         onCreateVolume={onCreateVolume}
+        onUploadStart={onUploadStart}
       />
     ));
   };
 
   return (
     <Button
+      className="add-bootable-volume-link__inline-text"
+      isDisabled={!!loadError || !canCreate}
+      isInline
       onClick={() => {
         hidePopover?.();
         openAddBootableVolumeModal();
       }}
-      className="add-bootable-volume-link__inline-text"
-      isDisabled={!!loadError || !canCreate}
-      isInline
       variant={ButtonVariant.link}
     >
       {text || t('Add volume')}

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/hooks/useAddBootableVolume.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/hooks/useAddBootableVolume.ts
@@ -3,6 +3,7 @@ import { useWatch } from 'react-hook-form';
 import { PreferenceOption } from '@kubevirt-utils/components/AddBootableVolumeModal/types';
 import useCanCreateBootableVolume from '@kubevirt-utils/resources/bootableresources/hooks/useCanCreateBootableVolume';
 import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
+import { addWizardBootableVolumeUploadKey } from '@kubevirt-utils/signals/wizardBootableVolumeKeysSignal';
 import { useVMWizard } from '@virtualmachines/wizard/state/vm-wizard-context/VMWizardContext';
 import { CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA } from '@virtualmachines/wizard/state/vm-wizard-form/consts';
 import { applySelectedBootableVolumeToForm } from '@virtualmachines/wizard/utils/utils';
@@ -11,6 +12,7 @@ export type AddBootableVolume = {
   canCreate: boolean;
   lockedPreference?: PreferenceOption;
   onCreateVolume: (volume: BootableVolume) => void;
+  onUploadStart: (uploadKey: string) => void;
 };
 
 const useAddBootableVolume = (): AddBootableVolume => {
@@ -37,10 +39,13 @@ const useAddBootableVolume = (): AddBootableVolume => {
       volumeSnapshotSource: null,
     });
 
+  const onUploadStart = (uploadKey: string) => addWizardBootableVolumeUploadKey(uploadKey);
+
   return {
     canCreate,
     lockedPreference: preference ?? undefined,
     onCreateVolume,
+    onUploadStart,
   };
 };
 

--- a/src/views/virtualmachines/wizard/utils/utils.test.ts
+++ b/src/views/virtualmachines/wizard/utils/utils.test.ts
@@ -16,16 +16,16 @@ describe('clearVMPendingUploadsAndSignal', () => {
     jest.clearAllMocks();
   });
 
-  it('nulls the wizard VM signal before cancelling pending uploads', () => {
+  it('cancels wizard pending uploads before clearing the signal', () => {
     const callOrder: string[] = [];
-    (setCustomizeWizardVMSignal as jest.Mock).mockImplementation(() => callOrder.push('setSignal'));
     (cancelAllWizardPendingUploads as jest.Mock).mockImplementation(() =>
       callOrder.push('cancelUploads'),
     );
+    (setCustomizeWizardVMSignal as jest.Mock).mockImplementation(() => callOrder.push('setSignal'));
 
     clearVMPendingUploadsAndSignal();
 
-    expect(callOrder).toEqual(['setSignal', 'cancelUploads']);
+    expect(callOrder).toEqual(['cancelUploads', 'setSignal']);
   });
 
   it('clears the signal with null', () => {
@@ -34,9 +34,10 @@ describe('clearVMPendingUploadsAndSignal', () => {
     expect(setCustomizeWizardVMSignal).toHaveBeenCalledWith(null);
   });
 
-  it('cancels all pending wizard uploads', () => {
+  it('cancels pending wizard uploads', () => {
     clearVMPendingUploadsAndSignal();
 
     expect(cancelAllWizardPendingUploads).toHaveBeenCalledTimes(1);
+    expect(cancelAllWizardPendingUploads).toHaveBeenCalledWith();
   });
 });

--- a/src/views/virtualmachines/wizard/utils/utils.ts
+++ b/src/views/virtualmachines/wizard/utils/utils.ts
@@ -133,6 +133,6 @@ export const markStepVisited = (
 };
 
 export const clearVMPendingUploadsAndSignal = (): void => {
-  setCustomizeWizardVMSignal(null);
   cancelAllWizardPendingUploads();
+  setCustomizeWizardVMSignal(null);
 };


### PR DESCRIPTION
## 📝 Description

Canceling the VM-Wizard cancels **all** pending uploads (CD-ROM, bootable volumes). 
We only need to cancel uploads that were initiated within the VM-Wizard and keep all other uploads active. 

## 🔗 Links

Jira ticket: [CNV-96397](https://redhat.atlassian.net/browse/CNV-96397)

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/57370ec2-d742-4ce2-a902-a90ca7e57089


After:

https://github.com/user-attachments/assets/fdf39dc1-b3d8-4e30-8e6f-e7663bd7932f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bootable-volume uploads now report their upload key when they begin, improving tracking during the VM creation wizard.
  * Upload tracking now includes bootable-volume uploads alongside other wizard resources.

* **Bug Fixes**
  * Canceling wizard uploads now targets only resources belonging to that wizard, including bootable-volume uploads.
  * Unrelated VM and export-disk uploads remain active.
  * Pending uploads are canceled before wizard VM state is cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->