### PR TITLE
[release-4.21] CNV-96280: Fix memory swap traffic unit conversion in Top Consumers

### DIFF
--- a/src/views/clusteroverview/TopConsumersTab/utils/utils.ts
+++ b/src/views/clusteroverview/TopConsumersTab/utils/utils.ts
@@ -23,7 +23,7 @@ export const humanizeTopConsumerMetric = (value: number, metric: TopConsumerMetr
       humanizedValue = humanizeBinaryBytes(value, 'B', 'GiB');
       break;
     case TopConsumerMetric.MEMORY_SWAP_TRAFFIC:
-      humanizedValue = humanizeDecimalBytes(value, 'MB');
+      humanizedValue = humanizeDecimalBytes(value, 'B');
       break;
     case TopConsumerMetric.VCPU_WAIT:
       humanizedValue = humanizeSeconds(value, 's', 'ms');


### PR DESCRIPTION
## 📝 Description

Fixes [CNV-96280](https://issues.redhat.com/browse/CNV-96280).

In the Virtualization Overview **Top Consumers** tab, the **Memory swap traffic** metric was displayed up to 1,000,000x too high (e.g. 37 TB instead of 37 MB).

Prometheus metrics `kubevirt_vmi_memory_swap_in_traffic_bytes` and `kubevirt_vmi_memory_swap_out_traffic_bytes` return values in bytes, but `humanizeTopConsumerMetric` passed `'MB'` as the initial unit to `humanizeDecimalBytes`, causing the formatter to treat byte values as already being in megabytes.

This change passes `'B'` as the initial unit so swap traffic is humanized correctly.

## 🎥 Demo

**BEFORE**

<img width="578" height="435" alt="Screenshot 2026-09-04 at 14 59 43" src="https://github.com/user-attachments/assets/4c5d3c91-5ace-48e0-8c56-35d07daa806d" />


**AFTER**
<img width="1913" height="1087" alt="Screenshot 2026-09-04 at 15 01 24" src="https://github.com/user-attachments/assets/f0713d49-795d-4059-999f-e49aa939f9d4" />


```
rate(kubevirt_vmi_memory_swap_in_traffic_bytes{name="<vm-name>"}[5m])
```

## Test plan

- [ ] Open Virtualization → Overview → Top Consumers
- [ ] Select **Memory swap traffic** as the metric
- [ ] Confirm displayed values match raw Prometheus byte/sec results (no 1,000,000x inflation)

Made with [Cursor](https://cursor.com)