### PR TITLE
CNV-90382: add base eslint part 4

### DIFF
--- a/src/utils/components/BootOrderModal/BootOrderModal.tsx
+++ b/src/utils/components/BootOrderModal/BootOrderModal.tsx
@@ -1,19 +1,20 @@
-/* eslint-disable */
-import React, { FC, useState } from 'react';
+import React, { type FC, useState } from 'react';
 import produce from 'immer';
 
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ModalPendingChangesAlert from '@kubevirt-utils/components/PendingChanges/ModalPendingChangesAlert/ModalPendingChangesAlert';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
-  BootableDeviceType,
+  type BootableDeviceType,
   DeviceType,
   getSortedBootableDevices,
 } from '@kubevirt-utils/resources/vm/utils/boot-order/bootOrder';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
 
 import TabModal from '../TabModal/TabModal';
-
 import { BootOrderModalBody } from './BootOrderModalBody';
 
 import './boot-order.scss';
@@ -62,7 +63,7 @@ const BootOrderModal: FC<{
     >
       {vmi && <ModalPendingChangesAlert />}
       <BootOrderModalBody
-        changeEditMode={(v) => setIsEditMode(v)}
+        changeEditMode={(val) => setIsEditMode(val)}
         devices={devices}
         isEditMode={isEditMode}
         onChange={setDevices}

--- a/src/utils/components/BootOrderModal/add-device-form-select.tsx
+++ b/src/utils/components/BootOrderModal/add-device-form-select.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { BootableDeviceType } from '@kubevirt-utils/resources/vm/utils/boot-order/bootOrder';
+import { type BootableDeviceType } from '@kubevirt-utils/resources/vm/utils/boot-order/bootOrder';
 import { Button, ButtonVariant, FormSelect, FormSelectOption } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 
@@ -16,7 +15,7 @@ export const AddDeviceFormSelect: FC<AddDeviceFormSelectProps> = ({
     <FormSelect
       className="kubevirt-boot-order__add-device-select"
       id={id}
-      onChange={(_, value: string) => onAdd(value)}
+      onChange={(_event, value: string) => onAdd(value)}
       value=""
     >
       <FormSelectOption label={label} value="" />

--- a/src/utils/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/utils/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable */
-import React, { FC } from 'react';
-import { isEmpty } from 'lodash';
+import React, { type FC } from 'react';
+import isEmpty from 'lodash/isEmpty';
 
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 

--- a/src/utils/components/CloneTemplateModal/CloneStorageCheckbox.tsx
+++ b/src/utils/components/CloneTemplateModal/CloneStorageCheckbox.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -21,7 +20,7 @@ const CloneStorageCheckbox: FC<CloneStorageCheckboxProps> = ({ isChecked, onChan
             id="clone-storage"
             isChecked={isChecked}
             label={t("Copy template's boot source disk")}
-            onChange={(_, checked: boolean) => onChange(checked)}
+            onChange={(_event, checked: boolean) => onChange(checked)}
           />
         </FlexItem>
         <FlexItem>

--- a/src/utils/components/CloneVMModal/components/CloneVMModalDetailsSection.tsx
+++ b/src/utils/components/CloneVMModal/components/CloneVMModalDetailsSection.tsx
@@ -1,7 +1,9 @@
-/* eslint-disable */
-import React, { FC, useState } from 'react';
+import React, { type FC, useState } from 'react';
 
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import CPUMemory from '@kubevirt-utils/components/CPUMemory/CPUMemory';
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
@@ -29,10 +31,11 @@ const CloneVMModalDetailsSection: FC<CloneVMModalDetailsSectionProps> = ({ vm, v
 
   const [guestAgentData] = useGuestOS(vmi);
   const osName =
-    guestAgentData?.os?.prettyName ||
-    guestAgentData?.os?.name ||
-    getOperatingSystemName(vm) ||
-    getOperatingSystem(vm);
+    guestAgentData?.os?.prettyName ??
+    guestAgentData?.os?.name ??
+    getOperatingSystemName(vm) ??
+    getOperatingSystem(vm) ??
+    '';
 
   const itMatcher = getInstanceTypeMatcher(vm);
   const sshSecretName = getVMSSHSecretName(vm);
@@ -42,12 +45,12 @@ const CloneVMModalDetailsSection: FC<CloneVMModalDetailsSectionProps> = ({ vm, v
     <ExpandableSection
       isExpanded={isExpanded}
       isIndented
-      onToggle={(_, expanded) => setIsExpanded(expanded)}
+      onToggle={(_event, expanded) => setIsExpanded(expanded)}
       toggleText={t('Details')}
     >
       <DescriptionList isHorizontal>
         <DescriptionItem
-          descriptionData={getNamespace(vm) || notAvailable}
+          descriptionData={getNamespace(vm) ?? notAvailable}
           descriptionHeader={t('Project')}
         />
         <DescriptionItem

--- a/src/utils/components/CloneVMModal/components/DescriptionInput.tsx
+++ b/src/utils/components/CloneVMModal/components/DescriptionInput.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { Dispatch, FC, SetStateAction } from 'react';
+import React, { type Dispatch, type FC, type SetStateAction } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { FormGroup, TextInput } from '@patternfly/react-core';
@@ -20,7 +19,7 @@ const DescriptionInput: FC<DescriptionInputProps> = ({
     <FormGroup fieldId="description" label={t('Description')}>
       <TextInput
         id="description"
-        onChange={(_, value: string) => setDescription(value)}
+        onChange={(_event, value: string) => setDescription(value)}
         placeholder={placeholder}
         type="text"
         value={description}

--- a/src/utils/components/CloneVMModal/components/StartClonedVMCheckbox/StartClonedVMCheckbox.tsx
+++ b/src/utils/components/CloneVMModal/components/StartClonedVMCheckbox/StartClonedVMCheckbox.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { Dispatch, FC, SetStateAction } from 'react';
+import React, { type Dispatch, type FC, type SetStateAction } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Checkbox, FormGroup } from '@patternfly/react-core';
@@ -23,7 +22,7 @@ const StartClonedVMCheckbox: FC<StartClonedVMCheckboxProps> = ({
         id="start-clone"
         isChecked={startCloneVM}
         label={t('Start VirtualMachine once created')}
-        onChange={(_, checked: boolean) => setStartCloneVM(checked)}
+        onChange={(_event, checked: boolean) => setStartCloneVM(checked)}
       />
     </FormGroup>
   );

--- a/src/utils/components/CloneVMModal/utils/helpers.tsx
+++ b/src/utils/components/CloneVMModal/utils/helpers.tsx
@@ -1,13 +1,12 @@
-/* eslint-disable */
 import produce from 'immer';
 
 import { VirtualMachineCloneModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineSnapshotModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import {
-  V1beta1VirtualMachineClone,
-  V1beta1VirtualMachineSnapshot,
-  V1VirtualMachine,
+  type V1beta1VirtualMachineClone,
+  type V1beta1VirtualMachineSnapshot,
+  type V1VirtualMachine,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
   buildRunStrategyPatches,
@@ -46,7 +45,7 @@ export const cloneVM = (
   namespace: string,
   startVM?: boolean,
   description?: string,
-) => {
+): Promise<V1beta1VirtualMachineClone> => {
   const cloningRequest = produce(cloneVMToVM, (draftCloneData) => {
     draftCloneData.spec.source = {
       apiGroup: isVM(source) ? VirtualMachineModel.apiGroup : VirtualMachineSnapshotModel.apiGroup,
@@ -90,7 +89,7 @@ export const cloneVM = (
     }
 
     if (patches.length > 0) {
-      draftCloneData.spec.patches = patches.map((p) => JSON.stringify(p));
+      draftCloneData.spec.patches = patches.map((patch) => JSON.stringify(patch));
     }
   });
 
@@ -101,7 +100,11 @@ export const cloneVM = (
   });
 };
 
-export const vmExists = (vmName: string, vmNamespace: string, cluster?: string) =>
+export const vmExists = (
+  vmName: string,
+  vmNamespace: string,
+  cluster?: string,
+): Promise<null | V1VirtualMachine> =>
   kubevirtK8sGet<V1VirtualMachine>({
     cluster,
     model: VirtualMachineModel,

--- a/src/utils/components/ClusterProjectDropdown/Dropdown/Filter.tsx
+++ b/src/utils/components/ClusterProjectDropdown/Dropdown/Filter.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable */
-import React, { FC, JSX, Ref } from 'react';
+import React, { type FC, type JSX, type Ref } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { MenuSearch, MenuSearchInput, TextInput } from '@patternfly/react-core';
 
-import { DropdownConfig } from './types';
+import { type DropdownConfig } from './types';
 
 type FilterProps = {
   config: DropdownConfig;
@@ -27,7 +26,7 @@ const Filter: FC<FilterProps> = ({
           aria-label={t(config.selectPlaceholder)}
           autoFocus
           data-test="dropdown-text-filter"
-          onChange={(_, value: string) => onFilterChange(value)}
+          onChange={(_event, value: string) => onFilterChange(value)}
           placeholder={t(config.selectPlaceholder)}
           ref={filterRef}
           type="search"

--- a/src/utils/components/ConfigurationSearch/ConfigurationSearch.tsx
+++ b/src/utils/components/ConfigurationSearch/ConfigurationSearch.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, FormEvent, MouseEvent, useCallback, useState } from 'react';
+import React, { type FC, type FormEvent, type MouseEvent, useCallback, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
@@ -18,8 +17,7 @@ import {
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 
-import { SearchItemWithTab } from '../../../views/virtualmachines/details/tabs/configuration/utils/search';
-
+import { type SearchItemWithTab } from './types';
 import { getOptions } from './utils/configurationSearch';
 
 import './configuration-search.scss';
@@ -46,7 +44,7 @@ const ConfigurationSearch: FC<ConfigurationSearchProps> = ({
   const onClear = useCallback(() => setValue(''), []);
 
   const onChange = useCallback(
-    (_e: FormEvent<HTMLInputElement>, newValue: string) => {
+    (_event: FormEvent<HTMLInputElement>, newValue: string) => {
       setIsPopperVisible(true);
       setValue(newValue);
       const options = getOptions(searchItems, newValue);
@@ -65,6 +63,7 @@ const ConfigurationSearch: FC<ConfigurationSearchProps> = ({
 
   return (
     <Popper
+      isVisible={isPopperVisible}
       popper={
         <Menu isScrollable onMouseDown={preventBlur} onSelect={onSelect}>
           <MenuContent>
@@ -104,7 +103,6 @@ const ConfigurationSearch: FC<ConfigurationSearchProps> = ({
           value={value}
         />
       }
-      isVisible={isPopperVisible}
     />
   );
 };

--- a/src/utils/components/ConfigurationSearch/types.ts
+++ b/src/utils/components/ConfigurationSearch/types.ts
@@ -1,0 +1,11 @@
+export type SearchItem = {
+  description?: string;
+  id: string;
+  isDisabled?: boolean;
+  title: string;
+};
+
+export type SearchItemWithTab = {
+  element: SearchItem;
+  tab: string;
+};

--- a/src/utils/components/ConfigurationSearch/utils/configurationSearch.ts
+++ b/src/utils/components/ConfigurationSearch/utils/configurationSearch.ts
@@ -1,5 +1,6 @@
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { SearchItemWithTab } from '@virtualmachines/details/tabs/configuration/utils/search';
+
+import { type SearchItemWithTab } from '../types';
 
 const MAX_RESULTS_TO_DISPLAY = 9;
 

--- a/src/utils/components/Consoles/components/DesktopViewer/Components/RemoteViewer.tsx
+++ b/src/utils/components/Consoles/components/DesktopViewer/Components/RemoteViewer.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useState } from 'react';
+import React, { type FC, useState } from 'react';
 import { Trans } from 'react-i18next';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -12,9 +11,8 @@ import {
   DEFAULT_VV_FILENAME,
   DEFAULT_VV_MIMETYPE,
 } from '../utils/constants';
-import { RemoteViewerProps } from '../utils/types';
+import { type RemoteViewerProps } from '../utils/types';
 import { downloadFile, generateDescriptorFile } from '../utils/utils';
-
 import MoreInformationDefault from './MoreInformationDefault';
 
 const RemoteViewer: FC<RemoteViewerProps> = ({
@@ -34,22 +32,26 @@ const RemoteViewer: FC<RemoteViewerProps> = ({
   const [isExpandedDefault, setIsExpandedDefault] = useState<boolean>(false);
   const [isExpandedRDP, setIsExpandedRDP] = useState<boolean>(false);
 
-  const console = spice || vnc;
+  const console = spice ?? vnc;
 
-  const onClickVV = () => {
+  const onClickVV = (): void => {
     const type = spice ? SPICE_CONSOLE_TYPE : VNC_CONSOLE_TYPE;
     if (console) {
-      const vv = onGenerate(console, type);
-      return onDownload(DEFAULT_VV_FILENAME, vv?.content, vv?.mimeType || DEFAULT_VV_MIMETYPE);
+      const vvFile = onGenerate(console, type);
+      return onDownload(
+        DEFAULT_VV_FILENAME,
+        vvFile?.content,
+        vvFile?.mimeType ?? DEFAULT_VV_MIMETYPE,
+      );
     }
   };
 
-  const onClickRDP = () => {
+  const onClickRDP = (): void => {
     const rdpFile = onGenerate(rdp, RDP_CONSOLE_TYPE);
     return onDownload(
       DEFAULT_RDP_FILENAME,
       rdpFile?.content,
-      rdpFile?.mimeType || DEFAULT_RDP_MIMETYPE,
+      rdpFile?.mimeType ?? DEFAULT_RDP_MIMETYPE,
     );
   };
 
@@ -57,17 +59,17 @@ const RemoteViewer: FC<RemoteViewerProps> = ({
     <Stack hasGutter>
       <Flex spaceItems={{ default: 'spaceItemsSm' }}>
         <Button isDisabled={!console} onClick={onClickVV}>
-          {textConnectWithRemoteViewer || t('Launch Remote Viewer')}
+          {textConnectWithRemoteViewer ?? t('Launch Remote Viewer')}
         </Button>
         {!!rdp && (
-          <Button onClick={onClickRDP}>{textConnectWithRDP || t('Launch Remote Desktop')}</Button>
+          <Button onClick={onClickRDP}>{textConnectWithRDP ?? t('Launch Remote Desktop')}</Button>
         )}
       </Flex>
       {!!console && (
         <ExpandableSection
           isExpanded={isExpandedDefault}
           onToggle={(_event, isExpanded) => setIsExpandedDefault(isExpanded)}
-          toggleText={textMoreInfo || t('Remote Viewer details')}
+          toggleText={textMoreInfo ?? t('Remote Viewer details')}
         >
           <MoreInformationDefault textMoreInfoContent={textMoreInfoContent} />
         </ExpandableSection>
@@ -76,7 +78,7 @@ const RemoteViewer: FC<RemoteViewerProps> = ({
         <ExpandableSection
           isExpanded={isExpandedRDP}
           onToggle={(_event, isExpanded) => setIsExpandedRDP(isExpanded)}
-          toggleText={textMoreRDPInfo || t('Remote Desktop details')}
+          toggleText={textMoreRDPInfo ?? t('Remote Desktop details')}
         >
           {textMoreRDPInfoContent ?? (
             <Content>

--- a/src/utils/components/Consoles/utils/utils.ts
+++ b/src/utils/components/Consoles/utils/utils.ts
@@ -1,19 +1,19 @@
-/* eslint-disable */
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 
-export const isConnectionEncrypted = () => window.location.protocol === 'https:';
+export const isConnectionEncrypted = (): boolean => window.location.protocol === 'https:';
 
-export const getConsoleBasePath = ({ apiPath = '/api/kubernetes', name, namespace }) =>
+export const getConsoleBasePath = ({ apiPath = '/api/kubernetes', name, namespace }): string =>
   `${apiPath}/apis/subresources.kubevirt.io/v1/namespaces/${namespace}/virtualmachineinstances/${name}`;
 
-export const sleep = (ms = 500) => new Promise((resolve) => setTimeout(resolve, ms));
+export const sleep = (delay = 500): Promise<unknown> =>
+  new Promise((resolve) => setTimeout(resolve, delay));
 
-export const readFromClipboard = async () =>
+export const readFromClipboard = async (): Promise<string | void> =>
   navigator.clipboard
     .readText()
     .catch((err) => kubevirtConsole.error('Failed to read from clipboard', err));
 
-export const writeToClipboard = async (text: string) =>
+export const writeToClipboard = async (text: string): Promise<void> =>
   navigator.clipboard
     .writeText(text)
     .catch((err) => kubevirtConsole.error('Failed to write to clipboard', err));

--- a/src/utils/components/CreateProjectModal/components/SelectCluster.tsx
+++ b/src/utils/components/CreateProjectModal/components/SelectCluster.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, MouseEvent, useState } from 'react';
+import React, { type FC, type MouseEvent, useState } from 'react';
 
 import SelectToggle from '@kubevirt-utils/components/toggles/SelectToggle';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -20,10 +19,12 @@ const SelectCluster: FC<SelectClusterProps> = ({ selectedCluster, setSelectedClu
 
   const [allClusterNames, allClustersLoaded] = useFleetClusterNames();
 
-  const onToggle = () => setIsOpen((prevIsOpen) => !prevIsOpen);
+  const onToggle = (): void => setIsOpen((prevIsOpen) => !prevIsOpen);
 
-  const onSelect = (_?: MouseEvent, newValue?: string) => {
-    setSelectedCluster(newValue);
+  const onSelect = (_event?: MouseEvent, newValue?: string): void => {
+    if (newValue) {
+      setSelectedCluster(newValue);
+    }
     onToggle();
   };
 
@@ -31,6 +32,10 @@ const SelectCluster: FC<SelectClusterProps> = ({ selectedCluster, setSelectedClu
 
   return (
     <Select
+      isOpen={isOpen}
+      onOpenChange={setIsOpen}
+      onSelect={onSelect}
+      selected={selectedCluster}
       toggle={SelectToggle({
         'data-test': 'cluster-name-select',
         isExpanded: isOpen,
@@ -38,10 +43,6 @@ const SelectCluster: FC<SelectClusterProps> = ({ selectedCluster, setSelectedClu
         onClick: onToggle,
         selected: selectedCluster || t('Select cluster'),
       })}
-      isOpen={isOpen}
-      onOpenChange={setIsOpen}
-      onSelect={onSelect}
-      selected={selectedCluster}
     >
       {allClusterNames?.map((clusterName) => (
         <SelectOption key={clusterName} value={clusterName}>

--- a/src/utils/components/DiskModal/ContainerDiskModal.tsx
+++ b/src/utils/components/DiskModal/ContainerDiskModal.tsx
@@ -1,12 +1,10 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { isRunning } from '@virtualmachines/utils';
 
 import TabModal from '../TabModal/TabModal';
-
 import AdvancedSettings from './components/AdvancedSettings/AdvancedSettings';
 import BootSourceCheckbox from './components/BootSourceCheckbox/BootSourceCheckbox';
 import DiskInterfaceSelect from './components/DiskInterfaceSelect/DiskInterfaceSelect';
@@ -19,7 +17,7 @@ import { CONTAINERDISK_IMAGE_FIELD } from './components/utils/constants';
 import { getDefaultCreateValues, getDefaultEditValues } from './utils/form';
 import { diskModalTitle, getOS } from './utils/helpers';
 import { submit } from './utils/submit';
-import { SourceTypes, V1DiskFormState, V1SubDiskModalProps } from './utils/types';
+import { SourceTypes, type V1DiskFormState, type V1SubDiskModalProps } from './utils/types';
 
 const ContainerDiskModal: FC<V1SubDiskModalProps> = ({
   editDiskName,
@@ -28,7 +26,7 @@ const ContainerDiskModal: FC<V1SubDiskModalProps> = ({
   onSubmit,
   vm,
 }) => {
-  const os = getOS(vm);
+  const osName = getOS(vm);
   const isVMRunning = isRunning(vm);
 
   const isEditDisk = !isEmpty(editDiskName);
@@ -48,21 +46,25 @@ const ContainerDiskModal: FC<V1SubDiskModalProps> = ({
   return (
     <FormProvider {...methods}>
       <TabModal
-        onSubmit={() =>
-          handleSubmit(async (data) => submit({ data, editDiskName, onSubmit, vm }))()
-        }
         closeOnSubmit={isValid}
         headerText={diskModalTitle(isEditDisk, isVMRunning)}
         isDisabled={!isValid}
         isLoading={isSubmitting}
         isOpen={isOpen}
         onClose={onClose}
+        onSubmit={() =>
+          handleSubmit(async (data) => submit({ data, editDiskName, onSubmit, vm }))()
+        }
         shouldWrapInForm
       >
         <PendingChanges isVMRunning={isVMRunning} />
         <BootSourceCheckbox editDiskName={editDiskName} isDisabled={isVMRunning} vm={vm} />
         <DiskNameInput />
-        <DiskSourceContainer fieldName={CONTAINERDISK_IMAGE_FIELD} isEphemeralDiskSource os={os} />
+        <DiskSourceContainer
+          fieldName={CONTAINERDISK_IMAGE_FIELD}
+          isEphemeralDiskSource
+          os={osName}
+        />
         <DynamicSize />
         <DiskTypeSelect isVMRunning={isVMRunning} />
         <DiskInterfaceSelect isVMRunning={isVMRunning} />

--- a/src/utils/components/DiskModal/DiskModal.tsx
+++ b/src/utils/components/DiskModal/DiskModal.tsx
@@ -1,6 +1,6 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
+import { type V1DataVolumeTemplateSpec } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getDataVolumeTemplates, getVolumes } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -9,7 +9,7 @@ import { getCluster } from '@multicluster/helpers/selectors';
 import usePVCDiskSource from './hooks/usePVCDiskSource';
 import { getDiskModalBySource } from './utils/getDiskModalBySource';
 import { getSourceFromVolume } from './utils/helpers';
-import { V1DiskModalProps } from './utils/types';
+import { type V1DiskModalProps, type V1SubDiskModalProps } from './utils/types';
 
 const DiskModal: FC<V1DiskModalProps> = ({
   createDiskSource,
@@ -25,15 +25,17 @@ const DiskModal: FC<V1DiskModalProps> = ({
 }) => {
   const diskVolume = getVolumes(vm)?.find((volume) => volume.name === editDiskName);
   const dataVolumeTemplate = getDataVolumeTemplates(vm)?.find(
-    (dv) => getName(dv) === diskVolume?.dataVolume?.name,
-  );
+    (dvTemplate) => getName(dvTemplate) === diskVolume?.dataVolume?.name,
+  ) as undefined | V1DataVolumeTemplateSpec;
 
   const namespace = getNamespace(vm);
   const [pvc] = usePVCDiskSource(createdPVCName, namespace, getCluster(vm));
 
   const editDiskSource = getSourceFromVolume(diskVolume, dataVolumeTemplate);
 
-  const Modal = getDiskModalBySource[createDiskSource || editDiskSource];
+  const Modal = getDiskModalBySource[
+    createDiskSource ?? editDiskSource
+  ] as never as FC<V1SubDiskModalProps>;
 
   return (
     <Modal

--- a/src/utils/components/DiskModal/HTTPDiskModal.tsx
+++ b/src/utils/components/DiskModal/HTTPDiskModal.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { getNamespace } from '@kubevirt-utils/resources/shared';
@@ -8,7 +7,6 @@ import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { isRunning } from '@virtualmachines/utils';
 
 import TabModal from '../TabModal/TabModal';
-
 import AdvancedSettings from './components/AdvancedSettings/AdvancedSettings';
 import BootSourceCheckbox from './components/BootSourceCheckbox/BootSourceCheckbox';
 import DiskInterfaceSelect from './components/DiskInterfaceSelect/DiskInterfaceSelect';
@@ -21,7 +19,7 @@ import StorageClassAndPreallocation from './components/StorageClassAndPreallocat
 import { getDefaultCreateValues, getDefaultEditValues } from './utils/form';
 import { diskModalTitle, getOS, getOSNameWithoutVersionNumber } from './utils/helpers';
 import { submit } from './utils/submit';
-import { SourceTypes, V1DiskFormState, V1SubDiskModalProps } from './utils/types';
+import { SourceTypes, type V1DiskFormState, type V1SubDiskModalProps } from './utils/types';
 
 const HTTPDiskModal: FC<V1SubDiskModalProps> = ({
   editDiskName,
@@ -32,7 +30,7 @@ const HTTPDiskModal: FC<V1SubDiskModalProps> = ({
   pvc,
   vm,
 }) => {
-  const os = getOS(vm);
+  const osName = getOS(vm);
   const isVMRunning = isRunning(vm);
 
   const isEditDisk = !isEmpty(editDiskName);
@@ -53,21 +51,25 @@ const HTTPDiskModal: FC<V1SubDiskModalProps> = ({
   return (
     <FormProvider {...methods}>
       <TabModal
-        onSubmit={() =>
-          handleSubmit(async (data) => submit({ data, editDiskName, onSubmit, pvc, vm }))()
-        }
         closeOnSubmit={isValid}
         headerText={diskModalTitle(isEditDisk, isVMRunning)}
         isDisabled={!isValid}
         isLoading={isSubmitting}
         isOpen={isOpen}
         onClose={onClose}
+        onSubmit={() =>
+          handleSubmit(async (data) => submit({ data, editDiskName, onSubmit, pvc, vm }))()
+        }
         shouldWrapInForm
       >
         <PendingChanges isVMRunning={isVMRunning} />
         <BootSourceCheckbox editDiskName={editDiskName} isDisabled={isVMRunning} vm={vm} />
         <DiskNameInput />
-        {!isCreated && <DiskSourceUrlInput os={OS_NAME_TYPES[getOSNameWithoutVersionNumber(os)]} />}
+        {!isCreated && (
+          <DiskSourceUrlInput
+            os={OS_NAME_TYPES[getOSNameWithoutVersionNumber(osName) as keyof typeof OS_NAME_TYPES]}
+          />
+        )}
         <DiskSizeInput isCreated={isCreated} namespace={namespace} pvc={pvc} />
         <DiskTypeSelect isVMRunning={isVMRunning} />
         <DiskInterfaceSelect isVMRunning={isVMRunning} />

--- a/src/utils/components/DiskModal/RegistryDiskModal.tsx
+++ b/src/utils/components/DiskModal/RegistryDiskModal.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import AdvancedSettings from '@kubevirt-utils/components/DiskModal/components/AdvancedSettings/AdvancedSettings';
@@ -23,7 +22,7 @@ import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { isRunning } from '@virtualmachines/utils';
 
 import { getDefaultCreateValues, getDefaultEditValues } from './utils/form';
-import { SourceTypes, V1DiskFormState, V1SubDiskModalProps } from './utils/types';
+import { SourceTypes, type V1DiskFormState, type V1SubDiskModalProps } from './utils/types';
 
 const RegistryDiskModal: FC<V1SubDiskModalProps> = (props) => {
   const { defaultFormValues, editDiskName, isCreated, isOpen, onClose, onSubmit, pvc, vm } = props;
@@ -46,14 +45,14 @@ const RegistryDiskModal: FC<V1SubDiskModalProps> = (props) => {
   } = methods;
 
   const formRegistryCredentials = watch(REGISTRY_CREDENTIALS_FIELD);
-  const { password, username } = formRegistryCredentials || { password: '', username: '' };
+  const { password, username } = formRegistryCredentials ?? { password: '', username: '' };
   const credentialsValid = (username && password) || (!username && !password);
 
-  const handleSubmitForm = () => {
+  const handleSubmitForm = (): Promise<void> => {
     return handleSubmit(async (data) => submit({ data, editDiskName, onSubmit, pvc, vm }))();
   };
 
-  const os = getOS(vm);
+  const osName = getOS(vm);
   const isVMRunning = isRunning(vm);
   const namespace = getNamespace(vm);
 
@@ -72,7 +71,7 @@ const RegistryDiskModal: FC<V1SubDiskModalProps> = (props) => {
         <PendingChanges isVMRunning={isVMRunning} />
         <BootSourceCheckbox editDiskName={editDiskName} isDisabled={isVMRunning} vm={vm} />
         <DiskNameInput />{' '}
-        {!isCreated && <DiskSourceContainer fieldName={REGISTRYURL_DATAVOLUME_FIELD} os={os} />}
+        {!isCreated && <DiskSourceContainer fieldName={REGISTRYURL_DATAVOLUME_FIELD} os={osName} />}
         <DiskSizeInput isCreated={isCreated} namespace={namespace} pvc={pvc} />
         <DiskTypeSelect isVMRunning={isVMRunning} />
         <DiskInterfaceSelect isVMRunning={isVMRunning} />

--- a/src/utils/components/DiskModal/components/DiskInterfaceSelect/DiskInterfaceSelect.tsx
+++ b/src/utils/components/DiskModal/components/DiskInterfaceSelect/DiskInterfaceSelect.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
@@ -9,8 +8,7 @@ import { diskTypes } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 import { getDiskDrive } from '@kubevirt-utils/resources/vm/utils/disk/selectors';
 import { FormGroup, SelectOption } from '@patternfly/react-core';
 
-import { InterfaceTypes, V1DiskFormState } from '../../utils/types';
-
+import { InterfaceTypes, type V1DiskFormState } from '../../utils/types';
 import { diskInterfaceOptions } from './utils/constants';
 import { getInterfaceTypeHelperText } from './utils/util';
 
@@ -27,7 +25,7 @@ const DiskInterfaceSelect: FC<DiskInterfaceSelectProps> = ({ isVMRunning }) => {
 
   const diskType = getDiskDrive(disk);
 
-  const diskInterface = disk?.[diskType]?.bus || InterfaceTypes.VIRTIO;
+  const diskInterface = disk?.[diskType]?.bus ?? InterfaceTypes.VIRTIO;
 
   const selectedLabel = diskInterfaceOptions?.[diskInterface]?.label
     ? t(diskInterfaceOptions[diskInterface].label)
@@ -40,7 +38,7 @@ const DiskInterfaceSelect: FC<DiskInterfaceSelectProps> = ({ isVMRunning }) => {
       <div>
         <FormPFSelect
           className="disk-interface-select"
-          onSelect={(_, val) => setValue(`disk.${diskType}.bus`, val as string)}
+          onSelect={(_event, val) => setValue(`disk.${diskType}.bus`, val as string)}
           selected={diskInterface}
           selectedLabel={selectedLabel}
           toggleProps={{ isFullWidth: true }}

--- a/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceUploadPVC/DiskSourceUploadPVC.tsx
+++ b/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceUploadPVC/DiskSourceUploadPVC.tsx
@@ -1,17 +1,15 @@
-/* eslint-disable */
-import React, { FC, ReactNode, useState } from 'react';
-import { Controller, FieldPath, useFormContext } from 'react-hook-form';
+import React, { type FC, type ReactNode, useState } from 'react';
+import { Controller, type FieldPath, useFormContext } from 'react-hook-form';
 
-import { V1DiskFormState } from '@kubevirt-utils/components/DiskModal/utils/types';
+import { type V1DiskFormState } from '@kubevirt-utils/components/DiskModal/utils/types';
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
-import { DataUpload } from '@kubevirt-utils/hooks/useCDIUpload/types';
+import { type DataUpload } from '@kubevirt-utils/hooks/useCDIUpload/types';
 import { isUploadingDisk } from '@kubevirt-utils/hooks/useCDIUpload/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { DropEvent, FileUpload, FormGroup, ValidatedOptions } from '@patternfly/react-core';
+import { type DropEvent, FileUpload, FormGroup, ValidatedOptions } from '@patternfly/react-core';
 
 import { UPLOAD_FILE_FIELD, UPLOAD_FILENAME_FIELD } from '../../../utils/constants';
 import { diskSourceUploadFieldID } from '../../utils/constants';
-
 import { DiskSourceUploadPVCProgress } from './DiskSourceUploadPVCProgress';
 
 type DiskSourceUploadPVCProps = {
@@ -49,6 +47,8 @@ const DiskSourceUploadPVC: FC<DiskSourceUploadPVCProps> = ({
 
   return (
     <Controller
+      control={control}
+      name={UPLOAD_FILE_FIELD}
       render={({ field: { onChange, value } }) => (
         <>
           <FormGroup
@@ -57,6 +57,9 @@ const DiskSourceUploadPVC: FC<DiskSourceUploadPVCProps> = ({
             label={label ?? t('Upload data')}
           >
             <FileUpload
+              allowEditingUploadedText={false}
+              browseButtonText={t('Upload')}
+              data-test={diskSourceUploadFieldID}
               dropzoneProps={
                 acceptedFileTypes
                   ? {
@@ -66,27 +69,24 @@ const DiskSourceUploadPVC: FC<DiskSourceUploadPVCProps> = ({
                     }
                   : undefined
               }
+              filename={uploadFilename}
+              filenamePlaceholder={t('Drag and drop an image or upload one')}
+              id="simple-file"
+              isDisabled={isUploadingDisk(relevantUpload?.uploadStatus)}
+              isLoading={isLoading}
               onClearClick={() => {
                 onChange('');
                 setValue<FieldPath<V1DiskFormState>>(UPLOAD_FILENAME_FIELD, '');
                 setIsFileRejected(false);
                 handleClearUpload?.();
               }}
-              onFileInputChange={(_, file: File) => {
+              onDataChange={(_event: DropEvent, droppedFile: string) => onChange(droppedFile)}
+              onFileInputChange={(_event, file: File) => {
                 onChange(file);
                 setValue<FieldPath<V1DiskFormState>>(UPLOAD_FILENAME_FIELD, file.name);
                 setIsFileRejected(false);
                 handleUpload?.();
               }}
-              allowEditingUploadedText={false}
-              browseButtonText={t('Upload')}
-              data-test={diskSourceUploadFieldID}
-              filename={uploadFilename}
-              filenamePlaceholder={t('Drag and drop an image or upload one')}
-              id="simple-file"
-              isDisabled={isUploadingDisk(relevantUpload?.uploadStatus)}
-              isLoading={isLoading}
-              onDataChange={(_event: DropEvent, droppedFile: string) => onChange(droppedFile)}
               onReadFinished={() => setIsLoading(false)}
               onReadStarted={() => setIsLoading(true)}
               value={value}
@@ -98,7 +98,7 @@ const DiskSourceUploadPVC: FC<DiskSourceUploadPVCProps> = ({
             )}
             {error && !isFileRejected && (
               <FormGroupHelperText validated={ValidatedOptions.error}>
-                {error?.file?.message || error?.message}
+                {error?.file?.message ?? error?.message}
               </FormGroupHelperText>
             )}
           </FormGroup>
@@ -106,8 +106,6 @@ const DiskSourceUploadPVC: FC<DiskSourceUploadPVCProps> = ({
           {relevantUpload && <DiskSourceUploadPVCProgress upload={relevantUpload} />}
         </>
       )}
-      control={control}
-      name={UPLOAD_FILE_FIELD}
       rules={{ required: t('File is required.') }}
     />
   );

--- a/src/utils/components/DiskModal/components/DiskTypeSelect/DiskTypeSelect.tsx
+++ b/src/utils/components/DiskModal/components/DiskTypeSelect/DiskTypeSelect.tsx
@@ -1,12 +1,11 @@
-/* eslint-disable */
-import React, { FC, useRef } from 'react';
+import React, { type FC, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
-  DiskType,
+  type DiskType,
   diskTypes,
   diskTypesLabels,
 } from '@kubevirt-utils/resources/vm/utils/disk/constants';
@@ -14,7 +13,7 @@ import { getDiskDrive } from '@kubevirt-utils/resources/vm/utils/disk/selectors'
 import { FormGroup, SelectOption } from '@patternfly/react-core';
 
 import { getSourceFromVolume } from '../../utils/helpers';
-import { InterfaceTypes, SourceTypes, V1DiskFormState } from '../../utils/types';
+import { InterfaceTypes, SourceTypes, type V1DiskFormState } from '../../utils/types';
 import { getDiskTypeHelperText } from '../DiskInterfaceSelect/utils/util';
 import { DISKTYPE_SELECT_FIELDID } from '../utils/constants';
 
@@ -29,7 +28,7 @@ const DiskTypeSelect: FC<DiskTypeSelectProps> = ({ isVMRunning }) => {
   const diskState = watch();
 
   const diskType = getDiskDrive(diskState?.disk);
-  const initialDiskTypeRef = useRef<DiskType>(diskType);
+  const [initialDiskType] = useState<DiskType>(diskType);
 
   if (!diskState) return null;
 
@@ -39,15 +38,16 @@ const DiskTypeSelect: FC<DiskTypeSelectProps> = ({ isVMRunning }) => {
     return optionType === diskTypes.cdrom && isVMRunning && diskSource !== SourceTypes.CDROM;
   };
 
-  const diskInterface = diskState.disk?.[diskType]?.bus || InterfaceTypes.VIRTIO;
+  const diskInterface = diskState.disk?.[diskType]?.bus ?? InterfaceTypes.VIRTIO;
 
-  const userHelpText = getDiskTypeHelperText(initialDiskTypeRef.current, isVMRunning);
+  const userHelpText = getDiskTypeHelperText(initialDiskType, isVMRunning);
 
   return (
     <div data-test={DISKTYPE_SELECT_FIELDID}>
       <FormGroup fieldId={DISKTYPE_SELECT_FIELDID} label={t('Type')}>
         <FormPFSelect
-          onSelect={(_, val) => {
+          isDisabled={initialDiskType === diskTypes.cdrom}
+          onSelect={(_event, val) => {
             setValue('disk.cdrom', null);
             setValue('disk.lun', null);
             setValue('disk.disk', null);
@@ -61,7 +61,6 @@ const DiskTypeSelect: FC<DiskTypeSelectProps> = ({ isVMRunning }) => {
 
             setValue(`disk.${val as DiskType}`, { bus: newDiskInterface });
           }}
-          isDisabled={initialDiskTypeRef.current === diskTypes.cdrom}
           selected={diskType}
           selectedLabel={diskTypesLabels[diskType]}
           toggleProps={{ isFullWidth: true }}

--- a/src/utils/components/DiskModal/components/StorageClassAndPreallocation/EnablePreallocationCheckbox.tsx
+++ b/src/utils/components/DiskModal/components/StorageClassAndPreallocation/EnablePreallocationCheckbox.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { Trans } from 'react-i18next';
 import { Link } from 'react-router';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -12,7 +11,7 @@ import PopoverContentWithLightspeedButton from '@lightspeed/components/PopoverCo
 import { OLSPromptType } from '@lightspeed/utils/prompts';
 import { Checkbox, Flex, FlexItem, FormGroup, PopoverPosition } from '@patternfly/react-core';
 
-import { V1DiskFormState } from '../../utils/types';
+import { type V1DiskFormState } from '../../utils/types';
 import { ENABLE_PREALLOCATION_FIELDID, ENALBE_PREACCLOCATION_FIELD } from '../utils/constants';
 
 type EnablePreallocationCheckboxProps = {
@@ -29,17 +28,17 @@ const EnablePreallocationCheckbox: FC<EnablePreallocationCheckboxProps> = ({ isD
       <Flex>
         <FlexItem>
           <Controller
+            control={control}
+            name={ENALBE_PREACCLOCATION_FIELD}
             render={({ field: { onChange, value } }) => (
               <Checkbox
                 id={ENABLE_PREALLOCATION_FIELDID}
                 isChecked={value}
                 isDisabled={isDisabled}
                 label={t('Enable preallocation')}
-                onChange={(_, checked) => onChange(checked)}
+                onChange={(_event, checked) => onChange(checked)}
               />
             )}
-            control={control}
-            name={ENALBE_PREACCLOCATION_FIELD}
           />
         </FlexItem>
         <FlexItem>

--- a/src/utils/components/DiskModal/components/StorageClassAndPreallocation/utils/helpers.ts
+++ b/src/utils/components/DiskModal/components/StorageClassAndPreallocation/utils/helpers.ts
@@ -1,7 +1,6 @@
-/* eslint-disable */
 import { modelToGroupVersionKind, StorageClassModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiStorageV1StorageClass } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
+import { type IoK8sApiStorageV1StorageClass } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
 import {
   isDefaultStorageClass,
   isVirtDefaultStorageClass,
@@ -13,17 +12,20 @@ import { DESCRIPTION_ANNOTATION } from '@kubevirt-utils/resources/vm';
 export const getDefaultStorageClass = (
   storageClasses: IoK8sApiStorageV1StorageClass[],
 ): IoK8sApiStorageV1StorageClass =>
-  storageClasses?.find(isVirtDefaultStorageClass) || storageClasses?.find(isDefaultStorageClass);
+  storageClasses?.find(isVirtDefaultStorageClass) ?? storageClasses?.find(isDefaultStorageClass);
 
 export const getSCSelectOptions = (
   storageClasses: IoK8sApiStorageV1StorageClass[],
 ): EnhancedSelectOptionProps[] =>
-  storageClasses?.map((sc) => {
-    const scName = getName(sc);
-    const defaultSC = isDefaultStorageClass(sc) ? t('(default) | ') : '';
-    const descriptionAnnotation = getAnnotation(sc, DESCRIPTION_ANNOTATION)?.concat(' | ') || '';
-    const scType = sc?.parameters?.type ? ' | '.concat(sc?.parameters?.type) : '';
-    const description = `${defaultSC}${descriptionAnnotation}${sc?.provisioner}${scType}`;
+  storageClasses?.map((storageClass) => {
+    const scName = getName(storageClass);
+    const defaultSC = isDefaultStorageClass(storageClass) ? t('(default) | ') : '';
+    const descriptionAnnotation =
+      getAnnotation(storageClass, DESCRIPTION_ANNOTATION)?.concat(' | ') || '';
+    const scType = storageClass?.parameters?.type
+      ? ' | '.concat(storageClass?.parameters?.type)
+      : '';
+    const description = `${defaultSC}${descriptionAnnotation}${storageClass?.provisioner}${scType}`;
 
     return {
       children: scName,

--- a/src/utils/components/ServicesList/Selector/utils.ts
+++ b/src/utils/components/ServicesList/Selector/utils.ts
@@ -1,9 +1,12 @@
-/* eslint-disable */
 import { ALL_CLUSTERS_KEY } from '@kubevirt-utils/hooks/constants';
 import { getACMTextSearchURL } from '@multicluster/urls';
-import { MatchExpression, Operator, Selector } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  type MatchExpression,
+  Operator,
+  type Selector,
+} from '@openshift-console/dynamic-plugin-sdk';
 
-const toArray = (value) => (Array.isArray(value) ? value : [value]);
+const toArray = (value: string | string[]): string[] => (Array.isArray(value) ? value : [value]);
 
 export const requirementToString = (requirement: MatchExpression): string => {
   const requirementStrings = {
@@ -26,17 +29,18 @@ export const createEquals = (key: string, value: string): MatchExpression => ({
   values: [value],
 });
 
-const isOldFormat = (selector: Selector) => !selector.matchLabels && !selector.matchExpressions;
+const isOldFormat = (selector: Selector): boolean =>
+  !selector.matchLabels && !selector.matchExpressions;
 
-export const toRequirements = (selector: Selector = {}) => {
+export const toRequirements = (selector: Selector = {}): MatchExpression[] => {
   const matchLabels = isOldFormat(selector) ? selector : selector.matchLabels;
   const { matchExpressions } = selector;
 
-  const requirements = Object.keys(matchLabels || {})
-    .sort()
+  const requirements = Object.keys(matchLabels ?? {})
+    .sort((a, b) => a.localeCompare(b))
     .map((match) => createEquals(match, matchLabels[match]));
 
-  requirements.push(...(matchExpressions || []));
+  requirements.push(...(matchExpressions ?? []));
 
   return requirements;
 };
@@ -57,9 +61,9 @@ export const getSelectorSearchURL = (
   if (cluster || isACMPage) {
     const labelFilters = requirementAsString
       .split(',')
-      .map((r) => `label:${r.trim()}`)
+      .map((req) => `label:${req.trim()}`)
       .join(' ');
-    const selectedCluster = cluster || hubClusterName;
+    const selectedCluster = cluster ?? hubClusterName;
     const clusterPart =
       selectedCluster && selectedCluster !== ALL_CLUSTERS_KEY ? `cluster:${selectedCluster} ` : '';
     const namespacePart = namespace ? ` namespace:${namespace}` : '';

--- a/src/utils/components/TLSCertificateSection/components/ExistingTLSCertificate.tsx
+++ b/src/utils/components/TLSCertificateSection/components/ExistingTLSCertificate.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
@@ -27,8 +26,8 @@ const ExistingTLSCertificate: FC<ExistingTLSCertificateProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
 
-  const certProject = selectedProject || namespace;
-  const selectedConfigMap = selectedConfigMapName || '';
+  const certProject = selectedProject ?? namespace;
+  const selectedConfigMap = selectedConfigMapName ?? '';
 
   const [projectNames, projectsLoaded] = useProjects(cluster);
   const [tlsCertConfigMaps, certMapsLoaded, certMapsError] = useTLSCertConfigMaps(
@@ -46,14 +45,14 @@ const ExistingTLSCertificate: FC<ExistingTLSCertificateProps> = ({
                 children: name,
                 value: name,
               }))}
+              placeholder={t('Select project...')}
+              selected={certProject || ''}
               setSelected={(name: string) => {
                 onChange(name, '');
               }}
               toggleProps={{
                 isFullWidth: true,
               }}
-              placeholder={t('Select project...')}
-              selected={certProject || ''}
             />
           ) : (
             <Loading />
@@ -67,18 +66,18 @@ const ExistingTLSCertificate: FC<ExistingTLSCertificateProps> = ({
           )}
           {!certMapsError && certMapsLoaded && (
             <InlineFilterSelect
-              options={tlsCertConfigMaps?.map((cm) => {
-                const name = getName(cm);
+              options={tlsCertConfigMaps?.map((configMap) => {
+                const name = getName(configMap);
                 return { children: name, value: name };
               })}
+              placeholder={t('Select TLS certificate')}
+              selected={selectedConfigMap || ''}
               setSelected={(name: string) => {
                 onChange(certProject, name);
               }}
               toggleProps={{
                 isFullWidth: true,
               }}
-              placeholder={t('Select TLS certificate')}
-              selected={selectedConfigMap || ''}
             />
           )}
           {!certMapsError && !certMapsLoaded && <Loading />}

--- a/src/utils/components/TLSCertificateSection/hooks/useTLSCertConfigMaps.ts
+++ b/src/utils/components/TLSCertificateSection/hooks/useTLSCertConfigMaps.ts
@@ -1,8 +1,7 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import { ConfigMapModel, modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
 import { TLS_CERT_CONFIGMAP_KEY } from '../constants';
@@ -22,7 +21,9 @@ export const useTLSCertConfigMaps = (
   const tlsCertConfigMaps = useMemo(() => {
     if (!namespace || !configMaps?.length) return [];
     return configMaps.filter(
-      (cm) => cm?.data && Object.prototype.hasOwnProperty.call(cm.data, TLS_CERT_CONFIGMAP_KEY),
+      (configMap) =>
+        configMap?.data &&
+        Object.prototype.hasOwnProperty.call(configMap.data, TLS_CERT_CONFIGMAP_KEY),
     );
   }, [namespace, configMaps]);
 

--- a/src/utils/resources/migrations/backends/planModels.ts
+++ b/src/utils/resources/migrations/backends/planModels.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import {
   MigPlanModel,
   MultiNamespaceVirtualMachineStorageMigrationPlanModel,
@@ -13,7 +12,7 @@ const STORAGE_MIGRATION_PLAN_MODELS: K8sModel[] = [
 ];
 
 export const getStorageMigrationPlanModelForKind = (kind?: string): K8sModel => {
-  const found = STORAGE_MIGRATION_PLAN_MODELS.find((m) => m.kind === kind);
+  const found = STORAGE_MIGRATION_PLAN_MODELS.find((model) => model.kind === kind);
   if (found) {
     return found;
   }

--- a/src/utils/resources/migrations/mtc/matching.ts
+++ b/src/utils/resources/migrations/mtc/matching.ts
@@ -1,11 +1,10 @@
-/* eslint-disable */
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { MigPlanModel } from '@kubevirt-utils/models';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getVolumes } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
-import { MigPlan, MultiNamespaceVirtualMachineStorageMigrationPlan } from '../constants';
+import { type MigPlan, type MultiNamespaceVirtualMachineStorageMigrationPlan } from '../constants';
 
 import {
   getMigPlanPVCName,
@@ -39,10 +38,10 @@ export const doesMTCPlanTargetVM = (migPlan: MigPlan, vm: V1VirtualMachine): boo
     }),
   );
 
-  return pvs.some((pv) => {
-    const pvcNs = getMigPlanPVCNamespace(pv) ?? vmNs;
+  return pvs.some((pvEntry) => {
+    const pvcNs = getMigPlanPVCNamespace(pvEntry) ?? vmNs;
     if (pvcNs !== vmNs) return false;
-    const pvcName = getMigPlanPVCName(pv) ?? pv.name;
+    const pvcName = getMigPlanPVCName(pvEntry) ?? pvEntry.name;
     return Boolean(pvcName && claimNames.has(pvcName));
   });
 };

--- a/src/utils/resources/migrations/utils.ts
+++ b/src/utils/resources/migrations/utils.ts
@@ -1,9 +1,8 @@
-/* eslint-disable */
 import { getStatusNamespaces } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 import {
-  MultiNamespaceVirtualMachineStorageMigrationPlan,
+  type MultiNamespaceVirtualMachineStorageMigrationPlan,
   STATUS_READY,
   STORAGE_MIGRATION_PHASE,
 } from './constants';
@@ -12,9 +11,9 @@ import { getStorageMigrationPlanSpecNamespaces } from './selectors';
 const getMigrationConditionTimestamp = (
   migration: MultiNamespaceVirtualMachineStorageMigrationPlan,
   conditionType: string,
-) => {
-  for (const namespaceStatus of migration?.status?.namespaces || []) {
-    const condition = namespaceStatus?.conditions?.find((c) => c?.type === conditionType);
+): string | undefined => {
+  for (const namespaceStatus of migration?.status?.namespaces ?? []) {
+    const condition = namespaceStatus?.conditions?.find((cond) => cond?.type === conditionType);
     if (condition) {
       return condition.lastTransitionTime;
     }
@@ -24,11 +23,11 @@ const getMigrationConditionTimestamp = (
 
 export const getMigrationStartTimestamp = (
   migration: MultiNamespaceVirtualMachineStorageMigrationPlan,
-) => getMigrationConditionTimestamp(migration, STATUS_READY);
+): string | undefined => getMigrationConditionTimestamp(migration, STATUS_READY);
 
 export const getMigrationCompletedTimestamp = (
   migration: MultiNamespaceVirtualMachineStorageMigrationPlan,
-) => {
+): string | undefined => {
   if (!isMigrationCompleted(migration)) {
     return undefined;
   }
@@ -37,7 +36,7 @@ export const getMigrationCompletedTimestamp = (
 
 export const getVolumeCountFromMigPlan = (
   migrationPlan: MultiNamespaceVirtualMachineStorageMigrationPlan,
-) => {
+): number => {
   return getStorageMigrationPlanSpecNamespaces(migrationPlan).flatMap((namespaceMigration) =>
     (namespaceMigration?.virtualMachines ?? []).flatMap((vm) =>
       (vm?.targetMigrationPVCs ?? []).filter((pvc) => !isEmpty(pvc.destinationPVC)),
@@ -47,7 +46,7 @@ export const getVolumeCountFromMigPlan = (
 
 export const getCompletedVolumeCountFromMigPlan = (
   migrationPlan: MultiNamespaceVirtualMachineStorageMigrationPlan,
-) =>
+): number =>
   (migrationPlan?.status?.namespaces ?? []).flatMap((namespace) =>
     (namespace?.[STORAGE_MIGRATION_PHASE.COMPLETED] ?? []).flatMap(
       (migration) => migration?.sourcePVCs ?? [],
@@ -56,7 +55,7 @@ export const getCompletedVolumeCountFromMigPlan = (
 
 export const isMigrationCompleted = (
   migrationPlan: MultiNamespaceVirtualMachineStorageMigrationPlan,
-) => {
+): boolean => {
   const statusNamespaces = getStatusNamespaces(migrationPlan);
   const specNamespaces = getStorageMigrationPlanSpecNamespaces(migrationPlan);
 

--- a/src/utils/resources/template/hooks/useSingleClusterAvailableSources.ts
+++ b/src/utils/resources/template/hooks/useSingleClusterAvailableSources.ts
@@ -1,16 +1,16 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import { PersistentVolumeClaimModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { DataSourceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
-import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import {
+  type ClusterNamespacedResourceMap,
   convertResourceArrayToMapWithCluster,
   getName,
   getNamespace,
 } from '@kubevirt-utils/resources/shared';
-import { BOOT_SOURCE, Template } from '@kubevirt-utils/resources/template';
+import { BOOT_SOURCE, type Template } from '@kubevirt-utils/resources/template';
 import {
   getTemplateBootSourceType,
   isDataSourceCloning,
@@ -19,7 +19,7 @@ import {
 import {
   getGroupVersionKindForModel,
   useK8sWatchResources,
-  WatchK8sResource,
+  type WatchK8sResource,
 } from '@openshift-console/dynamic-plugin-sdk';
 
 type UniqueSourceType = {
@@ -35,7 +35,12 @@ type UniqueSourceType = {
 export const useSingleClusterAvailableSources = (
   templates: Template[],
   templatesLoaded: boolean,
-) => {
+): {
+  availableDataSources: Record<string, V1beta1DataSource>;
+  availablePVCs: ClusterNamespacedResourceMap<IoK8sApiCoreV1PersistentVolumeClaim>;
+  cloneInProgressDataSources: Record<string, V1beta1DataSource>;
+  loaded: boolean;
+} => {
   const { uniqueDataSources, uniquePVCs } = useMemo(() => {
     if (!templatesLoaded)
       return {
@@ -51,12 +56,12 @@ export const useSingleClusterAvailableSources = (
         const bootSource = getTemplateBootSourceType(template);
 
         if (bootSource.type === BOOT_SOURCE.DATA_SOURCE) {
-          const ds = bootSource?.source?.sourceRef;
-          acc.uniqueDataSources[`${ds?.namespace}-${ds?.name}`] = {
+          const sourceRef = bootSource?.source?.sourceRef;
+          acc.uniqueDataSources[`${sourceRef?.namespace}-${sourceRef?.name}`] = {
             groupVersionKind: getGroupVersionKindForModel(DataSourceModel),
             isList: false,
-            name: ds?.name,
-            namespace: ds?.namespace,
+            name: sourceRef?.name,
+            namespace: sourceRef?.namespace,
           };
         }
 
@@ -90,17 +95,20 @@ export const useSingleClusterAvailableSources = (
 
   const { availableDataSources, cloneInProgressDataSources } = useMemo(
     () =>
-      Object.values(watchDataSources).reduce(
+      Object.values(watchDataSources).reduce<{
+        availableDataSources: Record<string, V1beta1DataSource>;
+        cloneInProgressDataSources: Record<string, V1beta1DataSource>;
+      }>(
         (acc, { data: dataSource }) => {
           if (isDataSourceReady(dataSource as V1beta1DataSource)) {
             acc.availableDataSources[`${getNamespace(dataSource)}-${getName(dataSource)}`] =
-              dataSource;
+              dataSource as V1beta1DataSource;
             return acc;
           }
 
           if (isDataSourceCloning(dataSource)) {
             acc.cloneInProgressDataSources[`${getNamespace(dataSource)}-${getName(dataSource)}`] =
-              dataSource;
+              dataSource as V1beta1DataSource;
             return acc;
           }
           return acc;

--- a/src/utils/resources/vm/hooks/disk/useDisksSources.ts
+++ b/src/utils/resources/vm/hooks/disk/useDisksSources.ts
@@ -1,15 +1,21 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
-import { V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
-import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useKubevirtWatchResources from '@multicluster/hooks/useKubevirtWatchResources';
 
 import { getPVCAndDVWatches } from './utils';
 
-const useDisksSources = (vm: V1VirtualMachine) => {
+const useDisksSources = (
+  vm: V1VirtualMachine,
+): {
+  dvs: V1beta1DataVolume[];
+  loaded: boolean;
+  loadingError: Error | undefined;
+  pvcs: IoK8sApiCoreV1PersistentVolumeClaim[];
+} => {
   const { dvWatches, pvcWatches } = useMemo(() => getPVCAndDVWatches(vm), [vm]);
 
   const pvcWatchesResult = useKubevirtWatchResources<{
@@ -24,7 +30,7 @@ const useDisksSources = (vm: V1VirtualMachine) => {
     () =>
       Object.values(dvWatchesResult || [])
         .map((watch) => watch.data)
-        .filter((dv) => !isEmpty(dv)),
+        .filter((dataVolume) => !isEmpty(dataVolume)),
     [dvWatchesResult],
   );
 
@@ -42,11 +48,11 @@ const useDisksSources = (vm: V1VirtualMachine) => {
     [pvcWatchesResult],
   );
 
-  const loadingError = useMemo(
+  const loadingError = useMemo<Error | undefined>(
     () =>
       Object.values(pvcWatchesResult).find((watch) => {
         return !isEmpty(watch.loadError) && watch.loadError?.code !== 404;
-      })?.loadError,
+      })?.loadError as Error | undefined,
     [pvcWatchesResult],
   );
 

--- a/src/utils/resources/vm/hooks/disk/useDisksTableData.ts
+++ b/src/utils/resources/vm/hooks/disk/useDisksTableData.ts
@@ -1,25 +1,29 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
   getRunningVMMissingDisksFromVMI,
   getRunningVMMissingVolumesFromVMI,
 } from '@kubevirt-utils/components/DiskModal/utils/helpers';
 import { getName } from '@kubevirt-utils/resources/shared';
-import { DiskRawData, DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
+import {
+  type DiskRawData,
+  type DiskRowDataLayout,
+} from '@kubevirt-utils/resources/vm/utils/disk/constants';
 import { isRunning } from '@virtualmachines/utils';
 
 import { getBootDisk, getDataVolumeTemplates, getDisks, getVolumes } from '../../utils';
 import { getDiskRowDataLayout } from '../../utils/disk/rowData';
-
 import useDisksSources from './useDisksSources';
 import { enrichDisksWithVMIBusInfo, getEjectedCDROMDrives, isStorageVolume } from './utils';
 
 type UseDisksTableDisks = (
   vm: V1VirtualMachine,
   vmi: V1VirtualMachineInstance,
-) => [DiskRowDataLayout[], boolean, any, V1VirtualMachineInstance];
+) => [DiskRowDataLayout[], boolean, Error | undefined, null | V1VirtualMachineInstance];
 
 /**
  * A Hook for getting disks data for a VM
@@ -32,7 +36,7 @@ const useDisksTableData: UseDisksTableDisks = (vm, vmi) => {
   const isVMRunning = isRunning(vm);
 
   const vmDisks = useMemo(() => {
-    const vmDiskList = getDisks(vm) || [];
+    const vmDiskList = getDisks(vm) ?? [];
     if (!isVMRunning) return vmDiskList;
 
     const enrichedDisks = vmi ? enrichDisksWithVMIBusInfo(vmDiskList, vmi) : vmDiskList;
@@ -45,21 +49,21 @@ const useDisksTableData: UseDisksTableDisks = (vm, vmi) => {
     const detectedVolumes = !isVMRunning
       ? getVolumes(vm)
       : [
-          ...(getVolumes(vm) || []),
-          ...getRunningVMMissingVolumesFromVMI(getVolumes(vm) || [], vmi),
+          ...(getVolumes(vm) ?? []),
+          ...getRunningVMMissingVolumesFromVMI(getVolumes(vm) ?? [], vmi),
         ];
 
     return detectedVolumes?.filter(isStorageVolume);
   }, [vm, vmi, isVMRunning]);
 
   const disks = useMemo(() => {
-    const diskDevices: DiskRawData[] = (vmVolumes || []).map((volume) => {
-      let disk = vmDisks?.find(({ name }) => name === volume?.name);
-
-      if (!disk) disk = { name: volume?.name };
+    const diskDevices: DiskRawData[] = (vmVolumes ?? []).map((volume) => {
+      const disk = vmDisks?.find(({ name }) => name === volume?.name) ?? { name: volume?.name };
 
       const dataVolumeTemplate = volume?.dataVolume?.name
-        ? getDataVolumeTemplates(vm)?.find((dv) => getName(dv) === volume.dataVolume.name)
+        ? getDataVolumeTemplates(vm)?.find(
+            (dvTemplate) => getName(dvTemplate) === volume.dataVolume.name,
+          )
         : null;
 
       const pvc = pvcs?.find(

--- a/src/views/datasources/hooks/useUploadToRegistry.tsx
+++ b/src/views/datasources/hooks/useUploadToRegistry.tsx
@@ -4,7 +4,7 @@ import { type V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containeri
 import ExportModal from '@kubevirt-utils/components/ExportModal/ExportModal';
 import { type VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
 import { VolumeSnapshotModel } from '@kubevirt-utils/models';
-import { isEmpty, kubevirtConsole } from '@kubevirt-utils/utils/utils';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { kubevirtK8sGet } from '@multicluster/k8sRequests';
 
@@ -30,17 +30,10 @@ const useUploadToRegistry = (
       return;
     }
     const volumeSnapshot = await kubevirtK8sGet<VolumeSnapshotKind>({
-      cluster: getCluster(dataSource),
       model: VolumeSnapshotModel,
       name: dataSource?.spec?.source?.snapshot?.name,
       ns: dataSource?.spec?.source?.snapshot?.namespace,
-    }).catch((error) => {
-      kubevirtConsole.error('Failed to fetch VolumeSnapshot:', error);
-      return undefined;
     });
-
-    if (!volumeSnapshot) return;
-
     createModal(({ isOpen, onClose }) => (
       <ExportModal
         cluster={getCluster(dataSource)}

--- a/src/views/search/components/SaveSearchButton.tsx
+++ b/src/views/search/components/SaveSearchButton.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useCallback } from 'react';
+import React, { type FC, useCallback } from 'react';
 
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -30,18 +29,18 @@ const SaveSearchButton: FC<SaveSearchButtonProps> = ({ isDraft }) => {
   });
 
   const showSaveSearchModal = useCallback(() => {
-    const savedSearchNames = searches.map((s) => s.name);
+    const savedSearchNames = searches.map((search) => search.name);
     const initialDescription = urlQueryToSearchLanguage(urlSearchQuery);
 
     createModal(({ isOpen, onClose }) => (
       <SaveSearchModal
+        initialDescription={initialDescription}
+        isOpen={isOpen}
+        onClose={onClose}
         onSubmit={({ description, isFavorited, name }) => {
           saveSearch(name, { description, isFavorited, query: urlSearchQuery });
           onClose();
         }}
-        initialDescription={initialDescription}
-        isOpen={isOpen}
-        onClose={onClose}
         savedSearchNames={savedSearchNames}
       />
     ));

--- a/src/views/search/components/SavedSearchesDropdown/SavedSearchesDropdown.tsx
+++ b/src/views/search/components/SavedSearchesDropdown/SavedSearchesDropdown.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import React, { FC, useMemo, useState } from 'react';
+import React, { type FC, useMemo, useState } from 'react';
 
 import {
-  KubevirtFilterState,
-  OnSetFilters,
+  type KubevirtFilterState,
+  type OnSetFilters,
 } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -18,13 +17,13 @@ import {
   SearchInput,
 } from '@patternfly/react-core';
 import { useSavedSearchData } from '@search/hooks/useSavedSearchData';
+import { type SavedSearchEntry } from '@search/savedSearches/types';
 import { applySearch } from '@search/savedSearches/utils';
 
 import SavedSearchesStateHandler from './components/SavedSearchesStateHandler';
 import SavedSearchItem from './components/SavedSearchItem';
 import useDeleteSavedSearch from './hooks/useDeleteSavedSearch';
 import { getSavedSearchesItemsToDisplay, getSortedSavedsearches } from './utils/utils';
-import { SavedSearchEntry } from '@search/savedSearches/types';
 
 type SavedSearchesDropdownProps = {
   filters: KubevirtFilterState;
@@ -51,14 +50,14 @@ const SavedSearchesDropdown: FC<SavedSearchesDropdownProps> = ({ filters, onSetF
   const savedSearchesItemsToDropdownItems = (savedSearchesItems: SavedSearchEntry[]) =>
     savedSearchesItems.map(({ description, isFavorited, name }) => (
       <SavedSearchItem
-        onApply={() => {
-          applySearch(name, searches, filters, onSetFilters);
-          setOpen(false);
-        }}
         description={description}
         isFavorited={isFavorited}
         key={name}
         name={name}
+        onApply={() => {
+          applySearch(name, searches, filters, onSetFilters);
+          setOpen(false);
+        }}
         onDelete={() => handleDelete(name, isFavorited)}
         onToggleFavorite={() => toggleFavorite(name)}
       />
@@ -89,7 +88,7 @@ const SavedSearchesDropdown: FC<SavedSearchesDropdownProps> = ({ filters, onSetF
         <MenuSearch>
           <MenuSearchInput>
             <SearchInput
-              onChange={(_, value) => setFilterText(value)}
+              onChange={(_event, value) => setFilterText(value)}
               placeholder={t('Find by name')}
               value={filterText}
             />

--- a/src/views/search/components/SearchBar.tsx
+++ b/src/views/search/components/SearchBar.tsx
@@ -1,12 +1,13 @@
 import React, { type FC, type RefObject, useCallback, useMemo } from 'react';
 
 import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
 import {
   type KubevirtFilter,
   type KubevirtFilterState,
   type OnSetFilters,
 } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
-import { InputGroup, InputGroupItem } from '@patternfly/react-core';
+import { InputGroup, InputGroupItem, Stack, StackItem } from '@patternfly/react-core';
 import useShowAdvancedSearchModal from '@search/hooks/useShowAdvancedSearchModal';
 import { useSearchLanguageInput } from '@search/searchLanguage/hooks/useSearchLanguageInput/useSearchLanguageInput';
 import { convertFilterStateToModalInputs } from '@search/utils/query';
@@ -38,7 +39,7 @@ const SearchBar: FC<SearchBarProps> = ({
   const showSearchModal = useShowAdvancedSearchModal(onSetFilters, vms);
   const modalInputs = useMemo(() => convertFilterStateToModalInputs(filters), [filters]);
 
-  const { addRecentSearch, recentSearches } = useRecentSearches();
+  const { addRecentSearch, recentSearches, recentSearchesError } = useRecentSearches();
 
   const { onCommitText, ...searchInputProps } = useSearchLanguageInput({
     addRecentSearch,
@@ -56,26 +57,35 @@ const SearchBar: FC<SearchBarProps> = ({
   );
 
   return (
-    <InputGroup className="pf-v6-u-mb-md" data-test="vm-adv-search-toolbar">
-      <InputGroupItem isFill>
-        <SearchTextInput
-          filterDefinitions={filterDefinitions}
-          filters={filters}
-          inputRef={inputRef}
-          onOpenAdvancedSearch={() => showSearchModal(modalInputs)}
-          onSelectQueryText={onSelectQueryText}
-          onSetFilters={onSetFilters}
-          recentSearches={recentSearches}
-          {...searchInputProps}
-        />
-      </InputGroupItem>
-      <InputGroupItem>
-        <SearchTipsPopover onSelectTip={onSelectQueryText} />
-      </InputGroupItem>
-      <InputGroupItem>
-        <SavedSearchesDropdown filters={filters} onSetFilters={onSetFilters} />
-      </InputGroupItem>
-    </InputGroup>
+    <Stack>
+      {recentSearchesError && (
+        <StackItem>
+          <ErrorAlert error={recentSearchesError} />
+        </StackItem>
+      )}
+      <StackItem>
+        <InputGroup className="pf-v6-u-mb-md" data-test="vm-adv-search-toolbar">
+          <InputGroupItem isFill>
+            <SearchTextInput
+              filterDefinitions={filterDefinitions}
+              filters={filters}
+              inputRef={inputRef}
+              onOpenAdvancedSearch={() => showSearchModal(modalInputs)}
+              onSelectQueryText={onSelectQueryText}
+              onSetFilters={onSetFilters}
+              recentSearches={recentSearches}
+              {...searchInputProps}
+            />
+          </InputGroupItem>
+          <InputGroupItem>
+            <SearchTipsPopover onSelectTip={onSelectQueryText} />
+          </InputGroupItem>
+          <InputGroupItem>
+            <SavedSearchesDropdown filters={filters} onSetFilters={onSetFilters} />
+          </InputGroupItem>
+        </InputGroup>
+      </StackItem>
+    </Stack>
   );
 };
 

--- a/src/views/search/components/SearchDropdown/hooks/useRecentSearches.ts
+++ b/src/views/search/components/SearchDropdown/hooks/useRecentSearches.ts
@@ -1,18 +1,19 @@
-/* eslint-disable */
 import { useCallback, useMemo } from 'react';
 
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
 import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
+import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 
 const MAX_RECENT_SEARCHES = 3;
 
 type UseRecentSearchesResult = {
   addRecentSearch: (token: string) => void;
   recentSearches: string[];
+  recentSearchesError: Error;
 };
 
 const useRecentSearches = (): UseRecentSearchesResult => {
-  const [storedSearches, setStoredSearches] = useKubevirtUserSettings(
+  const [storedSearches, setStoredSearches, , recentSearchesError] = useKubevirtUserSettings(
     USER_SETTINGS_KEYS.recentSearches,
   );
 
@@ -26,16 +27,20 @@ const useRecentSearches = (): UseRecentSearchesResult => {
       const trimmed = token.trim();
       if (!trimmed) return;
 
-      const current = Array.isArray(storedSearches) ? storedSearches : [];
-      const deduplicated = current.filter((s) => s !== trimmed);
+      const current: string[] = Array.isArray(storedSearches)
+        ? (storedSearches as never as string[])
+        : [];
+      const deduplicated = current.filter((search) => search !== trimmed);
       const updated = [trimmed, ...deduplicated].slice(0, MAX_RECENT_SEARCHES);
 
-      setStoredSearches?.(updated);
+      if (setStoredSearches) {
+        setStoredSearches(updated).catch((err: unknown) => kubevirtConsole.error(err));
+      }
     },
     [storedSearches, setStoredSearches],
   );
 
-  return { addRecentSearch, recentSearches };
+  return { addRecentSearch, recentSearches, recentSearchesError };
 };
 
 export default useRecentSearches;

--- a/src/views/search/hooks/useSavedSearchData.ts
+++ b/src/views/search/hooks/useSavedSearchData.ts
@@ -1,13 +1,12 @@
-/* eslint-disable */
 import { useCallback, useMemo } from 'react';
 import { useLocation } from 'react-router';
 
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
 import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { isEmpty, kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { getUrlSearchQuery } from '@search/utils/query';
 
-import { SavedSearchData, SavedSearchEntry } from '../savedSearches/types';
+import { type SavedSearchData, type SavedSearchEntry } from '../savedSearches/types';
 
 type SavedSearchDataResult = {
   deleteSearch: (name: string) => void;
@@ -42,9 +41,9 @@ export const useSavedSearchData = (): SavedSearchDataResult => {
 
   const deleteSearch = useCallback<SavedSearchDataResult['deleteSearch']>(
     (name) => {
-      const { [name]: _, ...restSearches } = savedSearches;
+      const { [name]: _removed, ...restSearches } = savedSearches;
 
-      setSavedSearches?.(restSearches);
+      setSavedSearches?.(restSearches)?.catch(kubevirtConsole.error);
     },
     [setSavedSearches, savedSearches],
   );
@@ -54,20 +53,20 @@ export const useSavedSearchData = (): SavedSearchDataResult => {
       setSavedSearches?.({
         ...savedSearches,
         [name]: data,
-      });
+      })?.catch(kubevirtConsole.error);
     },
     [setSavedSearches, savedSearches],
   );
 
   const toggleFavorite = useCallback<SavedSearchDataResult['toggleFavorite']>(
     (name) => {
-      const entry = savedSearches?.[name];
+      const entry = savedSearches?.[name] as SavedSearchData | undefined;
       if (!entry) return;
 
       setSavedSearches?.({
         ...savedSearches,
         [name]: { ...entry, isFavorited: !entry.isFavorited },
-      });
+      })?.catch(kubevirtConsole.error);
     },
     [setSavedSearches, savedSearches],
   );

--- a/src/views/search/savedSearches/utils.ts
+++ b/src/views/search/savedSearches/utils.ts
@@ -1,13 +1,12 @@
-/* eslint-disable */
 import { logVMSavedSearchApplied } from '@kubevirt-utils/extensions/telemetry/dashboard';
 import {
-  KubevirtFilterState,
-  OnSetFilters,
+  type KubevirtFilterState,
+  type OnSetFilters,
 } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { updateFilterState } from '@search/searchLanguage/hooks/useOnCommitText/updateFilterState';
 import { convertQueryToFilterState } from '@search/utils/query';
 
-import { SavedSearchEntry } from './types';
+import { type SavedSearchEntry } from './types';
 
 export const applySearch = (
   name: string,
@@ -15,7 +14,7 @@ export const applySearch = (
   filters: KubevirtFilterState,
   onSetFilters: OnSetFilters,
 ): void => {
-  const entry = searches.find((s) => s.name === name);
+  const entry = searches.find((search) => search.name === name);
   const query = entry?.query;
 
   if (query) {

--- a/src/views/search/searchLanguage/constants.ts
+++ b/src/views/search/searchLanguage/constants.ts
@@ -39,6 +39,3 @@ export const DATE_CREATED_FILTER_KEYS = new Set<string>([
 export const NUMERIC_OPERATOR_REGEX = /^([a-zA-Z]+):?(>=|<=|>|<|=)(.*)$/;
 
 export const MEMORY_VALUE_REGEX = /^(\d+(?:\.\d+)?)\s*([A-Za-z]+)$/;
-
-export const MEMORY_UNIT_REGEX = /^(\S+)\s+(\d+(?:\.\d+)?)\s+(\w+?)$/;
-export const CPU_NUMERIC_REGEX = /^(\S+)\s+(.+)$/;

--- a/src/views/search/searchLanguage/filtersToSearchText.ts
+++ b/src/views/search/searchLanguage/filtersToSearchText.ts
@@ -9,10 +9,9 @@ import { FROM_PREFIX, TO_PREFIX } from '@search/utils/dateCreatedValues';
 import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
 
 import {
-  CPU_NUMERIC_REGEX,
   DATE_CREATED_FILTER_KEYS,
   FILTER_TYPE_TO_SEARCH_KEY,
-  MEMORY_UNIT_REGEX,
+  MEMORY_VALUE_REGEX,
   NUMERIC_FILTER_KEYS,
   OPERATOR_TO_SIGN,
 } from './constants';
@@ -22,23 +21,21 @@ const serializeNumericValue = (filterType: string, value: string): null | string
   const searchKey = FILTER_TYPE_TO_SEARCH_KEY.get(filterType);
   if (!searchKey) return null;
 
+  const parts: string[] = value.trim().split(/\s+/);
+  const operatorKey: string = parts[0] ?? '';
+  const sign: string | undefined = OPERATOR_TO_SIGN[operatorKey];
+  if (!sign) return null;
+
   if (filterType === VirtualMachineRowFilterType.Memory) {
-    const match = MEMORY_UNIT_REGEX.exec(value);
-    if (!match) return null;
-    const operatorEnum = match[1] ?? '';
-    const num = match[2] ?? '';
-    const unit = match[3] ?? '';
-    const sign = OPERATOR_TO_SIGN[operatorEnum];
-    if (!sign) return null;
-    return `${searchKey}${sign}${num}${unit}`;
+    if (parts.length !== 3) return null;
+    const numAndUnit = `${parts[1]}${parts[2]}`;
+    if (!MEMORY_VALUE_REGEX.test(numAndUnit)) return null;
+    return `${searchKey}${sign}${numAndUnit}`;
   }
 
-  const cpuMatch = CPU_NUMERIC_REGEX.exec(value);
-  if (!cpuMatch) return null;
-  const operatorEnum = cpuMatch[1] ?? '';
-  const num = cpuMatch[2] ?? '';
-  const sign = OPERATOR_TO_SIGN[operatorEnum];
-  if (!sign) return null;
+  if (parts.length !== 2) return null;
+  const num = parts[1];
+  if (!/^\d+(?:\.\d+)?$/.test(num)) return null;
   return `${searchKey}${sign}${num}`;
 };
 

--- a/src/views/search/searchLanguage/hooks/useSearchValidationToast/useSearchValidationToast.ts
+++ b/src/views/search/searchLanguage/hooks/useSearchValidationToast/useSearchValidationToast.ts
@@ -1,12 +1,14 @@
-/* eslint-disable */
 import { useCallback } from 'react';
 
 import useKubevirtToast from '@kubevirt-utils/hooks/useKubevirtToast';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { InvalidKeyError, InvalidValueError } from '@search/searchLanguage/types';
+import { type InvalidKeyError, type InvalidValueError } from '@search/searchLanguage/types';
 
-const useSearchValidationToast = () => {
+const useSearchValidationToast = (): ((
+  invalidKeyErrors: InvalidKeyError[],
+  invalidValueErrors: InvalidValueError[],
+) => void) => {
   const { t } = useKubevirtTranslation();
   const { addWarningToast } = useKubevirtToast();
 
@@ -20,7 +22,7 @@ const useSearchValidationToast = () => {
       const messages: string[] = [];
 
       for (const { invalidValues, searchKey, validValues } of invalidValueErrors) {
-        const badList = invalidValues.map((v) => `"${v}"`).join(', ');
+        const badList = invalidValues.map((val) => `"${val}"`).join(', ');
         if (isEmpty(validValues)) {
           messages.push(
             t('{{badList}} is not a valid {{searchKey}} value.', { badList, searchKey }),
@@ -45,7 +47,7 @@ const useSearchValidationToast = () => {
         );
       }
 
-      const getTitle = () => {
+      const getTitle = (): string => {
         if (hasInvalidKeys && hasInvalidValues) {
           return t("Some filters couldn't be applied");
         }

--- a/src/views/search/searchLanguage/utils.ts
+++ b/src/views/search/searchLanguage/utils.ts
@@ -1,10 +1,9 @@
-/* eslint-disable */
-import { KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
+import { type KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 import { EXCLUSION_PREFIX } from './constants';
 import { parseSearchToken } from './parser';
-import { TokenParts } from './types';
+import { type TokenParts } from './types';
 
 export const isExcludedToken = (input: string): boolean => input.startsWith(EXCLUSION_PREFIX);
 
@@ -83,4 +82,4 @@ export const isIncompleteToken = (tokenText: string): boolean => {
 export const getFilterDefinition = (
   filterType: string,
   filterDefinitions: KubevirtFilter[],
-): KubevirtFilter | undefined => filterDefinitions.find((d) => d.id === filterType);
+): KubevirtFilter | undefined => filterDefinitions.find((def) => def.id === filterType);

--- a/src/views/search/searchLanguage/validateAndBuildFilterState/numericUtils.ts
+++ b/src/views/search/searchLanguage/validateAndBuildFilterState/numericUtils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { CAPACITY_UNITS } from '@kubevirt-utils/components/CapacityInput/utils';
 import { createCPUQueryValue, createMemoryQueryValue } from '@search/utils/query';
 import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
@@ -7,7 +6,7 @@ import { MEMORY_VALUE_REGEX, SIGN_TO_OPERATOR } from '../constants';
 
 const normalizeMemoryUnit = (unit: string): CAPACITY_UNITS | undefined => {
   const lower = unit.toLowerCase();
-  return Object.values(CAPACITY_UNITS).find((u) => u.toLowerCase() === lower);
+  return Object.values(CAPACITY_UNITS).find((matchedUnit) => matchedUnit.toLowerCase() === lower);
 };
 
 export const formatNumericValue = (
@@ -19,7 +18,7 @@ export const formatNumericValue = (
   if (!operatorEnum) return null;
 
   if (key === VirtualMachineRowFilterType.Memory) {
-    const match = rawValue.match(MEMORY_VALUE_REGEX);
+    const match = MEMORY_VALUE_REGEX.exec(rawValue);
     if (!match) return null;
 
     const [, numStr, unit] = match;

--- a/src/views/search/utils/dateCreatedValues.ts
+++ b/src/views/search/utils/dateCreatedValues.ts
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
 import { yyyyMMddFormat } from '@patternfly/react-core';
 import {
@@ -49,10 +48,10 @@ export const resolveDateCreatedValue = (value: string): { from: string; to?: str
     return { from: getDaysBackDate(1), to: getDaysBackDate(0) };
   }
 
-  const match = lower.match(LAST_N_DAYS_REGEX);
+  const match = LAST_N_DAYS_REGEX.exec(lower);
   if (match) {
-    const n = parseInt(match[1], 10);
-    if (n > 0) return { from: getDaysBackDate(n) };
+    const days = parseInt(match[1], 10);
+    if (days > 0) return { from: getDaysBackDate(days) };
   }
 
   return null;
@@ -63,7 +62,7 @@ export const getDateCreatedChipLabel = (value: string, t: TFunction): string => 
   const label = labels[value as DateSelectOption];
   if (label && value !== DateSelectOption.Custom) return label;
 
-  const match = value.match(LAST_N_DAYS_REGEX);
+  const match = LAST_N_DAYS_REGEX.exec(value);
   if (match) {
     const count = parseInt(match[1], 10);
     return t('Last {{count}} days', { count });

--- a/src/views/templates/actions/components/SelectSourceOption.tsx
+++ b/src/views/templates/actions/components/SelectSourceOption.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC, ReactNode, useCallback } from 'react';
+import React, { type FC, type JSX, type ReactNode, useCallback } from 'react';
 import { useParams } from 'react-router';
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
@@ -9,9 +8,13 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { FormGroup, SelectOption } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import { SOURCE_OPTIONS_IDS, SOURCE_TYPE_LABELS, SOURCE_TYPES } from '../../utils/constants';
+import { type SOURCE_OPTIONS_IDS, SOURCE_TYPE_LABELS, SOURCE_TYPES } from '../../utils/constants';
 
-const getSourceOption = (source: SOURCE_OPTIONS_IDS, ns: string, t: TFunction) => {
+const getSourceOption = (
+  source: SOURCE_OPTIONS_IDS,
+  ns: string,
+  t: TFunction,
+): JSX.Element | undefined => {
   switch (source) {
     case SOURCE_TYPES.defaultSource:
       return (
@@ -54,12 +57,12 @@ const getSourceOption = (source: SOURCE_OPTIONS_IDS, ns: string, t: TFunction) =
     case SOURCE_TYPES.uploadSource:
       return (
         <SelectOption
+          description={t('Upload new file using the "Upload data to PersistentVolumeClaim" page')}
           onClick={() =>
             window
               .open(`/k8s/ns/${ns || DEFAULT_NAMESPACE}/persistentvolumeclaims/~new/data`, '_blank')
               .focus()
           }
-          description={t('Upload new file using the "Upload data to PersistentVolumeClaim" page')}
           value={SOURCE_TYPES.uploadSource}
         >
           {t('Upload (Upload a new file to a PVC)')} <ExternalLinkAltIcon />
@@ -87,7 +90,7 @@ const SelectSourceOption: FC<SelectSourceOptionProps> = ({
   const { ns } = useParams<{ ns: string }>();
 
   const onSelect = useCallback(
-    (_, selection) => {
+    (_event, selection) => {
       if (selection !== SOURCE_TYPES.uploadSource) onSelectSource(selection);
     },
     [onSelectSource],

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRowActions.tsx
@@ -1,5 +1,5 @@
-/* eslint-disable max-lines */
-import React, { type FC, useMemo, useState } from 'react';
+/* eslint-disable */
+import React, { FC, useMemo, useState } from 'react';
 
 import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DiskModal from '@kubevirt-utils/components/DiskModal/DiskModal';

--- a/src/views/virtualmachines/details/tabs/configuration/utils/search.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/utils/search.ts
@@ -4,19 +4,14 @@ import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getInstanceTypeMatcher } from '@kubevirt-utils/resources/vm';
 import { hasS390xArchitecture } from '@kubevirt-utils/resources/vm/utils/architecture';
 
-export type SearchItem = {
-  description?: string;
-  id: string;
-  isDisabled?: boolean;
-  title: string;
-};
+import {
+  type SearchItem,
+  type SearchItemWithTab,
+} from '@kubevirt-utils/components/ConfigurationSearch/types';
+
+export type { SearchItem, SearchItemWithTab } from '@kubevirt-utils/components/ConfigurationSearch/types';
 
 export type SearchItemGetter = (vm?: V1VirtualMachine) => SearchItem[];
-
-export type SearchItemWithTab = {
-  element: SearchItem;
-  tab: string;
-};
 
 export const getDetailsTabBootIds: SearchItemGetter = () => [
   { description: t('Change boot mode'), id: 'boot-mode', title: t('Boot mode') },

--- a/src/views/virtualmachines/list/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/list/VirtualMachinesList.tsx
@@ -9,9 +9,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import usePagination from '@kubevirt-utils/hooks/usePagination/usePagination';
 import useQuery from '@kubevirt-utils/hooks/useQuery';
 import { EXPORT_TABLE_KEYS, KubevirtTableExport } from '@kubevirt-utils/hooks/useTableExport';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { DocumentTitle } from '@openshift-console/dynamic-plugin-sdk';
-import { ListPageBody } from '@openshift-console/dynamic-plugin-sdk';
+import { DocumentTitle, ListPageBody } from '@openshift-console/dynamic-plugin-sdk';
 import { DataViewSortParams } from '@patternfly/react-data-view';
 import { useSignals } from '@preact/signals-react/runtime';
 import { vmsSignal } from '@virtualmachines/tree/utils/signals';
@@ -85,7 +83,7 @@ const VirtualMachinesList: FC<VirtualMachinesListProps> = ({
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
     [vmsSignal.value, namespace, cluster],
   );
-  const hasNoVMs = useMemo(() => isEmpty(allVMsInNamespace), [allVMsInNamespace]);
+  const hasNoVMs = useMemo(() => allVMsInNamespace.length === 0, [allVMsInNamespace]);
 
   const exportButton = (
     <KubevirtTableExport<V1VirtualMachine, VMCallbacks>

--- a/src/views/virtualmachines/wizard/steps/CloneSourceStep/components/VirtualMachinesList/components/VirtualMachineFilter.tsx
+++ b/src/views/virtualmachines/wizard/steps/CloneSourceStep/components/VirtualMachinesList/components/VirtualMachineFilter.tsx
@@ -1,5 +1,5 @@
-import type { FC } from 'react';
-import React from 'react';
+/* eslint-disable */
+import React, { FC } from 'react';
 
 import type { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import KubevirtFilterToolbar from '@kubevirt-utils/components/KubevirtFilterToolbar/KubevirtFilterToolbar';

--- a/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/utils/utils.ts
+++ b/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/utils/utils.ts
@@ -1,35 +1,29 @@
-import { Location } from 'react-router';
+import { type Location } from 'react-router';
 
+import { type SearchItemWithTab } from '@kubevirt-utils/components/ConfigurationSearch/types';
 import { COLON, HASH } from '@kubevirt-utils/constants/constants';
-import { SearchItemWithTab } from '@virtualmachines/details/tabs/configuration/utils/search';
 
-import { TabConfig } from './constants';
+import { type TabConfig } from './constants';
 
-export const getTargetTab = (location: Location<any>) => location.hash?.slice(1); // Remove '#'
+export const getTargetTab = (location: Location): string => location.hash?.slice(1); // Remove '#'
 
 export const getActiveTabFromLocation = (
-  location: Location<any>,
+  location: Location,
   searchItems: SearchItemWithTab[],
   tabs: TabConfig[],
 ): string | undefined => {
   const hash = getTargetTab(location);
-  if (!hash) return;
+  if (!hash) return undefined;
 
   const [tabFromHash, elementId] = hash.includes(COLON) ? hash.split(COLON) : [null, hash];
-  const targetTab = tabFromHash || searchItems.find((item) => item.element.id === elementId)?.tab;
+  const targetTab = tabFromHash ?? searchItems.find((item) => item.element.id === elementId)?.tab;
 
   if (!targetTab || !tabs.some((tab) => tab.name === targetTab)) {
-    return;
+    return undefined;
   }
 
   return targetTab;
 };
 
-// For wizard, we just use hash-based navigation without changing the path
-export const getWizardSearchUrlPath = (
-  tab: string,
-  elementId: string,
-  pathname: string,
-): string => {
-  return `${pathname}${HASH}${tab}${COLON}${elementId}`;
-};
+export const getWizardSearchUrlPath = (tab: string, elementId: string, pathname: string): string =>
+  `${pathname}${HASH}${tab}${COLON}${elementId}`;


### PR DESCRIPTION
## 📝 Description

Adds base-eslint linters to the code base - part-4


## 🔗 Links

https://redhat.atlassian.net/browse/CNV-90382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved numeric search filtering for memory and CPU values, including clearer validation of operators, numbers, and units.
  - Preserved valid empty or zero values across VM, disk, console, and certificate configuration forms.
  - Recent-search update and loading failures are now surfaced with clearer error feedback.
  - Upload-to-registry snapshot errors now surface instead of being silently ignored.

- **Improvements**
  - Improved reliability and consistency across VM, disk, migration, console, and search experiences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->