### PR TITLE
CNV-87425: skip template-from-VM gating test until CNV 4.22+

### DIFF
--- a/playwright/src/components/vm/vm-list-template-create-component.ts
+++ b/playwright/src/components/vm/vm-list-template-create-component.ts
@@ -1,10 +1,10 @@
 import BaseComponent from '@/components/shared/base-component';
 import { TestTimeouts } from '@/utils/test-config';
-import type { Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 
 /** VM list split Create control, template quick-create form, and catalog navigation from the list page. */
 export default class VmListTemplateCreateComponent extends BaseComponent {
-  private readonly _createButton = this.testId('item-create');
+  private readonly _pageHeaderCreateButton = this.testId('page-heading').getByTestId('item-create');
   private readonly _quickCreateVmButton = this.testId('quick-create-vm-btn');
   private readonly _roleMenuitem = this.locator('[role="menuitem"]');
   private readonly _startAfterCreateCheckbox = this.locator('#start-after-create-checkbox');
@@ -39,9 +39,19 @@ export default class VmListTemplateCreateComponent extends BaseComponent {
   ): Promise<void> {
     switch (option) {
       case 'With YAML': {
-        await this.robustClick(this._createButton);
-        await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
-        await this.robustClick(this.locator('button[role="menuitem"]:has-text("With YAML")'));
+        await this._pageHeaderCreateButton.waitFor({
+          state: 'visible',
+          timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+        });
+        await expect(this._pageHeaderCreateButton).toBeEnabled({
+          timeout: TestTimeouts.UI_ACTION_COMPLETE,
+        });
+
+        await this.robustClick(this._pageHeaderCreateButton);
+
+        const yamlOption = this.page.getByRole('menuitem', { name: 'With YAML' });
+        await yamlOption.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ACTION_COMPLETE });
+        await this.robustClick(yamlOption);
         break;
       }
       case 'From template': {
@@ -66,9 +76,14 @@ export default class VmListTemplateCreateComponent extends BaseComponent {
 
   async getCreateSplitButtonDropdownOptions(): Promise<string[]> {
     try {
-      const toggle = this.testId('item-create');
-      await this.robustClick(toggle);
-      await this.page.waitForTimeout(TestTimeouts.UI_DELAY_SHORT);
+      await this._pageHeaderCreateButton.waitFor({
+        state: 'visible',
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await expect(this._pageHeaderCreateButton).toBeEnabled({
+        timeout: TestTimeouts.UI_ACTION_COMPLETE,
+      });
+      await this.robustClick(this._pageHeaderCreateButton);
       const items = this._roleMenuitem;
       const texts = await items.allTextContents();
       await this.page.keyboard.press('Escape');

--- a/playwright/tests/gating/scenario-resource-creation.spec.ts
+++ b/playwright/tests/gating/scenario-resource-creation.spec.ts
@@ -174,7 +174,8 @@ test.describe('Resource creation (gating)', { tag: [GATING_TAG, '@resource-creat
       .toBe(true);
   });
 
-  test('Create a template from a virtual machine', async ({
+  // Re-enable after hot cluster is upgraded to CNV 4.22+ (requires template.kubevirt.io CRDs).
+  test.skip('Create a template from a virtual machine', async ({
     apiClient,
     vmDetailPage,
     vmListPage,


### PR DESCRIPTION
## 📝 Description

Skip the "Create a template from a virtual machine" gating Playwright test until the hot cluster used in upstream CI is upgraded to CNV 4.22+. The test depends on `template.kubevirt.io` CRDs that are not yet available on the current cluster.

Also stabilizes the **Create a VM via YAML import** gating test by scoping the Create dropdown to `page-heading`, waiting for the button to become enabled after access review, and waiting for the **With YAML** menu item before clicking. This reduces flakiness when the empty-state Create button or a still-disabled header control was clicked instead.

## 🔗 Links

Jira: https://issues.redhat.com/browse/CNV-87425

## 🎥 Demo

N/A — test-only change (skips a failing gating test and hardens YAML create navigation).

Before: Gating test fails when native VM template CRDs are missing on the hot cluster; YAML import test could intermittently stay on the VM list.

After: Template-from-VM test is skipped with a comment documenting when to re-enable it; YAML import uses a more reliable Create → With YAML flow.

## Test plan

- [x] Verified diff is limited to skipping one gating test with an explanatory comment
- [x] VM list YAML create page object waits for enabled header Create button and visible With YAML menu item
- [ ] CI gating suite passes with the test skipped

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved VM creation workflows by waiting for controls to become visible and enabled before opening creation options and selecting YAML creation.

* **Tests**
  * Temporarily skipped the VM-to-template creation gating scenario while required platform support and template definitions are unavailable.
  * Existing feature-flag conditions and test workflow remain unchanged.
  * The scenario is expected to be re-enabled after upgrading to CNV 4.22 or later and installing the required template definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->