### PR TITLE
CNV-96224: Compute resources step - next button validation

### DIFF
--- a/playwright/src/components/vm-wizard/vm-wizard-navigation-component.ts
+++ b/playwright/src/components/vm-wizard/vm-wizard-navigation-component.ts
@@ -335,6 +335,23 @@ export default class VmWizardNavigationComponent extends BaseComponent {
     return await nextButton.isDisabled();
   }
 
+  async clickWizardNavStep(stepName: string): Promise<void> {
+    const navLink = this._wizardContainer
+      .locator('.pf-v6-c-wizard__nav-link')
+      .filter({ hasText: stepName });
+    await navLink.first().waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    await navLink.first().click({ force: true });
+    await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async isWizardNavStepDisabled(stepName: string): Promise<boolean> {
+    const navLink = this._wizardContainer
+      .locator('.pf-v6-c-wizard__nav-link')
+      .filter({ hasText: stepName });
+    await navLink.first().waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
+    return await navLink.first().isDisabled();
+  }
+
   async navigateToStepByName(stepName: string): Promise<void> {
     const toggle = this.locator('button:has-text("Wizard toggle")');
     await this.robustClick(toggle.first());
@@ -366,7 +383,9 @@ export default class VmWizardNavigationComponent extends BaseComponent {
 
     await this.openEditLocationPanel();
 
-    const toggle = this.locator('.vm-creation-wizard').getByTestId('namespace-dropdown-menu-toggle');
+    const toggle = this.locator('.vm-creation-wizard').getByTestId(
+      'namespace-dropdown-menu-toggle',
+    );
     await toggle.first().waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
     await this.robustClick(toggle.first());
 

--- a/playwright/src/utils/vm-wizard-test-helpers.ts
+++ b/playwright/src/utils/vm-wizard-test-helpers.ts
@@ -1,0 +1,82 @@
+import { expect } from '@playwright/test';
+
+import type {
+  VmWizardBootSourcePage,
+  VmWizardComputeCustomizationPage,
+  VmWizardNavigationPage,
+} from '@/page-objects';
+
+export async function completeDeploymentDetailsStep(
+  vmWizardNavigationPage: VmWizardNavigationPage,
+): Promise<void> {
+  const tilesVisible = await vmWizardNavigationPage.verifyCreationMethodTilesVisible();
+  expect.soft(tilesVisible, 'Creation method tiles should be visible').toBe(true);
+
+  const isCustomSelected = await vmWizardNavigationPage.verifyCreationMethodCardSelected('newVm');
+  expect.soft(isCustomSelected, 'Custom configuration should be selected by default').toBe(true);
+
+  await vmWizardNavigationPage.generateVmName();
+  await vmWizardNavigationPage.clickNext();
+}
+
+export async function completeGuestOsStep(
+  vmWizardNavigationPage: VmWizardNavigationPage,
+): Promise<void> {
+  const osTilesVisible = await vmWizardNavigationPage.verifyOsTilesVisible();
+  expect.soft(osTilesVisible, 'OS tiles (RHEL, Windows, Other Linux) should be visible').toBe(true);
+
+  const osDropdownVisible = await vmWizardNavigationPage.verifyOsTypeDropdownVisible();
+  expect.soft(osDropdownVisible, 'OS type dropdown should be visible').toBe(true);
+
+  const selectedOs = await vmWizardNavigationPage.getSelectedOsType();
+  expect.soft(selectedOs.length, 'An OS type should be pre-selected').toBeGreaterThan(0);
+
+  await vmWizardNavigationPage.clickNext();
+}
+
+export async function completeBootSourceStep(
+  vmWizardBootSourcePage: VmWizardBootSourcePage,
+  vmWizardNavigationPage: VmWizardNavigationPage,
+): Promise<void> {
+  const bootStepVisible = await vmWizardBootSourcePage.verifyBootSourceStepVisible();
+  expect.soft(bootStepVisible, 'Boot source step should be visible').toBe(true);
+
+  const tableVisible = await vmWizardBootSourcePage.verifyBootVolumeTableOrEmptyState();
+  expect.soft(tableVisible, 'Boot volume table or empty state should be visible').toBe(true);
+
+  const volumeCount = await vmWizardBootSourcePage.getBootVolumeCount();
+  if (volumeCount > 0) {
+    const columnsVisible = await vmWizardBootSourcePage.verifyBootVolumeTableColumnsVisible();
+    expect.soft(columnsVisible, 'Boot volume table columns should be visible').toBe(true);
+
+    await vmWizardBootSourcePage.selectBootVolumeByName('rhel');
+  } else {
+    await vmWizardBootSourcePage.selectNoBootSource();
+  }
+
+  await vmWizardNavigationPage.clickNext();
+}
+
+export async function verifyComputeResourcesStep(
+  vmWizardComputePage: VmWizardComputeCustomizationPage,
+): Promise<void> {
+  const computeVisible = await vmWizardComputePage.verifyComputeResourcesStepVisible();
+  expect.soft(computeVisible, 'Compute resources step should be visible').toBe(true);
+
+  const seriesVisible = await vmWizardComputePage.verifyInstanceTypeSeriesVisible();
+  expect.soft(seriesVisible, 'Instance type series cards should be visible').toBe(true);
+
+  await vmWizardComputePage.selectInstanceTypeSeries('u');
+  await vmWizardComputePage.selectComputeSize('medium');
+
+  const sizeText = await vmWizardComputePage.getComputeSizeDropdownText();
+  expect.soft(sizeText, 'A medium compute size should be selected').toContain('CPUs');
+}
+
+export async function completeComputeResourcesStep(
+  vmWizardComputePage: VmWizardComputeCustomizationPage,
+  vmWizardNavigationPage: VmWizardNavigationPage,
+): Promise<void> {
+  await verifyComputeResourcesStep(vmWizardComputePage);
+  await vmWizardNavigationPage.clickNext();
+}

--- a/playwright/tests/tier1/create-vm/create-vm-wizard-custom-config.spec.ts
+++ b/playwright/tests/tier1/create-vm/create-vm-wizard-custom-config.spec.ts
@@ -1,6 +1,12 @@
 import { ADMIN_ONLY_TAG, T1, T1_TAG } from '@/data-models/allure-constants';
 import { expect, test } from '@/fixtures/create-vm-fixture';
 import { setupTestNamespace } from '@/utils/test-setup-helpers';
+import {
+  completeBootSourceStep,
+  completeComputeResourcesStep,
+  completeDeploymentDetailsStep,
+  completeGuestOsStep,
+} from '@/utils/vm-wizard-test-helpers';
 
 const SUITE = 'VM Creation Wizard';
 
@@ -33,68 +39,19 @@ test.describe(
       expect(wizardVisible, 'Wizard should open').toBe(true);
 
       await test.step('Step 1: Deployment details — select Custom configuration and generate name', async () => {
-        const tilesVisible = await vmWizardNavigationPage.verifyCreationMethodTilesVisible();
-        expect.soft(tilesVisible, 'Creation method tiles should be visible').toBe(true);
-
-        const isCustomSelected =
-          await vmWizardNavigationPage.verifyCreationMethodCardSelected('newVm');
-        expect
-          .soft(isCustomSelected, 'Custom configuration should be selected by default')
-          .toBe(true);
-
-        await vmWizardNavigationPage.generateVmName();
-        await vmWizardNavigationPage.clickNext();
+        await completeDeploymentDetailsStep(vmWizardNavigationPage);
       });
 
       await test.step('Step 2: Guest OS — verify OS tiles and default selection', async () => {
-        const osTilesVisible = await vmWizardNavigationPage.verifyOsTilesVisible();
-        expect
-          .soft(osTilesVisible, 'OS tiles (RHEL, Windows, Other Linux) should be visible')
-          .toBe(true);
-
-        const osDropdownVisible = await vmWizardNavigationPage.verifyOsTypeDropdownVisible();
-        expect.soft(osDropdownVisible, 'OS type dropdown should be visible').toBe(true);
-
-        const selectedOs = await vmWizardNavigationPage.getSelectedOsType();
-        expect.soft(selectedOs.length, 'An OS type should be pre-selected').toBeGreaterThan(0);
-
-        await vmWizardNavigationPage.clickNext();
+        await completeGuestOsStep(vmWizardNavigationPage);
       });
 
       await test.step('Step 3: Boot source — select a boot volume', async () => {
-        const bootStepVisible = await vmWizardBootSourcePage.verifyBootSourceStepVisible();
-        expect.soft(bootStepVisible, 'Boot source step should be visible').toBe(true);
-
-        const tableVisible = await vmWizardBootSourcePage.verifyBootVolumeTableOrEmptyState();
-        expect.soft(tableVisible, 'Boot volume table or empty state should be visible').toBe(true);
-
-        const volumeCount = await vmWizardBootSourcePage.getBootVolumeCount();
-        if (volumeCount > 0) {
-          const columnsVisible = await vmWizardBootSourcePage.verifyBootVolumeTableColumnsVisible();
-          expect.soft(columnsVisible, 'Boot volume table columns should be visible').toBe(true);
-
-          await vmWizardBootSourcePage.selectBootVolumeByName('rhel');
-        } else {
-          await vmWizardBootSourcePage.selectNoBootSource();
-        }
-
-        await vmWizardNavigationPage.clickNext();
+        await completeBootSourceStep(vmWizardBootSourcePage, vmWizardNavigationPage);
       });
 
       await test.step('Step 4: Compute resources — verify series and size', async () => {
-        const computeVisible = await vmWizardComputePage.verifyComputeResourcesStepVisible();
-        expect.soft(computeVisible, 'Compute resources step should be visible').toBe(true);
-
-        const seriesVisible = await vmWizardComputePage.verifyInstanceTypeSeriesVisible();
-        expect.soft(seriesVisible, 'Instance type series cards should be visible').toBe(true);
-
-        await vmWizardComputePage.selectInstanceTypeSeries('u');
-        await vmWizardComputePage.selectComputeSize('medium');
-
-        const sizeText = await vmWizardComputePage.getComputeSizeDropdownText();
-        expect.soft(sizeText, 'A medium compute size should be selected').toContain('CPUs');
-
-        await vmWizardNavigationPage.clickNext();
+        await completeComputeResourcesStep(vmWizardComputePage, vmWizardNavigationPage);
       });
 
       await test.step('Step 5: Customization — verify tabs and settings', async () => {

--- a/playwright/tests/tier2/create-vm/create-vm-wizard-customization-step-navigation.spec.ts
+++ b/playwright/tests/tier2/create-vm/create-vm-wizard-customization-step-navigation.spec.ts
@@ -1,0 +1,81 @@
+import { ADMIN_ONLY_TAG, T2, T2_TAG } from '@/data-models/allure-constants';
+import { expect, test } from '@/fixtures/create-vm-fixture';
+import { setupTestNamespace } from '@/utils/test-setup-helpers';
+import {
+  completeBootSourceStep,
+  completeDeploymentDetailsStep,
+  completeGuestOsStep,
+  verifyComputeResourcesStep,
+} from '@/utils/vm-wizard-test-helpers';
+
+const SUITE = 'VM Creation Wizard';
+
+test.describe(
+  'VM Creation Wizard — Customization step navigation',
+  { tag: [T2_TAG, '@catalog-wizard', ADMIN_ONLY_TAG] },
+  () => {
+    test('Customization step stays disabled until compute resources is completed', async ({
+      apiClient,
+      vmListPage,
+      vmWizardNavigationPage,
+      vmWizardBootSourcePage,
+      vmWizardComputePage,
+      utils,
+    }) => {
+      test.setTimeout(utils.TestTimeouts.TEST_EXTENDED);
+      await utils.withAllure({
+        suite: SUITE,
+        feature: T2,
+        tags: [T2_TAG],
+      });
+
+      const wizardNs = await setupTestNamespace(apiClient, 'wizard-custom-nav');
+
+      await vmListPage.switchToVirtualizationPerspective();
+      await vmListPage.navigateToProjectVmListViaUI(wizardNs);
+      await vmWizardNavigationPage.openWizardFromCreateDropdown();
+
+      const wizardVisible = await vmWizardNavigationPage.verifyWizardVisible();
+      expect(wizardVisible, 'Wizard should open').toBe(true);
+
+      await test.step('Navigate to compute resources without advancing past it', async () => {
+        await completeDeploymentDetailsStep(vmWizardNavigationPage);
+        await completeGuestOsStep(vmWizardNavigationPage);
+        await completeBootSourceStep(vmWizardBootSourcePage, vmWizardNavigationPage);
+        await verifyComputeResourcesStep(vmWizardComputePage);
+      });
+
+      await test.step('Go back to Guest OS and verify Customization is disabled', async () => {
+        await vmWizardNavigationPage.clickBack();
+        await vmWizardNavigationPage.clickBack();
+        const customizationDisabled =
+          await vmWizardNavigationPage.isWizardNavStepDisabled('Customization');
+        expect(
+          customizationDisabled,
+          'Customization step should be disabled before compute resources is completed',
+        ).toBe(true);
+
+        await vmWizardNavigationPage.clickWizardNavStep('Customization');
+      });
+
+      await test.step('Complete compute resources and reach Customization with tabs', async () => {
+        await vmWizardNavigationPage.clickNext();
+        await vmWizardNavigationPage.clickNext();
+
+        const computeVisible = await vmWizardComputePage.verifyComputeResourcesStepVisible();
+        expect(computeVisible, 'Compute resources step should be visible again').toBe(true);
+
+        await vmWizardNavigationPage.clickNext();
+
+        const customizationVisible = await vmWizardComputePage.verifyCustomizationStepVisible();
+        expect(customizationVisible, 'Customization step should be visible').toBe(true);
+
+        const tabsVisible = await vmWizardComputePage.verifyCustomizationTabsVisible();
+        expect(
+          tabsVisible,
+          'Customization tabs (Details, Storage, Network, etc.) should be visible',
+        ).toBe(true);
+      });
+    });
+  },
+);

--- a/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/components/DetailsEditableItems.tsx
+++ b/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/components/DetailsEditableItems.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import { DescriptionModal } from '@kubevirt-utils/components/DescriptionModal/DescriptionModal';
@@ -15,6 +15,8 @@ import {
   patchCustomizeWizardVMSignal,
 } from '@kubevirt-utils/signals/customizeWizardVMSignal';
 import { VM_FOLDER_LABEL } from '@virtualmachines/tree/utils/constants';
+import { useVMWizard } from '@virtualmachines/wizard/state/vm-wizard-context/VMWizardContext';
+import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/wizard/state/vm-wizard-form/consts';
 
 type DetailsEditableItemsProps = {
   treeViewFoldersEnabled: boolean;
@@ -23,6 +25,7 @@ type DetailsEditableItemsProps = {
 const DetailsEditableItems: FC<DetailsEditableItemsProps> = ({ treeViewFoldersEnabled }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
+  const { setValue } = useVMWizard();
 
   const vm = customizeWizardVMSignal.value;
   const vmName = getName(vm);
@@ -30,57 +33,65 @@ const DetailsEditableItems: FC<DetailsEditableItemsProps> = ({ treeViewFoldersEn
   return (
     <>
       <DescriptionItem
+        data-test={`${vmName}-description`}
         descriptionData={
           getAnnotation(vm, DESCRIPTION_ANNOTATION) || <MutedTextSpan text={t('None')} />
         }
+        descriptionHeader={<SearchItem id="description">{t('Description')}</SearchItem>}
+        isEdit
         onEditClick={() =>
           createModal(({ isOpen, onClose }) => (
             <DescriptionModal
-              onSubmit={(description) =>
-                Promise.resolve(
-                  patchCustomizeWizardVMSignal([
-                    { data: description, path: `metadata.annotations.${DESCRIPTION_ANNOTATION}` },
-                  ]),
-                )
-              }
               isOpen={isOpen}
               obj={vm}
               onClose={onClose}
+              onSubmit={async (description) => {
+                setValue(CREATE_VM_FORM_FIELDS_VM_DATA.DESCRIPTION, description);
+                await Promise.resolve(
+                  patchCustomizeWizardVMSignal([
+                    { data: description, path: `metadata.annotations.${DESCRIPTION_ANNOTATION}` },
+                  ]),
+                );
+              }}
             />
           ))
         }
-        data-test={`${vmName}-description`}
-        descriptionHeader={<SearchItem id="description">{t('Description')}</SearchItem>}
-        isEdit
       />
       {treeViewFoldersEnabled && (
         <DescriptionItem
-          onEditClick={() =>
-            createModal(({ isOpen, onClose }) => (
-              <MoveVMToFolderModal
-                onSubmit={(folderName) =>
-                  Promise.resolve(
-                    patchCustomizeWizardVMSignal([
-                      { data: folderName, path: ['metadata', 'labels', VM_FOLDER_LABEL] },
-                    ]),
-                  )
-                }
-                isOpen={isOpen}
-                onClose={onClose}
-                vm={vm}
-              />
-            ))
-          }
           data-test={`${vmName}-folder`}
           descriptionData={getLabel(vm, VM_FOLDER_LABEL)}
           descriptionHeader={<SearchItem id="folder">{t('Group')}</SearchItem>}
           isEdit
+          onEditClick={() =>
+            createModal(({ isOpen, onClose }) => (
+              <MoveVMToFolderModal
+                isOpen={isOpen}
+                onClose={onClose}
+                onSubmit={async (folderName) => {
+                  setValue(CREATE_VM_FORM_FIELDS_VM_DATA.FOLDER, folderName);
+                  await Promise.resolve(
+                    patchCustomizeWizardVMSignal([
+                      { data: folderName, path: ['metadata', 'labels', VM_FOLDER_LABEL] },
+                    ]),
+                  );
+                }}
+                vm={vm}
+              />
+            ))
+          }
         />
       )}
       <DescriptionItem
+        data-test={`${vmName}-hostname`}
+        descriptionData={getHostname(vm) || vmName}
+        descriptionHeader={<SearchItem id="hostname">{t('Hostname')}</SearchItem>}
+        isEdit
         onEditClick={() =>
           createModal(({ isOpen, onClose }) => (
             <HostnameModal
+              isOpen={isOpen}
+              onClose={onClose}
               onSubmit={(updatedVM) =>
                 Promise.resolve(
                   patchCustomizeWizardVMSignal([
@@ -88,16 +99,10 @@ const DetailsEditableItems: FC<DetailsEditableItemsProps> = ({ treeViewFoldersEn
                   ]),
                 )
               }
-              isOpen={isOpen}
-              onClose={onClose}
               vm={vm}
             />
           ))
         }
-        data-test={`${vmName}-hostname`}
-        descriptionData={getHostname(vm) || vmName}
-        descriptionHeader={<SearchItem id="hostname">{t('Hostname')}</SearchItem>}
-        isEdit
       />
     </>
   );

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/ComputeResourcesStepFooter.tsx
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/ComputeResourcesStepFooter.tsx
@@ -1,7 +1,12 @@
-import React, { type FC } from 'react';
+import React, { type FC, useEffect, useRef } from 'react';
 
-import { setCustomizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
+import {
+  customizeWizardVMSignal,
+  setCustomizeWizardVMSignal,
+} from '@kubevirt-utils/signals/customizeWizardVMSignal';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { type ButtonProps, useWizardContext, WizardFooter } from '@patternfly/react-core';
+import { useSignals } from '@preact/signals-react/runtime';
 import useCloseWizard from '@virtualmachines/wizard/hooks/useCloseWizard';
 import useWizardStepValidation from '@virtualmachines/wizard/hooks/useWizardStepValidation';
 import { VMWizardStep } from '@virtualmachines/wizard/utils/constants';
@@ -9,14 +14,28 @@ import { VMWizardStep } from '@virtualmachines/wizard/utils/constants';
 import useGenerateVM from '../../hooks/useGenerateVM/useGenerateVM';
 
 const ComputeResourcesStepFooter: FC = () => {
+  useSignals();
+  const vm = customizeWizardVMSignal.value;
   const { activeStep, goToNextStep, goToPrevStep } = useWizardContext();
   const { generatedVM, loaded } = useGenerateVM();
   const closeWizard = useCloseWizard();
   const { isNextDisabledForStep } = useWizardStepValidation();
+  const isAbleToGoToNextStepRef = useRef(false);
+
+  useEffect(() => {
+    if (!isAbleToGoToNextStepRef.current || isEmpty(vm)) {
+      return;
+    }
+    isAbleToGoToNextStepRef.current = false;
+    void goToNextStep();
+  }, [goToNextStep, vm]);
 
   const handleGoToNextStep = (): void => {
+    if (isEmpty(generatedVM)) {
+      return;
+    }
     setCustomizeWizardVMSignal(generatedVM);
-    void goToNextStep();
+    isAbleToGoToNextStepRef.current = true;
   };
 
   return (

--- a/src/views/virtualmachines/wizard/utils/displaySteps.ts
+++ b/src/views/virtualmachines/wizard/utils/displaySteps.ts
@@ -1,5 +1,8 @@
-import { createElement, type ReactElement } from 'react';
 import { type TFunction } from 'i18next';
+import { createElement, type ReactElement } from 'react';
+
+import { customizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 import DefaultWizardFooter from '../components/DefaultWizardFooter';
 import CloneSourceStep from '../steps/CloneSourceStep/CloneSourceStep';
@@ -43,7 +46,7 @@ const getCustomizationStep = (
   displayIndex: 6,
   footer: getDefaultFooter(isNextDisabledForStep(VMWizardStep.CUSTOMIZATION)),
   id: VMWizardStep.CUSTOMIZATION,
-  isDisabled: isStepDisabled(VMWizardStep.CUSTOMIZATION),
+  isDisabled: isStepDisabled(VMWizardStep.CUSTOMIZATION) || isEmpty(customizeWizardVMSignal.value),
   name: t('Customization'),
   navItem: getVMGenerationNavItem(navItemConfig),
 });


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description


* Go to next step from compute resources step to customization step only if vm signal value exists
* Save description and folder in customization step to react hook form in order to not override their values.
* Added organize imports to settings json
## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-96224
## 🎥 Demo

Before:
https://github.com/user-attachments/assets/7058ae07-2a3a-41ed-9d89-68bb0fafa34e

After:
https://github.com/user-attachments/assets/07f598f7-d1df-4813-9791-182361adfd84



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM wizard progression so the Customization step remains unavailable until Compute resources are completed.
  * Ensured description and folder selections are retained when submitted during VM customization.
  * Improved step-transition handling to provide more reliable navigation.

* **Tests**
  * Added coverage for customization-step navigation and completed VM creation wizard flows.
  * Expanded automated checks for deployment details, guest OS, boot source, and compute resource selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->