### PR TITLE
CNV-96670: e2e tests for iso upload flow

### DIFF
--- a/playwright/src/clients/request-context-client.ts
+++ b/playwright/src/clients/request-context-client.ts
@@ -1149,7 +1149,7 @@ export default class RequestContextClient extends BaseClient implements ProxyApi
   async waitForDataVolumeGone(
     name: string,
     namespace: string,
-    timeoutMs = DATA_VOLUME_DELETION_POLLING.TIMEOUT_MS,
+    timeoutMs: number = DATA_VOLUME_DELETION_POLLING.TIMEOUT_MS,
   ): Promise<boolean> {
     const start = Date.now();
     while (Date.now() - start < timeoutMs) {

--- a/playwright/src/components/vm-wizard/vm-wizard-navigation-component.ts
+++ b/playwright/src/components/vm-wizard/vm-wizard-navigation-component.ts
@@ -67,6 +67,10 @@ export default class VmWizardNavigationComponent extends BaseComponent {
     await this.robustClick(
       this.locator('.pf-v6-c-wizard button.pf-v6-c-button.pf-m-link:has-text("Cancel")').first(),
     );
+    await this._wizardContainer.first().waitFor({
+      state: 'hidden',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
   }
 
   async clearCloneSourceFilters(): Promise<void> {

--- a/playwright/src/fixtures/bootable-volumes-fixture.ts
+++ b/playwright/src/fixtures/bootable-volumes-fixture.ts
@@ -12,6 +12,7 @@ import BootableVolumesPage from '@/page-objects/create-vm/bootable-volumes-page'
 import CreateVmPage from '@/page-objects/create-vm/create-vm-page';
 import VirtualMachineDetailPage from '@/page-objects/vm/virtual-machine-detail-page';
 import VirtualMachinesPage from '@/page-objects/vm/virtual-machines-page';
+import VmWizardNavigationPage from '@/page-objects/vm-wizard/vm-wizard-navigation-page';
 
 import { baseTest, expect } from './scenario-test-fixture';
 
@@ -21,6 +22,7 @@ interface BootableVolumesFixtures {
   createVmPage: CreateVmPage;
   vmDetailPage: VirtualMachineDetailPage;
   vmListPage: VirtualMachinesPage;
+  vmWizardNavigationPage: VmWizardNavigationPage;
 }
 
 const test = baseTest.extend<BootableVolumesFixtures>({
@@ -38,6 +40,9 @@ const test = baseTest.extend<BootableVolumesFixtures>({
   },
   vmListPage: async ({ page }, use) => {
     await use(new VirtualMachinesPage(page));
+  },
+  vmWizardNavigationPage: async ({ page }, use) => {
+    await use(new VmWizardNavigationPage(page));
   },
 });
 

--- a/playwright/src/fixtures/vm-tabs-fixture.ts
+++ b/playwright/src/fixtures/vm-tabs-fixture.ts
@@ -16,6 +16,7 @@ import PageCommons from '@/page-objects/page-commons';
 import VirtualMachineDetailPage from '@/page-objects/vm/virtual-machine-detail-page';
 import VirtualMachineSnapshotDetailPage from '@/page-objects/vm/virtual-machine-snapshot-detail-page';
 import VirtualMachinesPage from '@/page-objects/vm/virtual-machines-page';
+import VmWizardNavigationPage from '@/page-objects/vm-wizard/vm-wizard-navigation-page';
 
 import { baseTest, expect } from './scenario-test-fixture';
 
@@ -29,6 +30,7 @@ interface VmTabsFixtures {
   createVmPage: CreateVmPage;
   createVmCreatePage: CreateVmCreatePage;
   createVmTemplatesPage: CreateVmTemplatesPage;
+  vmWizardNavigationPage: VmWizardNavigationPage;
 }
 
 const test = baseTest.extend<VmTabsFixtures>({
@@ -58,6 +60,9 @@ const test = baseTest.extend<VmTabsFixtures>({
   },
   createVmTemplatesPage: async ({ page }, use) => {
     await use(new CreateVmTemplatesPage(page));
+  },
+  vmWizardNavigationPage: async ({ page }, use) => {
+    await use(new VmWizardNavigationPage(page));
   },
 });
 

--- a/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload.spec.md
+++ b/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload.spec.md
@@ -4,8 +4,8 @@
 
 - **Project Name:** KubeVirt UI — Playwright E2E Tests
 - **Feature Area:** Tier1 — Bootable volumes
-- **Latest version:** CNV 5.0.0
-- **Latest update:** 2026-08-17
+- **Latest version:** CNV 5.1.0
+- **Latest update:** 2026-09-03
 - **Document Status:** Approved
 
 ## 2. Introduction
@@ -13,14 +13,15 @@
 ### 2.1 Purpose
 
 Verify the bootable volume "Add volume" upload flow: uploading a local image file, the resulting
-progress toast, background upload behavior when the modal is closed, and the ability to abort an
-in-progress upload from the toast.
+progress toast, background upload behavior when the modal is closed, the ability to abort an
+in-progress upload from the toast, and upload isolation when the VM creation wizard is opened and
+closed.
 
 ### 2.2 Scope
 
 - **In-Scope:** Add volume form (local file upload), upload progress toast, modal close-while-uploading
   behavior, abort/cancel upload action, DataVolume success/deletion outcomes, bootable volumes list row
-  visibility after upload.
+  visibility after upload, upload isolation from the VM creation wizard.
 - **Out-of-Scope:** Warning shown when navigating away while an upload is in progress (CNV-89814).
 
 ## 3. Test Environment & Prerequisites
@@ -98,17 +99,36 @@ in-progress upload from the toast.
 
 ---
 
+### `004`: Closing the VM creation wizard does not cancel an unrelated bootable volume upload
+
+- **Objective:** Verify that closing the VM creation wizard only cancels uploads that were started
+  within the wizard, and does not affect a bootable volume upload started from the Bootable Volumes
+  page.
+- **Target version:** CNV 5.0.0
+- **Jira References:** CNV-96397
+- **Pre-conditions:** None
+- **Tags:** `@nonpriv`
+
+| Step | Action                                                        | Expected Result                                        |
+| :--- | :------------------------------------------------------------ | :----------------------------------------------------- |
+| 1    | Start a bootable volume upload from the Bootable Volumes page | Uploading toast for the image file is visible          |
+| 2    | Open the VM creation wizard via the Create dropdown           | Wizard is visible                                      |
+| 3    | Cancel the wizard                                             | Wizard closes                                          |
+| 4    | Check the upload toast state                                  | Toast shows `uploading` or `success` — not `cancelled` |
+| 5    | Abort the upload if still in progress (cleanup)               | Aborted toast is shown and DataVolume is removed       |
+
 ## 5. Requirements Traceability Matrix
 
-| Jira Ticket | Test Case ID | Coverage Type    | Status    |
-| ----------- | ------------ | ---------------- | --------- |
-| CNV-89946   | `001`        | Feature coverage | Automated |
-| CNV-89946   | `002`        | Feature coverage | Automated |
-| CNV-89946   | `003`        | Feature coverage | Automated |
-| CNV-89800   | `001`        | Feature coverage | Automated |
-| CNV-89800   | `002`        | Feature coverage | Automated |
-| CNV-89800   | `003`        | Feature coverage | Automated |
-| CNV-87382   | `001`        | Feature coverage | Automated |
+| Jira Ticket | Test Case ID | Coverage Type           | Status    |
+| ----------- | ------------ | ----------------------- | --------- |
+| CNV-89946   | `001`        | Feature coverage        | Automated |
+| CNV-89946   | `002`        | Feature coverage        | Automated |
+| CNV-89946   | `003`        | Feature coverage        | Automated |
+| CNV-89800   | `001`        | Feature coverage        | Automated |
+| CNV-89800   | `002`        | Feature coverage        | Automated |
+| CNV-89800   | `003`        | Feature coverage        | Automated |
+| CNV-87382   | `001`        | Feature coverage        | Automated |
+| CNV-96397   | `004`        | Bugfix regression guard | Automated |
 
 **Coverage Type values:**
 

--- a/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload.spec.ts
+++ b/playwright/tests/tier1/bootable-volumes/bootable-volumes-upload.spec.ts
@@ -164,4 +164,63 @@ test.describe('Tier1 Bootable Volumes - Upload experience', { tag: [T1_TAG] }, (
       });
     },
   );
+
+  test(
+    'Closing the VM creation wizard does not cancel an unrelated bootable volume upload',
+    { tag: ['@nonpriv'] },
+    async ({ bootableVolumesPage, vmWizardNavigationPage, apiClient, utils }) => {
+      await utils.withAllure({ suite: SUITE, feature: T1, tags: [T1_TAG] });
+
+      const ns = await setupTestNamespace(apiClient, 'bv-upload-wizard-isolation');
+      const volumeName = utils.generateRandomDataVolumeName('bv-wizard-iso');
+      const imagePath = await utils.TestFileFactory.downloadCirrosImage(UPLOAD_IMAGE_FILENAME);
+      apiClient.trackResource('DataVolume', volumeName, ns);
+
+      await bootableVolumesPage.navigateToNamespaceBootableVolumesViaUI(ns);
+
+      await test.step('Start a bootable volume upload from the Bootable Volumes page', async () => {
+        await bootableVolumesPage.clickCreateAndSelectOption('With form');
+        await bootableVolumesPage.fillCreateBootableVolumeFormAndSave(volumeName, imagePath);
+        await bootableVolumesPage.expectUploadingToastVisible(
+          UPLOAD_IMAGE_FILENAME,
+          utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+        );
+      });
+
+      await test.step('Open and cancel the VM creation wizard', async () => {
+        await vmWizardNavigationPage.openWizardFromCreateDropdown();
+
+        const wizardVisible = await vmWizardNavigationPage.verifyWizardVisible();
+        expect(wizardVisible, 'Wizard should open').toBe(true);
+
+        await vmWizardNavigationPage.cancelWizard();
+      });
+
+      await test.step('Bootable volume upload is still active after closing the wizard', async () => {
+        const state = await bootableVolumesPage.expectUploadingOrTerminalToastVisible(
+          UPLOAD_IMAGE_FILENAME,
+          utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+        );
+        expect(
+          state === 'uploading' || state === 'success',
+          `Expected uploading or success toast after closing wizard, got ${state}`,
+        ).toBe(true);
+      });
+
+      await test.step('Abort the upload to clean up when still in progress', async () => {
+        const abortVisible = await bootableVolumesPage.isAbortUploadButtonVisible(
+          utils.TestTimeouts.UI_DELAY_MEDIUM,
+          UPLOAD_IMAGE_FILENAME,
+        );
+        if (!abortVisible) {
+          return;
+        }
+        await bootableVolumesPage.clickAbortUpload(UPLOAD_IMAGE_FILENAME);
+        await bootableVolumesPage.expectAbortedUploadToastVisible(
+          UPLOAD_IMAGE_FILENAME,
+          utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+        );
+      });
+    },
+  );
 });

--- a/playwright/tests/tier1/virtualmachines/vm-tabs/vm-cdrom-upload.spec.md
+++ b/playwright/tests/tier1/virtualmachines/vm-tabs/vm-cdrom-upload.spec.md
@@ -4,8 +4,8 @@
 
 - **Project Name:** KubeVirt UI — Playwright E2E Tests
 - **Feature Area:** Tier1 — VM tabs (CD-ROM)
-- **Latest version:** CNV 5.0.0
-- **Latest update:** 2026-08-17
+- **Latest version:** CNV 5.1.0
+- **Latest update:** 2026-09-03
 - **Document Status:** Approved
 
 ## 2. Introduction
@@ -13,12 +13,14 @@
 ### 2.1 Purpose
 
 Verify the "Add CD-ROM" flow with the "Upload new ISO" source on an existing, stopped RHEL9 VM,
-including the resulting background upload toast and the ability to abort an in-progress upload.
+including the resulting background upload toast, the ability to abort an in-progress upload, and
+that creating a new VM does not cancel an unrelated in-progress CD-ROM upload.
 
 ### 2.2 Scope
 
 - **In-Scope:** Add CD-ROM disk modal with "Upload new ISO" source, background upload progress toast,
-  abort/cancel upload action, DataVolume deletion after abort.
+  abort/cancel upload action, DataVolume deletion after abort, and that an in-progress CD-ROM upload
+  is not canceled when the VM creation wizard is opened and left.
 - **Out-of-Scope:** Adding a CD-ROM with upload during new VM creation (CNV-90313) — this file covers
   upload to an already-existing VM only.
 
@@ -82,15 +84,36 @@ including the resulting background upload toast and the ability to abort an in-p
 
 ---
 
+### `003`: Creating a new VM does not cancel an in-progress CD-ROM upload on another VM
+
+- **Objective:** Verify that opening and leaving the VM creation wizard does not cancel a background
+  CD-ROM ISO upload that was started on an existing VM (CNV-96397).
+- **Target version:** CNV 5.0.0
+- **Jira References:** CNV-96397
+- **Pre-conditions:** VM must exist and be reachable via the VM tree view (created stopped from the
+  RHEL9 template)
+- **Tags:** `@nonpriv`
+
+| Step | Action                                                              | Expected Result                                                       |
+| :--- | :------------------------------------------------------------------ | :-------------------------------------------------------------------- |
+| 1    | Add a CD-ROM disk using "Upload new ISO" with the sized ISO fixture | CD-ROM disk is added; uploading toast is visible                      |
+| 2    | Navigate to the VM list and open the VM creation wizard             | Wizard is visible                                                     |
+| 3    | Cancel / leave the wizard                                           | Wizard closes (unmount cleanup runs)                                  |
+| 4    | Observe the upload toast                                            | Uploading or success toast is shown; upload is not aborted/canceled   |
+| 5    | Check for the "Cancel upload" (abort) button                        | If still visible (upload in progress), the test aborts it to clean up |
+
+---
+
 ## 5. Requirements Traceability Matrix
 
-| Jira Ticket | Test Case ID | Coverage Type    | Status    |
-| ----------- | ------------ | ---------------- | --------- |
-| CNV-89946   | `001`        | Feature coverage | Automated |
-| CNV-89946   | `002`        | Feature coverage | Automated |
-| CNV-89800   | `001`        | Feature coverage | Automated |
-| CNV-89800   | `002`        | Feature coverage | Automated |
-| CNV-87382   | `001`        | Feature coverage | Automated |
+| Jira Ticket | Test Case ID | Coverage Type           | Status    |
+| ----------- | ------------ | ----------------------- | --------- |
+| CNV-89946   | `001`        | Feature coverage        | Automated |
+| CNV-89946   | `002`        | Feature coverage        | Automated |
+| CNV-89800   | `001`        | Feature coverage        | Automated |
+| CNV-89800   | `002`        | Feature coverage        | Automated |
+| CNV-87382   | `001`        | Feature coverage        | Automated |
+| CNV-96397   | `003`        | Bugfix regression guard | Automated |
 
 **Coverage Type values:**
 

--- a/playwright/tests/tier1/virtualmachines/vm-tabs/vm-cdrom-upload.spec.ts
+++ b/playwright/tests/tier1/virtualmachines/vm-tabs/vm-cdrom-upload.spec.ts
@@ -137,4 +137,85 @@ test.describe('Tier1 VM CD-ROM upload — stopped RHEL9', { tag: [T1_TAG, '@nonp
       expect(dvGone, 'DataVolume should be deleted after abort').toBe(true);
     });
   });
+
+  test('Creating a new VM does not cancel an in-progress CD-ROM upload on another VM', async ({
+    apiClient,
+    vmTreePage,
+    vmDetailPage,
+    vmWizardNavigationPage,
+    utils,
+  }) => {
+    await utils.withAllure({ suite: SUITE, feature: T1, tags: [T1_TAG, VM_TABS_TAG] });
+    test.setTimeout(utils.TestTimeouts.TEST_VM_CREATION);
+
+    const ns = utils.generateTestNamespace('vm-cdrom-create');
+    await apiClient.createNamespace(ns);
+    await apiClient.waitForNamespaceReady(ns);
+    apiClient.trackResource('Namespace', ns);
+
+    const vmName = utils.generateRandomVmName('vm-cdrom-create');
+    await apiClient.createVmFromTemplate(
+      utils.TEMPLATE_METADATA_NAMES.RHEL9,
+      vmName,
+      ns,
+      'openshift',
+      false,
+    );
+    apiClient.trackResource('VirtualMachine', vmName, ns);
+
+    const result = await apiClient.verifyVmCreated(vmName, ns, utils.TestTimeouts.VM_BOOTUP);
+    if (!result.exists) throw new Error(`VM ${vmName} was not created`);
+
+    await vmTreePage.navigateToVmViaTreeView(ns, vmName);
+
+    const isoFileName = 'vm-cdrom-create-test.iso';
+    const isoPath = utils.TestFileFactory.createSizedIsoFile(isoFileName);
+    const diskName = utils.generateRandomDiskName('cdrom-create');
+    apiClient.trackResource('DataVolume', diskName, ns);
+
+    await test.step('Start the CD-ROM upload', async () => {
+      const added = await vmDetailPage.addCDROMDisk(diskName, 'Upload new ISO', isoPath);
+      expect(added, `CD-ROM disk ${diskName} should be added from UI`).toBe(true);
+      await vmDetailPage.expectUploadingToastVisible(
+        isoFileName,
+        utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+      );
+    });
+
+    await test.step('Open and leave the VM creation wizard', async () => {
+      await vmTreePage.navigateToProjectVmListViaUI(ns);
+      await vmWizardNavigationPage.openWizardFromCreateDropdown();
+
+      const wizardVisible = await vmWizardNavigationPage.verifyWizardVisible();
+      expect(wizardVisible, 'Wizard should open').toBe(true);
+
+      await vmWizardNavigationPage.cancelWizard();
+    });
+
+    await test.step('Uploading toast is still visible after leaving the wizard', async () => {
+      const state = await vmDetailPage.expectUploadingOrTerminalToastVisible(
+        isoFileName,
+        utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+      );
+      expect(
+        state === 'uploading' || state === 'success',
+        `Expected uploading or success toast after creating a VM, got ${state}`,
+      ).toBe(true);
+    });
+
+    await test.step('Abort the upload to clean up when still in progress', async () => {
+      const abortVisible = await vmDetailPage.isAbortUploadButtonVisible(
+        utils.TestTimeouts.UI_DELAY_MEDIUM,
+        isoFileName,
+      );
+      if (!abortVisible) {
+        return;
+      }
+      await vmDetailPage.clickAbortUpload(isoFileName);
+      await vmDetailPage.expectAbortedUploadToastVisible(
+        isoFileName,
+        utils.TestTimeouts.UI_ELEMENT_VISIBILITY,
+      );
+    });
+  });
 });


### PR DESCRIPTION
## 📝 Description

Adding E2E tests for VM uploads. 

## 🔗 Links

Jira ticket: [CNV-96670](https://redhat.atlassian.net/browse/CNV-96670)

## 🎥 Demo

Will be validated in the pipeline. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Uploads now continue when the VM creation wizard is opened and canceled, preventing unrelated bootable-volume and CD-ROM ISO uploads from being interrupted.
  - Canceling the VM creation wizard now completes reliably after the wizard is hidden.

- **Tests**
  - Added regression coverage for upload behavior during VM creation workflows.

- **Documentation**
  - Updated testing documentation and traceability details for upload isolation scenarios and VM creation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->