### PR TITLE
CNV-96372: fix Services card stuck loading for stopped VMs

### DIFF
--- a/src/utils/components/SSHAccess/components/SSHCommand.tsx
+++ b/src/utils/components/SSHAccess/components/SSHCommand.tsx
@@ -5,7 +5,7 @@ import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import StateHandler from '@kubevirt-utils/components/StateHandler/StateHandler';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
+import { useVMIAndPodForVM } from '@kubevirt-utils/resources/vm';
 import { getVMILabelForServiceSelector } from '@kubevirt-utils/resources/vmi/utils/services';
 import { getCluster } from '@multicluster/helpers/selectors';
 import {
@@ -52,7 +52,7 @@ const SSHCommand: FC<SSHCommandProps> = ({
     loaded: vmiAndPodsLoaded,
     pod,
     vmi,
-  } = useVMIAndPodsForVM(getName(vm), getNamespace(vm), getCluster(vm));
+  } = useVMIAndPodForVM(getName(vm), getNamespace(vm), getCluster(vm));
   const loadError = sshServiceError ?? vmiAndPodsError;
 
   const onSSHChange = async (newServiceType: SERVICE_TYPES): Promise<void> => {

--- a/src/utils/components/SSHAccess/components/SSHCommand.tsx
+++ b/src/utils/components/SSHAccess/components/SSHCommand.tsx
@@ -1,12 +1,11 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { type FC, useEffect, useState } from 'react';
 
-import { IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import StateHandler from '@kubevirt-utils/components/StateHandler/StateHandler';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
-import { getVMIPod } from '@kubevirt-utils/resources/vmi/utils/pod';
 import { getVMILabelForServiceSelector } from '@kubevirt-utils/resources/vmi/utils/services';
 import { getCluster } from '@multicluster/helpers/selectors';
 import {
@@ -51,13 +50,12 @@ const SSHCommand: FC<SSHCommandProps> = ({
   const {
     error: vmiAndPodsError,
     loaded: vmiAndPodsLoaded,
-    pods,
+    pod,
     vmi,
   } = useVMIAndPodsForVM(getName(vm), getNamespace(vm), getCluster(vm));
-  const loadError = sshServiceError || vmiAndPodsError;
-  const pod = getVMIPod(vmi, pods);
+  const loadError = sshServiceError ?? vmiAndPodsError;
 
-  const onSSHChange = async (newServiceType: SERVICE_TYPES) => {
+  const onSSHChange = async (newServiceType: SERVICE_TYPES): Promise<void> => {
     setLoading(true);
 
     try {

--- a/src/utils/components/SSHAccess/useSSHService.tsx
+++ b/src/utils/components/SSHAccess/useSSHService.tsx
@@ -2,7 +2,7 @@ import { modelToGroupVersionKind, ServiceModel } from '@kubevirt-ui-ext/kubevirt
 import { type IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
+import { useVMIAndPodForVM } from '@kubevirt-utils/resources/vm';
 import { getServicesForVmi } from '@kubevirt-utils/resources/vmi';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
@@ -27,7 +27,7 @@ const useSSHService = (vm: V1VirtualMachine): UseSSHServiceReturnType => {
     vm && watchServiceResources,
   );
 
-  const { pod, vmi } = useVMIAndPodsForVM(
+  const { pod, vmi } = useVMIAndPodForVM(
     vm ? getName(vm) : '',
     vm ? getNamespace(vm) : '',
     vm ? getCluster(vm) : undefined,

--- a/src/utils/components/SSHAccess/useSSHService.tsx
+++ b/src/utils/components/SSHAccess/useSSHService.tsx
@@ -4,7 +4,6 @@ import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
 import { getServicesForVmi } from '@kubevirt-utils/resources/vmi';
-import { getVMIPod } from '@kubevirt-utils/resources/vmi/utils/pod';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
@@ -28,7 +27,7 @@ const useSSHService = (vm: V1VirtualMachine): UseSSHServiceReturnType => {
     vm && watchServiceResources,
   );
 
-  const { pods, vmi } = useVMIAndPodsForVM(
+  const { pod, vmi } = useVMIAndPodsForVM(
     vm ? getName(vm) : '',
     vm ? getNamespace(vm) : '',
     vm ? getCluster(vm) : undefined,
@@ -36,7 +35,6 @@ const useSSHService = (vm: V1VirtualMachine): UseSSHServiceReturnType => {
 
   if (!vm) return [undefined, false, undefined];
 
-  const pod = getVMIPod(vmi, pods);
   const vmiServices = getServicesForVmi(services, pod, vm, vmi);
 
   const sshVMIService = vmiServices.find((service) =>

--- a/src/utils/resources/vm/hooks/index.ts
+++ b/src/utils/resources/vm/hooks/index.ts
@@ -1,1 +1,1 @@
-export * from './useVMIAndPodsForVM';
+export * from './useVMIAndPodForVM';

--- a/src/utils/resources/vm/hooks/useVMIAndPodForVM.ts
+++ b/src/utils/resources/vm/hooks/useVMIAndPodForVM.ts
@@ -6,18 +6,18 @@ import useVMI from '@kubevirt-utils/resources/vm/hooks/useVMI';
 import { getVMIPod } from '@kubevirt-utils/resources/vmi/utils/pod';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
-type UseVMIAndPodsForVMValues = {
+type UseVMIAndPodForVMValues = {
   error: Error | undefined;
   loaded: boolean;
   pod: IoK8sApiCoreV1Pod | null | undefined;
-  vmi: V1VirtualMachineInstance;
+  vmi: undefined | V1VirtualMachineInstance;
 };
 
-export const useVMIAndPodsForVM = (
+export const useVMIAndPodForVM = (
   vmName: string,
   vmNamespace: string,
   vmCluster?: string,
-): UseVMIAndPodsForVMValues => {
+): UseVMIAndPodForVMValues => {
   const { vmi, vmiLoaded, vmiLoadError } = useVMI(vmName, vmNamespace, vmCluster);
 
   const [pods, podsLoaded, podsLoadError] = useK8sWatchData<K8sResourceCommon[]>({

--- a/src/utils/resources/vm/hooks/useVMIAndPodsForVM.ts
+++ b/src/utils/resources/vm/hooks/useVMIAndPodsForVM.ts
@@ -1,13 +1,15 @@
 import { modelToGroupVersionKind, PodModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { type IoK8sApiCoreV1Pod } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { type V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import useVMI from '@kubevirt-utils/resources/vm/hooks/useVMI';
+import { getVMIPod } from '@kubevirt-utils/resources/vmi/utils/pod';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
 type UseVMIAndPodsForVMValues = {
   error: Error | undefined;
   loaded: boolean;
-  pods: IoK8sApiCoreV1Pod[];
+  pod: IoK8sApiCoreV1Pod | null | undefined;
   vmi: V1VirtualMachineInstance;
 };
 
@@ -27,11 +29,13 @@ export const useVMIAndPodsForVM = (
 
   const loaded = vmiLoaded && podsLoaded;
   const error = vmiLoadError || podsLoadError;
+  const filteredVmi =
+    vmName === getName(vmi) && vmNamespace === getNamespace(vmi) ? vmi : undefined;
 
   return {
     error,
     loaded,
-    pods,
-    vmi: vmName === vmi?.metadata?.name && vmNamespace === vmi?.metadata?.namespace && vmi,
+    pod: getVMIPod(filteredVmi, pods),
+    vmi: filteredVmi,
   };
 };

--- a/src/utils/resources/vm/hooks/useVMIAndPodsForVM.ts
+++ b/src/utils/resources/vm/hooks/useVMIAndPodsForVM.ts
@@ -1,11 +1,11 @@
 import { modelToGroupVersionKind, PodModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1Pod } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type IoK8sApiCoreV1Pod } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import useVMI from '@kubevirt-utils/resources/vm/hooks/useVMI';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
 type UseVMIAndPodsForVMValues = {
-  error: any;
+  error: Error | undefined;
   loaded: boolean;
   pods: IoK8sApiCoreV1Pod[];
   vmi: V1VirtualMachineInstance;

--- a/src/utils/resources/vmi/utils/pod.ts
+++ b/src/utils/resources/vmi/utils/pod.ts
@@ -22,7 +22,7 @@ export const isPodReady = (pod): boolean =>
  * @returns {*}
  */
 export const getVMIPod = (
-  vmi: V1VirtualMachineInstance,
+  vmi: null | undefined | V1VirtualMachineInstance,
   pods: IoK8sApiCoreV1Pod[],
 ): IoK8sApiCoreV1Pod | null | undefined => {
   if (!pods || !vmi) {

--- a/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/VMDetailsPanelRightColumn.tsx
+++ b/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/VMDetailsPanelRightColumn.tsx
@@ -1,10 +1,12 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
 import { hasS390xArchitecture } from '@kubevirt-utils/resources/vm/utils/architecture';
-import { getVMIPod } from '@kubevirt-utils/resources/vmi';
 import { DescriptionList } from '@patternfly/react-core';
 import SSHTabAuthorizedSSHKey from '@virtualmachines/details/tabs/configuration/ssh/components/SSHTabAuthorizedSSHKey';
 
@@ -27,19 +29,18 @@ export type VMResourceListProps = {
 };
 
 const VMDetailsPanelRightColumn: FC<VMResourceListProps> = ({ instanceTypeVM, vm, vmi }) => {
-  const { pods } = useVMIAndPodsForVM(getName(vm), getNamespace(vm));
-  const launcherPod = getVMIPod(vmi, pods);
+  const { pod } = useVMIAndPodsForVM(getName(vm), getNamespace(vm));
   const vmHasS390xArchitecture = hasS390xArchitecture(vm);
 
   return (
     <DescriptionList className="pf-v6-c-description-list__group">
       <VMStatusDetailsItem vm={vm} vmi={vmi} />
-      <VMPodDetailsItem pods={pods} vmi={vmi} />
+      <VMPodDetailsItem pod={pod} />
       <VMBootOrderDetailsItem instanceTypeVM={instanceTypeVM} vm={vm} vmi={vmi} />
-      <VMIPAddressesDetailsItem launcherPod={launcherPod} vmi={vmi} />
+      <VMIPAddressesDetailsItem launcherPod={pod} vmi={vmi} />
       <VMHostnameDetailsItem vm={vm} vmi={vmi} />
       <VMTimezoneDetailsItem vmi={vmi} />
-      <VMNodeDetailsItem launcherPod={launcherPod} vm={vm} vmi={vmi} />
+      <VMNodeDetailsItem launcherPod={pod} vm={vm} vmi={vmi} />
       <VMWorkloadProfileDetailsItem vm={vm} />
       <VMUserCredentialsDetailsItem vm={vm} vmi={vmi} />
       <SSHTabAuthorizedSSHKey className="topology-vm-details-panel__item" vm={vm} />

--- a/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/VMDetailsPanelRightColumn.tsx
+++ b/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/VMDetailsPanelRightColumn.tsx
@@ -5,7 +5,7 @@ import {
   type V1VirtualMachineInstance,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
+import { useVMIAndPodForVM } from '@kubevirt-utils/resources/vm';
 import { hasS390xArchitecture } from '@kubevirt-utils/resources/vm/utils/architecture';
 import { DescriptionList } from '@patternfly/react-core';
 import SSHTabAuthorizedSSHKey from '@virtualmachines/details/tabs/configuration/ssh/components/SSHTabAuthorizedSSHKey';
@@ -29,7 +29,7 @@ export type VMResourceListProps = {
 };
 
 const VMDetailsPanelRightColumn: FC<VMResourceListProps> = ({ instanceTypeVM, vm, vmi }) => {
-  const { pod } = useVMIAndPodsForVM(getName(vm), getNamespace(vm));
+  const { pod } = useVMIAndPodForVM(getName(vm), getNamespace(vm));
   const vmHasS390xArchitecture = hasS390xArchitecture(vm);
 
   return (

--- a/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/components/VMPodDetailsItem.tsx
+++ b/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/components/VMPodDetailsItem.tsx
@@ -1,42 +1,38 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { modelToGroupVersionKind, PodModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1Pod } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type IoK8sApiCoreV1Pod } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
-import { getVMIPod } from '@kubevirt-utils/resources/vmi';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 
 import '../../../TopologyVMDetailsPanel.scss';
 
 type VMPodDetailsItemProps = {
-  pods?: IoK8sApiCoreV1Pod[];
-  vmi: V1VirtualMachineInstance;
+  pod?: IoK8sApiCoreV1Pod | null;
 };
 
-const VMPodDetailsItem: FC<VMPodDetailsItemProps> = ({ pods, vmi }) => {
+const VMPodDetailsItem: FC<VMPodDetailsItemProps> = ({ pod }) => {
   const { t } = useKubevirtTranslation();
 
-  const launcherPod = getVMIPod(vmi, pods);
-  const launcherPodName = getName(launcherPod);
+  const launcherPodName = getName(pod);
 
   return (
     <DescriptionItem
+      className="topology-vm-details-panel__item"
       descriptionData={
         launcherPodName ? (
           <ResourceLink
             groupVersionKind={modelToGroupVersionKind(PodModel)}
             name={launcherPodName}
-            namespace={getNamespace(launcherPod)}
+            namespace={getNamespace(pod)}
           />
         ) : (
           NO_DATA_DASH
         )
       }
-      className="topology-vm-details-panel__item"
       descriptionHeader={t('Pod')}
     />
   );

--- a/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineLogViewer/VirtualMachineLogViewer.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineLogViewer/VirtualMachineLogViewer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { V1Devices } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1Devices, type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { getChangedGuestSystemAccessLog } from '@kubevirt-utils/components/PendingChanges/utils/helpers';
 import { DISABLED_GUEST_SYSTEM_LOGS_ACCESS } from '@kubevirt-utils/hooks/useFeatures/constants';
@@ -8,20 +8,25 @@ import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getDevices, useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
-import { getVMIPod } from '@kubevirt-utils/resources/vmi';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { Bullseye, spinnerSize } from '@patternfly/react-core';
 import { isRunning } from '@virtualmachines/utils';
 
+import { GUEST_CONSOLE_LOG_CONTAINER_NAME } from './constants';
 import useVirtualMachineLogData from './hooks/useVirtualMachineLogData';
 import VirtualMachineBasicLogViewer from './VirtualMachineBasicLogViewer/VirtualMachineBasicLogViewer';
-import { GUEST_CONSOLE_LOG_CONTAINER_NAME } from './constants';
 
-const VirtualMachineLogViewer = ({ connect, vm }) => {
+type VirtualMachineLogViewerProps = {
+  connect?: boolean;
+  vm: V1VirtualMachine;
+};
+
+const VirtualMachineLogViewer = ({
+  connect,
+  vm,
+}: VirtualMachineLogViewerProps): React.JSX.Element => {
   const { t } = useKubevirtTranslation();
-  const { loaded, pods, vmi } = useVMIAndPodsForVM(getName(vm), getNamespace(vm), getCluster(vm));
-
-  const pod = getVMIPod(vmi, pods);
+  const { loaded, pod, vmi } = useVMIAndPodsForVM(getName(vm), getNamespace(vm), getCluster(vm));
   const { featureEnabled: isClusterDisabledGuestSystemLogs } = useFeatures(
     DISABLED_GUEST_SYSTEM_LOGS_ACCESS,
   );
@@ -38,7 +43,10 @@ const VirtualMachineLogViewer = ({ connect, vm }) => {
     ),
   );
 
-  const { data } = useVirtualMachineLogData({ connect: connect && isPodLogContainerExist, pod });
+  const { data }: { data: string[] } = useVirtualMachineLogData({
+    connect: connect && isPodLogContainerExist,
+    pod,
+  });
 
   if (!loaded) {
     return (

--- a/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineLogViewer/VirtualMachineLogViewer.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineLogViewer/VirtualMachineLogViewer.tsx
@@ -7,7 +7,7 @@ import { DISABLED_GUEST_SYSTEM_LOGS_ACCESS } from '@kubevirt-utils/hooks/useFeat
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { getDevices, useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
+import { getDevices, useVMIAndPodForVM } from '@kubevirt-utils/resources/vm';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { Bullseye, spinnerSize } from '@patternfly/react-core';
 import { isRunning } from '@virtualmachines/utils';
@@ -26,7 +26,7 @@ const VirtualMachineLogViewer = ({
   vm,
 }: VirtualMachineLogViewerProps): React.JSX.Element => {
   const { t } = useKubevirtTranslation();
-  const { loaded, pod, vmi } = useVMIAndPodsForVM(getName(vm), getNamespace(vm), getCluster(vm));
+  const { loaded, pod, vmi } = useVMIAndPodForVM(getName(vm), getNamespace(vm), getCluster(vm));
   const { featureEnabled: isClusterDisabledGuestSystemLogs } = useFeatures(
     DISABLED_GUEST_SYSTEM_LOGS_ACCESS,
   );

--- a/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineLogViewer/VirtualMachineLogViewerStandAlone/VirtualMachineLogViewerStandAlone.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineLogViewer/VirtualMachineLogViewerStandAlone/VirtualMachineLogViewerStandAlone.tsx
@@ -1,20 +1,20 @@
-import React from 'react';
+import React, { type JSX } from 'react';
 import { useLocation } from 'react-router';
 
 import { VirtualMachineModelRef } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
+import { useVMIAndPodForVM } from '@kubevirt-utils/resources/vm';
 
 import useVirtualMachineLogData from '../hooks/useVirtualMachineLogData';
 import VirtualMachineBasicLogViewer from '../VirtualMachineBasicLogViewer/VirtualMachineBasicLogViewer';
 
 import './virtual-machine-log-viewer-stand-alone.scss';
 
-const VirtualMachineLogViewerStandAlone = (): React.JSX.Element => {
+const VirtualMachineLogViewerStandAlone = (): JSX.Element => {
   const location = useLocation();
   const locationSplitter = location.pathname.split('/');
   const ns = locationSplitter[locationSplitter.indexOf('ns') + 1];
   const name = locationSplitter[locationSplitter.indexOf(VirtualMachineModelRef) + 1];
-  const { pod, vmi } = useVMIAndPodsForVM(name, ns);
+  const { pod, vmi } = useVMIAndPodForVM(name, ns);
 
   const { data } = useVirtualMachineLogData({ pod });
 

--- a/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineLogViewer/VirtualMachineLogViewerStandAlone/VirtualMachineLogViewerStandAlone.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/VirtualMachineLogViewer/VirtualMachineLogViewerStandAlone/VirtualMachineLogViewerStandAlone.tsx
@@ -3,20 +3,18 @@ import { useLocation } from 'react-router';
 
 import { VirtualMachineModelRef } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
-import { getVMIPod } from '@kubevirt-utils/resources/vmi';
 
 import useVirtualMachineLogData from '../hooks/useVirtualMachineLogData';
 import VirtualMachineBasicLogViewer from '../VirtualMachineBasicLogViewer/VirtualMachineBasicLogViewer';
 
 import './virtual-machine-log-viewer-stand-alone.scss';
 
-const VirtualMachineLogViewerStandAlone = () => {
+const VirtualMachineLogViewerStandAlone = (): React.JSX.Element => {
   const location = useLocation();
   const locationSplitter = location.pathname.split('/');
   const ns = locationSplitter[locationSplitter.indexOf('ns') + 1];
   const name = locationSplitter[locationSplitter.indexOf(VirtualMachineModelRef) + 1];
-  const { pods, vmi } = useVMIAndPodsForVM(name, ns);
-  const pod = getVMIPod(vmi, pods);
+  const { pod, vmi } = useVMIAndPodsForVM(name, ns);
 
   const { data } = useVirtualMachineLogData({ pod });
 

--- a/src/views/virtualmachines/details/tabs/overview/VirtualMachinesOverviewTab.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/VirtualMachinesOverviewTab.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef } from 'react';
+import React, { type FC, useRef } from 'react';
 
 import AlertsCard from '@kubevirt-utils/components/AlertsCard/AlertsCard';
 import useContainerWidth from '@kubevirt-utils/hooks/useContainerWidth';
@@ -7,7 +7,7 @@ import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm/hooks/useVMIAnd
 import { useGuestOS } from '@kubevirt-utils/resources/vmi';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { Grid, GridItem, PageSection } from '@patternfly/react-core';
-import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
+import { type NavPageComponentProps } from '@virtualmachines/details/utils/types';
 
 import VirtualMachinesOverviewTabActiveUser from './components/VirtualMachinesOverviewTabActiveUser/VirtualMachinesOverviewTabActiveUser';
 import VirtualMachinesOverviewTabDetails from './components/VirtualMachinesOverviewTabDetails/VirtualMachinesOverviewTabDetails';
@@ -26,7 +26,7 @@ const VirtualMachinesOverviewTab: FC<NavPageComponentProps> = ({
   obj: vm,
 }) => {
   const vmAlerts = useVMAlerts(vm);
-  const { error, loaded, pods, vmi } = useVMIAndPodsForVM(
+  const { error, loaded, pod, vmi } = useVMIAndPodsForVM(
     getName(vm),
     getNamespace(vm),
     getCluster(vm),
@@ -65,7 +65,7 @@ const VirtualMachinesOverviewTab: FC<NavPageComponentProps> = ({
                 <AlertsCard sortedAlerts={vmAlerts} />
               </GridItem>
               <GridItem>
-                <VirtualMachinesOverviewTabGeneral pods={pods} vm={vm} vmi={vmi} />
+                <VirtualMachinesOverviewTabGeneral pod={pod} vm={vm} vmi={vmi} />
               </GridItem>
               <GridItem>
                 <VirtualMachinesOverviewTabSnapshots vm={vm} />

--- a/src/views/virtualmachines/details/tabs/overview/VirtualMachinesOverviewTab.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/VirtualMachinesOverviewTab.tsx
@@ -3,7 +3,7 @@ import React, { type FC, useRef } from 'react';
 import AlertsCard from '@kubevirt-utils/components/AlertsCard/AlertsCard';
 import useContainerWidth from '@kubevirt-utils/hooks/useContainerWidth';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm/hooks/useVMIAndPodsForVM';
+import { useVMIAndPodForVM } from '@kubevirt-utils/resources/vm/hooks/useVMIAndPodForVM';
 import { useGuestOS } from '@kubevirt-utils/resources/vmi';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { Grid, GridItem, PageSection } from '@patternfly/react-core';
@@ -26,7 +26,7 @@ const VirtualMachinesOverviewTab: FC<NavPageComponentProps> = ({
   obj: vm,
 }) => {
   const vmAlerts = useVMAlerts(vm);
-  const { error, loaded, pod, vmi } = useVMIAndPodsForVM(
+  const { error, loaded, pod, vmi } = useVMIAndPodForVM(
     getName(vm),
     getNamespace(vm),
     getCluster(vm),

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabGeneral/VirtualMachinesOverviewTabGeneral.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabGeneral/VirtualMachinesOverviewTabGeneral.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import {
   modelToGroupVersionKind,
@@ -7,39 +7,42 @@ import {
   VirtualMachineInstanceModelGroupVersionKind,
 } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type IoK8sApiCoreV1Pod } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import {
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DescriptionItemNamespace from '@kubevirt-utils/components/DescriptionItem/components/DescriptionItemNamespace';
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import OwnerDetailsItem from '@kubevirt-utils/components/OwnerDetailsItem/OwnerDetailsItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
-import { getVMIPod } from '@kubevirt-utils/resources/vmi';
 import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
 import { ManagedClusterModel } from '@multicluster/constants';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
-import { K8sResourceCommon, K8sVerb } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sVerb } from '@openshift-console/dynamic-plugin-sdk';
 import { Card, CardBody, CardTitle, DescriptionList, Divider } from '@patternfly/react-core';
 import { useFleetAccessReview } from '@stolostron/multicluster-sdk';
 
 import './virtual-machines-overview-tab-general.scss';
 
 type VirtualMachinesOverviewTabGeneralProps = {
-  pods: K8sResourceCommon[];
+  pod: IoK8sApiCoreV1Pod | null | undefined;
   vm: V1VirtualMachine;
   vmi: V1VirtualMachineInstance;
 };
 
 const VirtualMachinesOverviewTabGeneral: FC<VirtualMachinesOverviewTabGeneralProps> = ({
-  pods,
+  pod,
   vm,
   vmi,
 }) => {
   const { t } = useKubevirtTranslation();
 
   const clusterParam = useClusterParam();
-  const cluster = getCluster(vm) || clusterParam;
+  const cluster = getCluster(vm) ?? clusterParam;
 
   const [canGetNode] = useFleetAccessReview({
     cluster,
@@ -47,8 +50,6 @@ const VirtualMachinesOverviewTabGeneral: FC<VirtualMachinesOverviewTabGeneralPro
     resource: NodeModel.plural,
     verb: 'get' as K8sVerb,
   });
-  const pod = getVMIPod(vmi, pods);
-
   return (
     <div className="VirtualMachinesOverviewTabGeneral--main">
       <Card>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabService/VirtualMachinesOverviewTabService.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabService/VirtualMachinesOverviewTabService.tsx
@@ -1,14 +1,15 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { modelToGroupVersionKind, ServiceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ServicesList from '@kubevirt-utils/components/ServicesList/ServicesList';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
 import { getServicesForVmi } from '@kubevirt-utils/resources/vmi';
 import { getVMIPod } from '@kubevirt-utils/resources/vmi/utils/pod';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import { Card, CardBody, CardTitle, Divider } from '@patternfly/react-core';
@@ -26,6 +27,7 @@ const VirtualMachinesOverviewTabService: FC<VirtualMachinesOverviewTabServicePro
   });
 
   const {
+    error: vmiAndPodsLoadError,
     loaded: vmiAndPodsLoaded,
     pods,
     vmi,
@@ -33,6 +35,7 @@ const VirtualMachinesOverviewTabService: FC<VirtualMachinesOverviewTabServicePro
 
   const pod = getVMIPod(vmi, pods);
   const data = getServicesForVmi(services, pod, vm, vmi);
+  const vmiLoaded = vmiAndPodsLoaded || !isEmpty(vmiAndPodsLoadError);
 
   return (
     <Card>
@@ -41,7 +44,7 @@ const VirtualMachinesOverviewTabService: FC<VirtualMachinesOverviewTabServicePro
       </CardTitle>
       <Divider />
       <CardBody isFilled>
-        <ServicesList data={data} loaded={loaded && vmiAndPodsLoaded} loadError={loadError} />
+        <ServicesList data={data} loaded={loaded && vmiLoaded} loadError={loadError} />
       </CardBody>
     </Card>
   );

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabService/VirtualMachinesOverviewTabService.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabService/VirtualMachinesOverviewTabService.tsx
@@ -6,7 +6,7 @@ import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ServicesList from '@kubevirt-utils/components/ServicesList/ServicesList';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
-import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
+import { useVMIAndPodForVM } from '@kubevirt-utils/resources/vm';
 import { getServicesForVmi } from '@kubevirt-utils/resources/vmi';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
@@ -30,10 +30,10 @@ const VirtualMachinesOverviewTabService: FC<VirtualMachinesOverviewTabServicePro
     loaded: vmiAndPodsLoaded,
     pod,
     vmi,
-  } = useVMIAndPodsForVM(getName(vm), getNamespace(vm), getCluster(vm));
+  } = useVMIAndPodForVM(getName(vm), getNamespace(vm), getCluster(vm));
 
   const data = getServicesForVmi(services, pod, vm, vmi);
-  const vmiLoaded = vmiAndPodsLoaded || !isEmpty(vmiAndPodsLoadError);
+  const vmiAndPodsResolved = vmiAndPodsLoaded || !isEmpty(vmiAndPodsLoadError);
 
   return (
     <Card>
@@ -42,7 +42,7 @@ const VirtualMachinesOverviewTabService: FC<VirtualMachinesOverviewTabServicePro
       </CardTitle>
       <Divider />
       <CardBody isFilled>
-        <ServicesList data={data} loaded={loaded && vmiLoaded} loadError={loadError} />
+        <ServicesList data={data} loaded={loaded && vmiAndPodsResolved} loadError={loadError} />
       </CardBody>
     </Card>
   );

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabService/VirtualMachinesOverviewTabService.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabService/VirtualMachinesOverviewTabService.tsx
@@ -8,7 +8,6 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { useVMIAndPodsForVM } from '@kubevirt-utils/resources/vm';
 import { getServicesForVmi } from '@kubevirt-utils/resources/vmi';
-import { getVMIPod } from '@kubevirt-utils/resources/vmi/utils/pod';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
@@ -29,11 +28,10 @@ const VirtualMachinesOverviewTabService: FC<VirtualMachinesOverviewTabServicePro
   const {
     error: vmiAndPodsLoadError,
     loaded: vmiAndPodsLoaded,
-    pods,
+    pod,
     vmi,
   } = useVMIAndPodsForVM(getName(vm), getNamespace(vm), getCluster(vm));
 
-  const pod = getVMIPod(vmi, pods);
   const data = getServicesForVmi(services, pod, vm, vmi);
   const vmiLoaded = vmiAndPodsLoaded || !isEmpty(vmiAndPodsLoadError);
 


### PR DESCRIPTION
## 📝 Description

Fixes the Services card on the VM Overview tab staying on the loading skeleton for stopped VMs.

For stopped VMs, the VMI watch can finish with an error while pods are still loading. The card waited for both hooks to report `loaded`, so it never left the loading state. The fix treats a VMI load error as a resolved VMI load state so the Services list can render (showing services or "No services found").

Also refactors `useVMIAndPodsForVM` to return the VM launcher `pod` instead of the full namespace pod list. Pod resolution via `getVMIPod` is now centralized in the hook, and consumers (Overview, Services, SSH, log viewer, topology panel) no longer duplicate that logic.

## 🧪 Testing notes

Temporarily skipped gating test **"Create a template from a virtual machine"** (`playwright/tests/gating/scenario-resource-creation.spec.ts`) — native VM template CRDs (`template.kubevirt.io`) are not available on the current hot cluster (CNV 4.21). We will re-enable this test after the hot cluster is upgraded to **CNV 4.22+**.

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-96372

## 🎥 Demo

Before: Services card shows loading skeleton indefinitely on a stopped VM.

https://github.com/user-attachments/assets/e482b6e4-1f9f-45ec-995b-6d72f06424f1


After: Services card loads and shows the services list or empty state.

<img width="1913" height="1087" alt="Screenshot 2026-09-03 at 17 11 21" src="https://github.com/user-attachments/assets/0f766678-0525-45c7-be6c-f7c73bc40d59" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved virtual machine detail loading by using the directly associated pod.
  - Ensured service information can finish loading even when VMI or pod retrieval encounters an error.
  - Improved handling of missing virtual machine, pod, and cluster data across overview, topology, SSH access, and log views.
- **Refactor**
  - Standardized virtual machine views and utilities on singular pod data, improving consistency and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->