### PR TITLE
CNV-95929: Fix registry import DataImportCron managedDataSource mismatch

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/bootableVolumeSources.ts
+++ b/src/utils/components/AddBootableVolumeModal/bootableVolumeSources.ts
@@ -289,7 +289,6 @@ export const createDataSourceWithImportCron: CreateDataSourceWithImportCronType 
 ) => {
   const {
     bootableVolumeCluster,
-    bootableVolumeName,
     cronExpression,
     registryCredentials,
     registryURL,
@@ -298,11 +297,12 @@ export const createDataSourceWithImportCron: CreateDataSourceWithImportCronType 
     storageClassName,
   } = bootableVolume;
 
+  const dataSourceName = getName(initialDataSource);
   const targetNamespace = getNamespace(initialDataSource);
   const { password, username } = registryCredentials || {};
   const addRegistrySecret = !!(username && password);
   const imageSecretName = addRegistrySecret
-    ? truncateToK8sName(bootableVolumeName, `registry-secret-${getRandomChars()}`)
+    ? truncateToK8sName(dataSourceName, `registry-secret-${getRandomChars()}`)
     : null;
 
   if (addRegistrySecret) {
@@ -322,7 +322,7 @@ export const createDataSourceWithImportCron: CreateDataSourceWithImportCronType 
   }
 
   const dataImportCronName = truncateToK8sName(
-    bootableVolumeName,
+    dataSourceName,
     `import-cron-${getRandomChars()}`,
   );
 
@@ -332,7 +332,7 @@ export const createDataSourceWithImportCron: CreateDataSourceWithImportCronType 
     draft.spec = {
       garbageCollect: 'Outdated',
       importsToKeep: retainRevisions,
-      managedDataSource: bootableVolumeName,
+      managedDataSource: dataSourceName,
       schedule: cronExpression,
       template: {
         spec: {


### PR DESCRIPTION
## Summary

Fixes [CNV-95929](https://redhat.atlassian.net/browse/CNV-95929): when importing a bootable volume from a registry with scheduling enabled, the import could succeed but the volume would not appear in the Bootable volumes list.

When one or more architectures are selected in the Add volume form, the UI creates a **DataSource** and a **DataImportCron** for each architecture. To keep those resources unique, each DataSource is named with an architecture suffix: `${bootableVolumeName}-${architecture}` (for example, `rhel9gm-amd64`). In this flow, `bootableVolumeName` is only the prefix entered in the form — it is not the final Kubernetes resource name.

The bug was that `createDataSourceWithImportCron` set `DataImportCron.spec.managedDataSource` to the base `bootableVolumeName` instead of the actual DataSource name. Because of that mismatch, CDI managed a different DataSource than the one the UI created. The UI created the labeled DataSource (e.g. `rhel9gm-amd64`), but the DataImportCron pointed at the base name (e.g. `rhel9gm`). CDI then created and managed that second DataSource on its own, with the imported PVC attached to it but without the bootable-volume labels. The UI-created DataSource stayed Not Ready with no source PVC.

This change links each DataImportCron to the correct DataSource by using `getName(initialDataSource)` for `managedDataSource` and for all related resource naming in this flow.

## Test plan

- [ ] Bootable volumes → Add volume → With form → Content from container registry
- [ ] Select one or more architectures in Volume metadata
- [ ] Fill scheduling settings (cron expression, retain revisions) and submit
- [ ] Verify only one DataSource per architecture exists, with correct labels
- [ ] Verify `DataImportCron.spec.managedDataSource` matches the DataSource name (including `-<architecture>` suffix)
- [ ] Confirm the volume appears in the Bootable volumes list after import completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected imported bootable volume configuration to consistently use the intended data source name for registry secrets, import schedules, and managed data source references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->