### PR TITLE
CNV-96320: disable Unpause bulk action when VM list is empty

### DIFF
--- a/src/views/virtualmachines/actions/bulkLifecycleActionConfigs.tsx
+++ b/src/views/virtualmachines/actions/bulkLifecycleActionConfigs.tsx
@@ -85,7 +85,7 @@ export const createUnpauseConfig =
     cta: (): void => {
       for (const vm of vms) void unpauseVM(vm);
     },
-    disabled: !vms.every((vm) => vm.status?.printableStatus === Paused),
+    disabled: isEmpty(vms) || !vms.every((vm) => vm.status?.printableStatus === Paused),
     id: BULK_ACTIONS_ID.UNPAUSE,
     label: t('Unpause'),
   });


### PR DESCRIPTION
## 📝 Description

Fixes the Manage all VMs → Control → Unpause action staying enabled on empty projects and folders.

For an empty VM list, `vms.every(...)` is vacuously true, so Unpause was incorrectly enabled while Start and Stop already used `isEmpty(vms)`. Unpause now follows the same empty-list guard.

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-96320

## 🎥 Demo

Before: Right-click an empty project/folder → Manage all VMs → Control → Unpause is enabled (click is a no-op).

<img width="1913" height="1087" alt="Screenshot 2026-09-03 at 17 34 19" src="https://github.com/user-attachments/assets/aeb29292-1e2e-4bf5-97cb-c8dd11628624" />


After: Unpause is disabled when there are no VMs in the scope.

<img width="1913" height="1087" alt="Screenshot 2026-09-03 at 17 32 40" src="https://github.com/user-attachments/assets/3617a971-c53d-467a-9c3d-9136537d41e6" />

