### PR TITLE
[release-4.21] CNV-96600: Support MCOA ClusterManagementAddOn for fleet observability

### DIFF
--- a/src/utils/hooks/useAlerts/utils/useMCOInstalled.ts
+++ b/src/utils/hooks/useAlerts/utils/useMCOInstalled.ts
@@ -1,11 +1,15 @@
 import { TFunction } from 'react-i18next';
 
-import { MultiClusterObservabilityModel } from '@kubevirt-utils/models';
+import { isObservabilityCMA } from '@kubevirt-utils/hooks/useVirtualizationObservabilityLink/utils';
+import {
+  ClusterManagementAddOnModel,
+  modelToGroupVersionKind,
+  MultiClusterObservabilityModel,
+} from '@kubevirt-utils/models';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
 export const getMCONotInstalledTooltip = (t: TFunction): string =>
   t(
@@ -23,20 +27,26 @@ type UseMCOInstalledResult = {
  * MCO is required for fleet-wide Prometheus metrics polling.
  * When MCO is not installed, only the hub cluster should be shown and spoke clusters
  * should be disabled with a tooltip.
+ *
+ * Detection accepts either a MultiClusterObservability CR or a matching
+ * ClusterManagementAddOn (legacy observability-controller or MCOA).
  */
 export const useMCOInstalled = (): UseMCOInstalledResult => {
   const isACMPage = useIsACMPage();
-  const [hubClusterName] = useHubClusterName();
 
-  const [mcoResource, loaded, error] = useK8sWatchData<K8sResourceCommon[]>(
+  const [mcoResource, mcoLoaded, mcoError] = useK8sWatchData<K8sResourceCommon[]>(
     isACMPage
       ? {
-          cluster: hubClusterName,
-          groupVersionKind: {
-            group: MultiClusterObservabilityModel.apiGroup,
-            kind: MultiClusterObservabilityModel.kind,
-            version: MultiClusterObservabilityModel.apiVersion,
-          },
+          groupVersionKind: modelToGroupVersionKind(MultiClusterObservabilityModel),
+          isList: true,
+        }
+      : null,
+  );
+
+  const [observabilityAddOns, cmaLoaded, cmaError] = useK8sWatchData<K8sResourceCommon[]>(
+    isACMPage
+      ? {
+          groupVersionKind: modelToGroupVersionKind(ClusterManagementAddOnModel),
           isList: true,
         }
       : null,
@@ -49,11 +59,13 @@ export const useMCOInstalled = (): UseMCOInstalledResult => {
       mcoInstalled: true,
     };
   }
-  const mcoInstalled = !isEmpty(mcoResource);
+
+  const hasObservabilityCMA = observabilityAddOns?.some(isObservabilityCMA);
+  const mcoInstalled = !isEmpty(mcoResource) || Boolean(hasObservabilityCMA);
 
   return {
-    error,
-    loaded,
+    error: mcoError || cmaError,
+    loaded: mcoLoaded && cmaLoaded,
     mcoInstalled,
   };
 };

--- a/src/utils/hooks/useVirtualizationObservabilityLink/constants.ts
+++ b/src/utils/hooks/useVirtualizationObservabilityLink/constants.ts
@@ -3,8 +3,14 @@ export const VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAME =
 
 export const VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAMESPACE =
   'open-cluster-management-observability';
+const OBSERVABILITY_CONTROLLER_NAME = 'observability-controller';
 
-export const OBSERVABILITY_CONTROLLER_NAME = 'observability-controller';
+const MULTICLUSTER_OBSERVABILITY_ADDON_NAME = 'multicluster-observability-addon';
+
+export const OBSERVABILITY_CMA_NAMES = [
+  OBSERVABILITY_CONTROLLER_NAME,
+  MULTICLUSTER_OBSERVABILITY_ADDON_NAME,
+] as const;
 
 export const VIRTUALIZATION_OBSERVABILITY_DASHBOARD_JSON_NAME =
   'acm-openshift-virtualization-clusters-overview.json';

--- a/src/utils/hooks/useVirtualizationObservabilityLink/useVirtualizationObservabilityLink.ts
+++ b/src/utils/hooks/useVirtualizationObservabilityLink/useVirtualizationObservabilityLink.ts
@@ -6,40 +6,51 @@ import {
 } from '@kubevirt-utils/models';
 import { getAnnotation } from '@kubevirt-utils/resources/shared';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 import {
-  OBSERVABILITY_CONTROLLER_NAME,
   VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAME,
   VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAMESPACE,
   VIRTUALIZATION_OBSERVABILITY_DASHBOARD_ANNOTATION,
   VIRTUALIZATION_OBSERVABILITY_DASHBOARD_JSON_NAME,
 } from './constants';
+import { isObservabilityCMA, parseDashboardData } from './utils';
 
-export const useVirtualizationObservabilityLink = () => {
+export const useVirtualizationObservabilityLink = (): null | string => {
   const [virtObservabilityConfigMap] = useK8sWatchData<IoK8sApiCoreV1ConfigMap>({
     groupVersionKind: modelToGroupVersionKind(ConfigMapModel),
     name: VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAME,
     namespace: VIRTUALIZATION_OBSERVABILITY_CONFIG_MAP_NAMESPACE,
   });
 
-  const [observabilityController] = useK8sWatchData({
+  const [observabilityAddOns] = useK8sWatchData<K8sResourceCommon[]>({
     groupVersionKind: modelToGroupVersionKind(ClusterManagementAddOnModel),
-    name: OBSERVABILITY_CONTROLLER_NAME,
+    isList: true,
   });
 
-  const parsedDashboardData = JSON.parse(
-    virtObservabilityConfigMap?.data?.[VIRTUALIZATION_OBSERVABILITY_DASHBOARD_JSON_NAME] || '{}',
+  const observabilityAddon = observabilityAddOns?.find(
+    (addon) =>
+      isObservabilityCMA(addon) &&
+      getAnnotation(addon, VIRTUALIZATION_OBSERVABILITY_DASHBOARD_ANNOTATION),
   );
 
-  const dashboardId = parsedDashboardData?.uid;
+  const parsedDashboardData = parseDashboardData(
+    virtObservabilityConfigMap?.data?.[VIRTUALIZATION_OBSERVABILITY_DASHBOARD_JSON_NAME],
+  );
+
+  const dashboardId = parsedDashboardData.uid;
 
   const grafanaLink = getAnnotation(
-    observabilityController,
+    observabilityAddon,
     VIRTUALIZATION_OBSERVABILITY_DASHBOARD_ANNOTATION,
   );
 
   if (!grafanaLink || !dashboardId) return null;
 
-  const grafanaOrigin = new URL(grafanaLink).origin;
-  return `${grafanaOrigin}/d/${dashboardId}/executive-dashboards-clusters-overview?orgId=1`;
+  try {
+    const grafanaOrigin = new URL(grafanaLink).origin;
+    return `${grafanaOrigin}/d/${dashboardId}/executive-dashboards-clusters-overview?orgId=1`;
+  } catch {
+    return null;
+  }
 };

--- a/src/utils/hooks/useVirtualizationObservabilityLink/utils.ts
+++ b/src/utils/hooks/useVirtualizationObservabilityLink/utils.ts
@@ -1,0 +1,27 @@
+import { getName } from '@kubevirt-utils/resources/shared';
+import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+
+import { OBSERVABILITY_CMA_NAMES } from './constants';
+
+type GrafanaDashboardData = {
+  uid?: string;
+};
+
+export const isObservabilityCMA = (addon: K8sResourceCommon): boolean => {
+  const name = getName(addon);
+  return Boolean(name && (OBSERVABILITY_CMA_NAMES as readonly string[]).includes(name));
+};
+
+export const parseDashboardData = (raw: string | undefined): GrafanaDashboardData => {
+  try {
+    const parsed: unknown = JSON.parse(raw ?? '{}');
+    if (typeof parsed !== 'object' || parsed === null) {
+      return {};
+    }
+
+    const uid = (parsed as { uid?: unknown }).uid;
+    return typeof uid === 'string' ? { uid } : {};
+  } catch {
+    return {};
+  }
+};

--- a/src/utils/models/index.ts
+++ b/src/utils/models/index.ts
@@ -62,7 +62,7 @@ export const ClusterManagementAddOnModel: K8sModel = {
   kind: 'ClusterManagementAddOn',
   label: 'ClusterManagementAddOn',
   labelPlural: 'ClusterManagementAddOns',
-  namespaced: true,
+  namespaced: false,
   plural: 'clustermanagementaddons',
 };
 


### PR DESCRIPTION
## Summary

- Backport of #4630 to `release-4.21`
- Accept both legacy `observability-controller` and MCOA's `multicluster-observability-addon` when resolving Grafana launch links and detecting multicluster observability
- Mark `ClusterManagementAddOn` as cluster-scoped so watches resolve correctly

## Test plan

- [ ] Verify Grafana launch link resolves when MCOA (`multicluster-observability-addon`) is installed instead of legacy observability-controller
- [ ] Verify MCO detection works for both MultiClusterObservability CR and ClusterManagementAddOn
- [ ] Verify no regression when legacy observability-controller is installed


Made with [Cursor](https://cursor.com)