### PR TITLE
CNV-96431: VirtualMachines page crashes when the guided tour is running - add e2e for guided tour

### DIFF
--- a/playwright/tests/tier1/create-vm/create-vm-wizard-default-ssh-windows.spec.md
+++ b/playwright/tests/tier1/create-vm/create-vm-wizard-default-ssh-windows.spec.md
@@ -88,5 +88,5 @@ a planned coverage gap (status: Pending).
 ## 6. Approvals
 
 - **Prepared By:** Test automation / QE
-- **Reviewed By:** **\*\*\*\***\_\_**\*\*\*\***
-- **Approval Signature:** **\*\*\*\***\_\_**\*\*\*\***
+- **Reviewed By:** Batya Nahmias
+- **Approval Signature:** Batya Nahmias

--- a/playwright/tests/tier2/welcome-modal/utils/utils.ts
+++ b/playwright/tests/tier2/welcome-modal/utils/utils.ts
@@ -14,6 +14,7 @@ const TOUR_STEP_COUNTER_LOCATOR = '[data-test="tour-step-counter"]';
 const TOUR_HEADER_LOCATOR = '[data-test="tour-popover-header"]';
 const TOUR_NEXT_BUTTON_LOCATOR = '[data-test="tour-next-btn"]';
 const TOUR_STEPS_COUNT = 8;
+const TOUR_GUIDE_VM_NAME = 'rhel9-tour-guide';
 
 export const verifyWelcomeModalVisibility = async (
   page: Page,
@@ -65,7 +66,9 @@ export const getTourTotalSteps = async (page: Page): Promise<number> => {
 export const enterVirtualMachinesPage = async (page: Page, nav: NavigationComponent) => {
   await nav.clickNavVirtualMachines();
   await page.waitForLoadState('load');
-  await verifyWelcomeModalVisibility(page, true, TestTimeouts.SHORT_WAIT);
+  await page.reload({ waitUntil: 'load' });
+  await page.waitForLoadState('load');
+  await verifyWelcomeModalVisibility(page, true, TestTimeouts.DEFAULT);
 };
 
 export const checkIfModalIsVisibleAfterCheckboxClick = async (page: Page) => {
@@ -87,6 +90,52 @@ export const checkIfModalIsVisibleAfterCheckboxClick = async (page: Page) => {
   ).not.toBeNull();
 
   await verifyWelcomeModalVisibility(page, true);
+};
+
+export const assertVirtualMachinesUsableDuringTour = async (page: Page) => {
+  await page
+    .locator('[data-test="tour-popover"]')
+    .waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+
+  const crashed = await page
+    .getByTestId('error-boundary')
+    .or(page.locator('text=Something wrong happened'))
+    .first()
+    .isVisible({ timeout: TestTimeouts.UI_STABILIZE })
+    .catch(() => false);
+  expect(
+    crashed,
+    'VirtualMachines should not show an error boundary while the tour is running',
+  ).toBe(false);
+
+  expect(
+    await page.locator('.pf-v6-c-tree-view').isVisible(),
+    'VM tree should be visible during the tour',
+  ).toBe(true);
+
+  await expect
+    .poll(
+      () =>
+        page
+          .locator('.pf-v6-c-tree-view__node')
+          .filter({ hasText: TOUR_GUIDE_VM_NAME })
+          .isVisible()
+          .catch(() => false),
+      {
+        message: `Tour guide VM ${TOUR_GUIDE_VM_NAME} should appear in the tree`,
+        timeout: TestTimeouts.ELEMENT_WAIT,
+      },
+    )
+    .toBe(true);
+
+  expect(
+    await page.getByTestId('overview-tab').isVisible(),
+    'Overview tab should be present during the tour',
+  ).toBe(true);
+  expect(
+    await page.getByTestId('vm-list-tab').isVisible(),
+    'Virtual machines tab should be present during the tour',
+  ).toBe(true);
 };
 
 export const tourStepsTest = async (page: Page) => {

--- a/playwright/tests/tier2/welcome-modal/welcome-modal.spec.md
+++ b/playwright/tests/tier2/welcome-modal/welcome-modal.spec.md
@@ -1,0 +1,83 @@
+# Software Test Description (STD): Welcome Modal / Guided Tour
+
+## 1. Project Overview
+
+- **Project Name:** KubeVirt UI — Playwright E2E Tests
+- **Feature Area:** Tier2 — Welcome modal / guided tour
+- **Latest version:** CNV 5.1.0
+- **Latest update:** 2026-09-03
+- **Document Status:** Approved
+
+## 2. Introduction
+
+### 2.1 Purpose
+
+Verify the Virtualization welcome modal dismiss flow, that starting the guided tour walks all
+steps in order, and that VirtualMachines (tree and navigator tabs) stays usable while the tour
+runs.
+
+### 2.2 Scope
+
+- **In-Scope:** Welcome modal visibility, Start tour, tour step sequence, VirtualMachines error
+  boundary absence during the tour, VM tree with the tour-guide VM (`rhel9-tour-guide`), Overview
+  and Virtual machines tabs, "Do not show again" checkbox, and modal close.
+- **Out-of-Scope:** Starting the tour from Settings → Getting started → Guided tour.
+
+## 3. Test Environment & Prerequisites
+
+- **Environment:** OpenShift with CNV operator installed; Playwright `Tier2` project.
+- **Configuration:** No special feature gates required.
+- **Initial Setup:** `resetUserSettings` via `apiClient` so `dontShowWelcomeModal` is false. No extra
+  namespaces or VMs are created; the tour injects the dummy `rhel9-tour-guide` VM into the tree.
+
+---
+
+## 4. Test Case Definitions
+
+**Spec file:** `tests/tier2/welcome-modal/welcome-modal.spec.ts`
+**Describe:** `Welcome Modal` — **Tags:** `@tier2`, `@tier2-welcome-modal`
+**Allure:** suite `Welcome Modal`, feature `Tier 2`
+
+---
+
+### `001`: Welcome modal dismiss flow and VirtualMachines stays usable during the tour
+
+- **Objective:** Verify the welcome modal can start the guided tour without crashing VirtualMachines,
+  that all tour steps display in order, and that checking "Do not show again" then closing the modal
+  prevents it from returning.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-96348
+- **Pre-conditions:** User settings are reset so the welcome modal is shown on VirtualMachines.
+- **Tags:** `@tier2`, `@tier2-welcome-modal`
+
+| Step | Action                                                      | Expected Result                                                                                         |
+| :--- | :---------------------------------------------------------- | :------------------------------------------------------------------------------------------------------ |
+| 1    | Navigate to VirtualMachines                                 | Welcome modal is visible                                                                                |
+| 2    | Click Start tour                                            | Tour popover is visible                                                                                 |
+| 3    | Assert crash state, tree, tour-guide VM, and navigator tabs | No error boundary; tree visible; `rhel9-tour-guide` in tree; Overview and Virtual machines tabs present |
+| 4    | Advance through all tour steps                              | All eight step titles display in order                                                                  |
+| 5    | Reload VirtualMachines and check "Do not show again"        | Welcome modal remounts; user settings are patched; modal stays open                                     |
+| 6    | Close the modal and reload                                  | Welcome modal and onboarding popovers are not shown                                                     |
+
+---
+
+## 5. Requirements Traceability Matrix
+
+Maps Jira tickets to the test cases that provide coverage. Tickets without a specific test case indicate
+a planned coverage gap (status: Pending).
+
+| Jira Ticket | Test Case ID | Coverage Type           | Status    |
+| ----------- | ------------ | ----------------------- | --------- |
+| CNV-96348   | `001`        | Bugfix regression guard | Automated |
+
+**Coverage Type values:**
+
+- `Feature coverage` — test validates a feature delivered by the ticket
+- `Bugfix regression guard` — test asserts the specific bug fixed by the ticket does not regress
+- `Functional smoke` — test validates baseline behavior; no specific Jira ticket drives it
+
+## 6. Approvals
+
+- **Prepared By:** Test automation / QE
+- **Reviewed By:** Gal Kremer
+- **Approval Signature:** Gal Kremer

--- a/playwright/tests/tier2/welcome-modal/welcome-modal.spec.ts
+++ b/playwright/tests/tier2/welcome-modal/welcome-modal.spec.ts
@@ -3,6 +3,7 @@ import { T2, T2_TAG } from '@/data-models/allure-constants';
 import { expect, test } from '@/fixtures/scenario-test-fixture';
 import { TestTimeouts } from '@/utils/test-config';
 import {
+  assertVirtualMachinesUsableDuringTour,
   checkIfModalIsVisibleAfterCheckboxClick,
   CLOSE_BUTTON_LOCATOR,
   enterVirtualMachinesPage,
@@ -38,6 +39,7 @@ test.describe('Welcome Modal', { tag: [T2_TAG, '@tier2-welcome-modal'] }, () => 
 
       await page.getByTestId('start-tour-btn').click();
 
+      await assertVirtualMachinesUsableDuringTour(page);
       await tourStepsTest(page);
 
       // Dismiss onboarding popover if it appeared after tour ended


### PR DESCRIPTION
# 📝 Description

E2E tests for https://github.com/kubevirt-ui/kubevirt-plugin/pull/4622

## 🔗 Links

Jira ticket: [CNV-96431](https://redhat.atlassian.net/browse/CNV-96431)

## 🎥 Demo

Tested locally. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded guided-tour coverage to verify that virtual machines remain usable throughout the welcome experience.
  - Added checks for tour prompts, error-free rendering, the virtual machine tree, the tour-guide VM, and navigation between the Overview and Virtual machines tabs.
  - Added validation of the guided tour’s step sequence.

- **Documentation**
  - Added detailed coverage documentation for the welcome modal and guided-tour workflow, including prerequisites, test scope, workflow steps, and traceability information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->