### PR TITLE
CNV-96404: Edit hostname modal- invalid hostname error doesn't propagated when clicking Enter on keyboard 

### DIFF
--- a/src/utils/components/HostnameModal/HostnameModal.tsx
+++ b/src/utils/components/HostnameModal/HostnameModal.tsx
@@ -1,4 +1,5 @@
-import React, { type FC, useMemo, useState } from 'react';
+import React, { type FC, useCallback } from 'react';
+import { Controller, useForm, useWatch } from 'react-hook-form';
 import produce from 'immer';
 
 import {
@@ -10,7 +11,11 @@ import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getHostname } from '@kubevirt-utils/resources/vm';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
-import { getNameValidationMessage } from '@kubevirt-utils/utils/validation';
+import {
+  getDNS1123LabelError,
+  getDNS1123LabelErrorLenient,
+  getFieldRequiredMessage,
+} from '@kubevirt-utils/utils/validation';
 import { FormGroup, TextInput, ValidatedOptions } from '@patternfly/react-core';
 
 import FormGroupHelperText from '../FormGroupHelperText/FormGroupHelperText';
@@ -23,44 +28,78 @@ type HostnameModalProps = {
   vmi?: V1VirtualMachineInstance;
 };
 
+type HostnameFormValues = {
+  hostname: string;
+};
+
 const HostnameModal: FC<HostnameModalProps> = ({ isOpen, onClose, onSubmit, vm, vmi }) => {
   const { t } = useKubevirtTranslation();
-  const [newHostname, setNewHostname] = useState<string>(() => getHostname(vm));
-  const [isTouched, setIsTouched] = useState(false);
+  const {
+    control,
+    formState: { errors, isDirty, isSubmitted, touchedFields },
+    handleSubmit: submitForm,
+  } = useForm<HostnameFormValues>({
+    defaultValues: { hostname: getHostname(vm) ?? '' },
+    mode: 'onTouched',
+  });
 
-  const hostnameError = getNameValidationMessage(t, newHostname);
-  const isHostnameInvalid = isTouched && !!hostnameError;
+  const newHostname = useWatch({ control, name: 'hostname' });
 
-  const updatedVirtualMachine = useMemo(() => {
-    const updatedVM = produce<V1VirtualMachine>(vm, (vmDraft: V1VirtualMachine) => {
-      ensurePath(vmDraft, ['spec.template.spec']);
-      vmDraft.spec.template.spec.hostname = newHostname || undefined;
-    });
-    return updatedVM;
-  }, [vm, newHostname]);
+  const lenientHostnameError = isDirty ? getDNS1123LabelErrorLenient(newHostname)?.(t) : undefined;
+
+  // RHF always validates strictly - only the displayed error is lenient before blur or submit.
+  const hostnameError =
+    touchedFields.hostname || isSubmitted ? errors.hostname?.message : lenientHostnameError;
+
+  const handleSubmit = useCallback(
+    () =>
+      submitForm(async ({ hostname }) => {
+        const updatedVM = produce<V1VirtualMachine>(vm, (vmDraft: V1VirtualMachine) => {
+          ensurePath(vmDraft, ['spec.template.spec']);
+
+          vmDraft.spec.template.spec.hostname = hostname;
+        });
+
+        await onSubmit(updatedVM);
+        onClose();
+      })(),
+    [onClose, onSubmit, submitForm, vm],
+  );
+
   return (
     <TabModal
+      closeOnSubmit={false}
       headerText={t('Edit hostname')}
-      isDisabled={!!getNameValidationMessage(t, newHostname)}
+      isDisabled={!!hostnameError}
       isOpen={isOpen}
-      obj={updatedVirtualMachine}
       onClose={onClose}
-      onSubmit={onSubmit}
+      onSubmit={handleSubmit}
       shouldWrapInForm
     >
       {vmi && <ModalPendingChangesAlert />}
+
       <FormGroup fieldId="hostname" isRequired label={t('Hostname')}>
-        <TextInput
-          autoFocus
-          id="hostname"
-          onBlur={() => setIsTouched(true)}
-          onChange={(_event, val) => setNewHostname(val)}
-          type="text"
-          validated={isHostnameInvalid ? ValidatedOptions.error : ValidatedOptions.default}
-          value={newHostname}
+        <Controller
+          control={control}
+          name="hostname"
+          render={({ field }) => (
+            <TextInput
+              {...field}
+              autoFocus
+              id="hostname"
+              onChange={(_event, value) => field.onChange(value)}
+              type="text"
+              validated={hostnameError ? ValidatedOptions.error : ValidatedOptions.default}
+            />
+          )}
+          rules={{
+            required: getFieldRequiredMessage(t),
+            validate: (value) => getDNS1123LabelError(value)?.(t),
+          }}
         />
-        <FormGroupHelperText validated={isHostnameInvalid ? ValidatedOptions.error : undefined}>
-          {isHostnameInvalid ? hostnameError : t('Please provide hostname.')}
+
+        <FormGroupHelperText validated={hostnameError ? ValidatedOptions.error : undefined}>
+          {hostnameError ?? t('Please provide hostname.')}
         </FormGroupHelperText>
       </FormGroup>
     </TabModal>

--- a/src/utils/utils/validation.test.ts
+++ b/src/utils/utils/validation.test.ts
@@ -5,7 +5,6 @@ import {
   getDNS1123LabelError,
   getDNS1123LabelErrorLenient,
   getFieldRequiredMessage,
-  getNameValidationMessage,
   isDigitsOnly,
   isDNS1123Label,
   isDNS1123LabelLenient,
@@ -103,21 +102,6 @@ describe('validateDNS1123Label', () => {
 describe('getFieldRequiredMessage', () => {
   it('should return the required field message', () => {
     expect(getFieldRequiredMessage(t)).toBe('This field is required');
-  });
-});
-
-describe('getNameValidationMessage', () => {
-  it('should return the required message for an empty value', () => {
-    expect(getNameValidationMessage(t, '')).toBe('This field is required');
-    expect(getNameValidationMessage(t, '   ')).toBe('This field is required');
-  });
-
-  it('should return the format error for an invalid non-empty value', () => {
-    expect(getNameValidationMessage(t, 'My_VM')).toContain('lowercase RFC 1123 label');
-  });
-
-  it('should return undefined for a valid value', () => {
-    expect(getNameValidationMessage(t, 'my-vm')).toBeUndefined();
   });
 });
 

--- a/src/utils/utils/validation.ts
+++ b/src/utils/utils/validation.ts
@@ -33,7 +33,9 @@ export const getDNS1123LabelError = (value: string): ((t: TFunction) => string) 
 
 // Tolerates a trailing '-' since the user is likely still typing (e.g. "my-vm-").
 // A leading '-' is still rejected because it's never valid.
-export const getDNS1123LabelErrorLenient = (value: string): ((t: TFunction) => string) => {
+export const getDNS1123LabelErrorLenient = (
+  value: string,
+): ((t: TFunction) => string) | undefined => {
   const error = getDNS1123LabelError(value);
   if (
     error &&
@@ -55,18 +57,6 @@ export const validateDNS1123Label = (t: TFunction, value: string): string | unde
 };
 
 export const getFieldRequiredMessage = (t: TFunction): string => t('This field is required');
-
-/**
- * Validates a required DNS-1123 name field (trims whitespace before format validation).
- * @param t
- * @param value
- */
-export const getNameValidationMessage = (t: TFunction, value: string): string | undefined => {
-  if (!value?.trim()) {
-    return getFieldRequiredMessage(t);
-  }
-  return validateDNS1123Label(t, value);
-};
 
 export const isDigitsOnly = (value: string): boolean => /^\d+$/.test(value);
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Fixes flaky validation within hostname modal by refactoring the modal to use react hook form and to have soft and strict validation in the modal UI. Strict validation is always applied but displayed only after form submission or input blur.

Added empty value validation message to getDNS1123LabelError to distinguish between empty and invalid value and therefore to communicate correct error message to user.

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-96404

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/b273a065-4c20-4374-a171-5d01cf2a3b52

After:

https://github.com/user-attachments/assets/8fcd988f-d4b1-49dc-8628-fe15b82bb8e9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved hostname validation in the hostname editor using DNS-compliant rules.
- Empty or whitespace-only hostnames now display a required-field error.
- Validation messaging is less intrusive while users enter a hostname and becomes stricter on submission.
- Hostname changes are applied only after successful form submission, with the modal closing afterward.
- Empty submissions now preserve the submitted hostname value rather than clearing it unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->