### PR TITLE
CNV-96336: Added is scrollable to saved searches dropdown

### DIFF
--- a/src/views/search/components/SavedSearchesDropdown/SavedSearchesDropdown.tsx
+++ b/src/views/search/components/SavedSearchesDropdown/SavedSearchesDropdown.tsx
@@ -23,6 +23,8 @@ import { applySearch } from '@search/savedSearches/utils';
 import SavedSearchesStateHandler from './components/SavedSearchesStateHandler';
 import SavedSearchItem from './components/SavedSearchItem';
 import useDeleteSavedSearch from './hooks/useDeleteSavedSearch';
+import { getSavedSearchesItemsToDisplay, getSortedSavedsearches } from './utils/utils';
+import { SavedSearchEntry } from '@search/savedSearches/types';
 
 type SavedSearchesDropdownProps = {
   filters: KubevirtFilterState;
@@ -40,28 +42,44 @@ const SavedSearchesDropdown: FC<SavedSearchesDropdownProps> = ({ filters, onSetF
 
   const handleDelete = useDeleteSavedSearch(deleteSearch, setOpen);
 
-  const filteredSearches = useMemo(() => {
-    const sorted = [...searches].sort((a, b) => Number(b.isFavorited) - Number(a.isFavorited));
-    if (!filterText) return sorted;
-    const lower = filterText.toLowerCase();
-    return sorted.filter(({ name }) => name.toLowerCase().includes(lower));
-  }, [searches, filterText]);
+  const { favoriteSavedSearchesItems, otherSavedSearchesItems, shouldDisplayDivider } =
+    useMemo(() => {
+      const sorted = getSortedSavedsearches(searches, filterText);
+      return getSavedSearchesItemsToDisplay(sorted);
+    }, [searches, filterText]);
+
+  const savedSearchesItemsToDropdownItems = (savedSearchesItems: SavedSearchEntry[]) =>
+    savedSearchesItems.map(({ description, isFavorited, name }) => (
+      <SavedSearchItem
+        onApply={() => {
+          applySearch(name, searches, filters, onSetFilters);
+          setOpen(false);
+        }}
+        description={description}
+        isFavorited={isFavorited}
+        key={name}
+        name={name}
+        onDelete={() => handleDelete(name, isFavorited)}
+        onToggleFavorite={() => toggleFavorite(name)}
+      />
+    ));
 
   return (
     <Dropdown
+      isOpen={open}
+      isScrollable
       onOpenChange={(isOpen: boolean) => {
         setOpen(isOpen);
         if (!isOpen) {
           setFilterText('');
         }
       }}
+      popperProps={{ position: 'end' }}
       toggle={(toggleRef) => (
         <MenuToggle isExpanded={open} onClick={() => setOpen(!open)} ref={toggleRef}>
           {t('Saved searches')}
         </MenuToggle>
       )}
-      isOpen={open}
-      popperProps={{ position: 'end' }}
     >
       <SavedSearchesStateHandler
         loaded={searchesInitiallyLoaded}
@@ -79,25 +97,16 @@ const SavedSearchesDropdown: FC<SavedSearchesDropdownProps> = ({ filters, onSetF
         </MenuSearch>
         <Divider />
         <DropdownList className="saved-searches-dropdown-menu" data-test="saved-searches">
-          {isEmpty(filteredSearches) ? (
+          {isEmpty(favoriteSavedSearchesItems) && isEmpty(otherSavedSearchesItems) ? (
             <DropdownItem isDisabled key="no-results">
               {t('No saved searches match "{{filterText}}".', { filterText })}
             </DropdownItem>
           ) : (
-            filteredSearches.map(({ description, isFavorited, name }) => (
-              <SavedSearchItem
-                onApply={() => {
-                  applySearch(name, searches, filters, onSetFilters);
-                  setOpen(false);
-                }}
-                description={description}
-                isFavorited={isFavorited}
-                key={name}
-                name={name}
-                onDelete={() => handleDelete(name, isFavorited)}
-                onToggleFavorite={() => toggleFavorite(name)}
-              />
-            ))
+            <>
+              {savedSearchesItemsToDropdownItems(favoriteSavedSearchesItems)}
+              {shouldDisplayDivider && <Divider component="li" />}
+              {savedSearchesItemsToDropdownItems(otherSavedSearchesItems)}
+            </>
           )}
         </DropdownList>
       </SavedSearchesStateHandler>

--- a/src/views/search/components/SavedSearchesDropdown/utils/utils.ts
+++ b/src/views/search/components/SavedSearchesDropdown/utils/utils.ts
@@ -1,0 +1,28 @@
+import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { type SavedSearchEntry } from '@search/savedSearches/types';
+
+export const getSortedSavedsearches = (searches: SavedSearchEntry[], filterText: string) => {
+  const sorted = [...searches].sort((a, b) => Number(b.isFavorited) - Number(a.isFavorited));
+  if (!filterText) return sorted;
+  const lower = filterText.toLowerCase();
+  return sorted.filter(({ name }) => name.toLowerCase().includes(lower));
+};
+
+type SavedSearchesItemsToDisplay = {
+  favoriteSavedSearchesItems: SavedSearchEntry[];
+  otherSavedSearchesItems: SavedSearchEntry[];
+  shouldDisplayDivider: boolean;
+};
+
+export const getSavedSearchesItemsToDisplay = (
+  savedSearchesItems: SavedSearchEntry[],
+): SavedSearchesItemsToDisplay => {
+  const favoriteSavedSearchesItems = savedSearchesItems.filter((item) => item.isFavorited);
+  const otherSavedSearchesItems = savedSearchesItems.filter((item) => !item.isFavorited);
+
+  return {
+    favoriteSavedSearchesItems,
+    otherSavedSearchesItems,
+    shouldDisplayDivider: !isEmpty(favoriteSavedSearchesItems) && !isEmpty(otherSavedSearchesItems),
+  };
+};


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

* Added isScrollable to saved searches dropdown
* Added a divider to separate between the favorite searches and the other saved searches items
## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-96336

## 🎥 Demo

Before:
https://github.com/user-attachments/assets/c8cc5b90-3f80-45a6-979f-9ceed7449946


After:
https://github.com/user-attachments/assets/9ab21aaf-f78c-49ed-a4ba-ab61d249e4cc



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Saved search menus now group favorited searches separately from other saved searches, with a divider when both groups are present.
  * Filtering remains case-insensitive and prioritizes favorited results.
  * Saved search menus can scroll when they contain more items than fit in the available space.
  * A no-results message appears only when no matching saved searches are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->