### PR TITLE
CNV-96216: show correct OS and icon for VirtualMachineTemplates in VM wizard

### DIFF
--- a/images/globals.d.ts
+++ b/images/globals.d.ts
@@ -1,9 +1,9 @@
 declare module '*.png' {
-  const value: any;
-  export = value;
+  const value: string;
+  export default value;
 }
 
 declare module '*.svg' {
-  const value: any;
-  export = value;
+  const value: string;
+  export default value;
 }

--- a/src/utils/hooks/useClusterPreferencesByName.ts
+++ b/src/utils/hooks/useClusterPreferencesByName.ts
@@ -1,0 +1,17 @@
+import { useMemo } from 'react';
+
+import { type V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import useClusterPreferences from '@kubevirt-utils/hooks/useClusterPreferences';
+import { convertResourceArrayToMap, type ResourceMap } from '@kubevirt-utils/resources/shared';
+
+type UseClusterPreferencesByName = (
+  cluster?: string,
+) => ResourceMap<V1beta1VirtualMachineClusterPreference>;
+
+const useClusterPreferencesByName: UseClusterPreferencesByName = (cluster) => {
+  const [clusterPreferences] = useClusterPreferences(undefined, undefined, cluster);
+
+  return useMemo(() => convertResourceArrayToMap(clusterPreferences), [clusterPreferences]);
+};
+
+export default useClusterPreferencesByName;

--- a/src/utils/resources/shared.ts
+++ b/src/utils/resources/shared.ts
@@ -63,7 +63,7 @@ export const getLabels = (
 export const getAnnotations = (
   entity: K8sResourceCommon,
   defaultValue?: { [key: string]: string },
-): { [key: string]: string } => entity?.metadata?.annotations || defaultValue;
+): { [key: string]: string } | undefined => entity?.metadata?.annotations || defaultValue;
 
 /**
  * function for getting an entity's annotation
@@ -76,7 +76,7 @@ export const getAnnotation = (
   entity: K8sResourceCommon,
   annotationName: string,
   defaultValue?: string,
-): string => entity?.metadata?.annotations?.[annotationName] ?? defaultValue;
+): string | undefined => entity?.metadata?.annotations?.[annotationName] ?? defaultValue;
 
 /**
  * function for getting an entity's display name
@@ -85,6 +85,9 @@ export const getAnnotation = (
  */
 export const getDisplayName = (entity: K8sResourceCommon): string | undefined =>
   getAnnotation(entity, ANNOTATIONS.displayName);
+
+export const getIconClass = (entity: K8sResourceCommon): string | undefined =>
+  getAnnotation(entity, ANNOTATIONS.iconClass);
 
 /**
  * function for getting an entity's label
@@ -433,16 +436,18 @@ export const getKind = <A extends K8sResourceCommon = K8sResourceCommon>(resourc
 export const getUID = <A extends K8sResourceCommon = K8sResourceCommon>(resource: A): string =>
   resource?.metadata?.uid;
 
+type K8sResource = { metadata?: { name?: string; namespace?: string } };
+
 export type ResourceMap<A> = { [name: string]: A };
 export type NamespacedResourceMap<A> = { [namespace: string]: ResourceMap<A> };
 
 // Function overloads
-export function convertResourceArrayToMap<A extends K8sResourceCommon = K8sResourceCommon>(
+export function convertResourceArrayToMap<A extends K8sResource>(
   resources: A[],
   isNamespaced: true,
 ): NamespacedResourceMap<A>;
 
-export function convertResourceArrayToMap<A extends K8sResourceCommon = K8sResourceCommon>(
+export function convertResourceArrayToMap<A extends K8sResource>(
   resources: A[],
   isNamespaced?: false,
 ): ResourceMap<A>;
@@ -459,7 +464,7 @@ export function convertResourceArrayToMap<A extends K8sResourceCommon = K8sResou
  * @param {boolean} isNamespaced - (optional) - a flag to indicate if the resource is namespace-scoped
  * @param isMultiCluster - (optional) - a flag to indicate if the resource is fetched multi-cluster
  */
-export function convertResourceArrayToMap<A extends K8sResourceCommon = K8sResourceCommon>(
+export function convertResourceArrayToMap<A extends K8sResource>(
   resources: A[],
   isNamespaced?: boolean,
 ): NamespacedResourceMap<A> | ResourceMap<A> {

--- a/src/utils/resources/template/utils/annotations.ts
+++ b/src/utils/resources/template/utils/annotations.ts
@@ -4,6 +4,7 @@ export const ANNOTATIONS = Object.freeze({
   description: 'description',
   displayName: 'openshift.io/display-name',
   documentationURL: 'openshift.io/documentation-url',
+  iconClass: 'iconClass',
   importURLs: 'template.kubevirt.io/images',
   os: 'vm.kubevirt.io/os',
   osTemplate: 'vm.kubevirt.io/template',

--- a/src/utils/resources/template/utils/selectors.ts
+++ b/src/utils/resources/template/utils/selectors.ts
@@ -1,5 +1,10 @@
-import { type V1Template, VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import {
+  type TemplateParameter,
+  type V1Template,
+  VirtualMachineModel,
+} from '@kubevirt-ui-ext/kubevirt-api/console';
+import {
+  type V1CPU,
   type V1Disk,
   type V1Interface,
   type V1Network,
@@ -43,18 +48,21 @@ export const isDefaultVariantTemplate = (template: Template): boolean =>
   getLabels(template)?.[TEMPLATE_DEFAULT_VARIANT_LABEL] === 'true';
 
 /**
- * A selector that returns the os label name of a given template
+ * A selector that returns the os annotation of a VM template of a given template
  * @param {Template} template - template
  */
-export const getTemplateOSLabelName = (template: Template): string =>
-  getAnnotation(getTemplateVirtualMachineObject(template)?.spec?.template, ANNOTATIONS.os);
+export const getTemplateOSAnnotation = (template: Template): string | undefined =>
+  getAnnotation(
+    getTemplateVirtualMachineObject(template)?.spec?.template as K8sResourceCommon,
+    ANNOTATIONS.os,
+  );
 
 /**
  * A selector that returns the os label of a given template
  * @param {Template} template - template
  */
 export const getTemplateOS = (template: Template): OS_NAME_TYPES => {
-  const templateOS = getTemplateOSLabelName(template);
+  const templateOS = getTemplateOSAnnotation(template);
   return (
     Object.values(OS_NAME_TYPES).find((osName) => templateOS?.includes(osName)) ??
     OS_NAME_TYPES.other
@@ -96,7 +104,7 @@ export const getTemplateImportURLs = (template: V1Template): string[] | undefine
  * @param {Template} template - template
  */
 export const getTemplateFlavor = (template: Template): string => {
-  const isFlavorExist = (flavor: string) =>
+  const isFlavorExist = (flavor: string): boolean =>
     getLabel(template, `${TEMPLATE_FLAVOR_LABEL}/${flavor}`) === 'true';
 
   return Object.values(FLAVORS).find((flavor) => isFlavorExist(flavor)) ?? 'unknown';
@@ -107,7 +115,7 @@ export const getTemplateFlavor = (template: Template): string => {
  * @param {Template} template - template
  */
 export const getTemplateWorkload = (template: Template): string => {
-  const isWorkloadExist = (workload: string) =>
+  const isWorkloadExist = (workload: string): boolean =>
     getLabel(template, `${TEMPLATE_WORKLOAD_LABEL}/${workload}`) === 'true';
 
   return Object.values(WORKLOADS).find((flavor) => isWorkloadExist(flavor)) ?? 'unknown';
@@ -159,7 +167,7 @@ export const getTemplateDisks = (template: Template): V1Disk[] => {
  * A selector that returns the parameters of a given template
  * @param {Template} template - template
  */
-export const getParameters = (template: Template) =>
+export const getParameters = (template: Template): TemplateParameter[] | undefined =>
   isOpenShiftTemplate(template) ? template?.parameters : template?.spec?.parameters;
 
 /**
@@ -204,5 +212,5 @@ export const getTemplateDescription = (template: Template): string =>
  * A selector that returns the CPU of a given template
  * @param {V1Template} template - template
  */
-export const getTemplateVirtualMachineCPU = (template: Template) =>
+export const getTemplateVirtualMachineCPU = (template: Template): undefined | V1CPU =>
   getCPU(getTemplateVirtualMachineObject(template));

--- a/src/utils/resources/vm/utils/operation-system/operationSystem.ts
+++ b/src/utils/resources/vm/utils/operation-system/operationSystem.ts
@@ -4,7 +4,7 @@ import {
   OS_TEMPLATE_LABEL,
   VM_OS_ANNOTATION,
 } from '@kubevirt-utils/resources/vm';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 /**
  * @date 3/16/2022 - 10:08:55 AM
@@ -22,8 +22,11 @@ type LabelsOrAnnotationsMap = {
  * @param {string} keyPrefix - prefix to search
  * @returns {*}
  */
-const getPrefixedKey = (obj: LabelsOrAnnotationsMap, keyPrefix: string) =>
-  obj ? Object.keys(obj).find((key) => key.startsWith(keyPrefix)) : null;
+const getPrefixedKey = (
+  obj: LabelsOrAnnotationsMap | undefined,
+  keyPrefix: string,
+): string | undefined =>
+  obj ? Object.keys(obj).find((key) => key.startsWith(keyPrefix)) : undefined;
 
 /**
  * @date 3/16/2022 - 10:08:55 AM
@@ -31,31 +34,38 @@ const getPrefixedKey = (obj: LabelsOrAnnotationsMap, keyPrefix: string) =>
  * @param {string} key - key to search
  * @returns {*}
  */
-const getSuffixValue = (key: string) => {
-  const index = key ? key.lastIndexOf('/') : -1;
-  return index > 0 ? key.substring(index + 1) : null;
+const getSuffixValue = (key: string | undefined): string | undefined => {
+  if (!key) return undefined;
+  const index = key.lastIndexOf('/');
+  return index > 0 ? key.substring(index + 1) : undefined;
 };
 
 /**
  * @date 3/16/2022 - 10:08:55 AM
- * Find in a {LabelsOrAnnotationsMap} object a key that start with {keyPrefix} prefix after '/' in label
+ * Find in a {LabelsOrAnnotationsMap} object a key that start with {keyPrefix} prefix and return the value after '/' in the key
  * @param {LabelsOrAnnotationsMap} obj - object to search
  * @param {string} keyPrefix - prefix to search
  * @returns {*}
  */
-export const findKeySuffixValue = (obj: LabelsOrAnnotationsMap, keyPrefix: string) =>
-  getSuffixValue(getPrefixedKey(obj, keyPrefix));
+export const findKeySuffixValue = (
+  obj: LabelsOrAnnotationsMap | undefined,
+  keyPrefix: string,
+): string | undefined => getSuffixValue(getPrefixedKey(obj, keyPrefix));
 
 /**
  * @date 3/16/2022 - 10:08:55 AM
- * Find in a {LabelsOrAnnotationsMap} object a label that start with {keyPrefix}
+ * Find in a {LabelsOrAnnotationsMap} object a label that start with {keyPrefix}, return its value
  * @param {LabelsOrAnnotationsMap} obj - object to search
  * @param {string} keyPrefix - prefix to search
  * @returns {string}
  */
-export const getValueByPrefix = (obj: LabelsOrAnnotationsMap, keyPrefix: string): string => {
-  const objectKey = Object.keys(obj || {}).find((key) => key.startsWith(keyPrefix));
-  return objectKey ? obj[objectKey] : null;
+const getValueByPrefix = (
+  obj: LabelsOrAnnotationsMap | undefined,
+  keyPrefix: string,
+): string | undefined => {
+  if (!obj) return undefined;
+  const objectKey = getPrefixedKey(obj, keyPrefix);
+  return objectKey ? obj[objectKey] : undefined;
 };
 
 /**
@@ -64,8 +74,8 @@ export const getValueByPrefix = (obj: LabelsOrAnnotationsMap, keyPrefix: string)
  * @param {K8sResourceCommon} obj - object to search
  * @returns {string}
  */
-export const getOperatingSystem = (obj: K8sResourceCommon): string =>
-  findKeySuffixValue(obj?.metadata?.labels, OS_TEMPLATE_LABEL) ||
+export const getOperatingSystem = (obj: K8sResourceCommon): string | undefined =>
+  findKeySuffixValue(obj?.metadata?.labels, OS_TEMPLATE_LABEL) ??
   obj?.metadata?.annotations?.[VM_OS_ANNOTATION];
 
 /**
@@ -74,7 +84,7 @@ export const getOperatingSystem = (obj: K8sResourceCommon): string =>
  * @param {K8sResourceCommon} obj - object to search
  * @returns {string}
  */
-export const getOperatingSystemName = (obj: K8sResourceCommon): string =>
+export const getOperatingSystemName = (obj: K8sResourceCommon): string | undefined =>
   getValueByPrefix(
     obj?.metadata?.annotations,
     `${NAME_OS_TEMPLATE_ANNOTATION}/${getOperatingSystem(obj)}`,
@@ -97,7 +107,7 @@ export const OS_WINDOWS_PREFIX = 'win';
  */
 
 export const isWindows = (obj: K8sResourceCommon): boolean =>
-  (getOperatingSystem(obj) || '')?.startsWith(OS_WINDOWS_PREFIX);
+  (getOperatingSystem(obj) ?? '').startsWith(OS_WINDOWS_PREFIX);
 
 /**
  * Match one or more raw OS terms (annotation value, label, preference name)

--- a/src/utils/resources/vm/utils/selectors.ts
+++ b/src/utils/resources/vm/utils/selectors.ts
@@ -357,7 +357,7 @@ export const getHostname = (vm: V1VirtualMachine): string => vm?.spec?.template?
 export const getInstanceTypeMatcher = (vm: V1VirtualMachine): V1InstancetypeMatcher =>
   vm?.spec?.instancetype;
 
-export const getPreferenceMatcher = (vm: V1VirtualMachine): V1PreferenceMatcher =>
+export const getPreferenceMatcher = (vm: V1VirtualMachine): V1PreferenceMatcher | undefined =>
   vm?.spec?.preference;
 
 /**

--- a/src/views/virtualmachines/wizard/VMCreationWizardContent.tsx
+++ b/src/views/virtualmachines/wizard/VMCreationWizardContent.tsx
@@ -57,7 +57,7 @@ const VMCreationWizardContent: FC = () => {
       }
 
       if (currentStep?.id) {
-        setValue(CREATE_VM_FORM_FIELDS_STEP_NAVIGATION.CURRENT_STEP, currentStep.id);
+        setValue(CREATE_VM_FORM_FIELDS_STEP_NAVIGATION.CURRENT_STEP, String(currentStep.id));
         markStepVisited(String(currentStep.id), getValues, setValue);
       }
 

--- a/src/views/virtualmachines/wizard/components/TemplatesDrawerWrapper.tsx
+++ b/src/views/virtualmachines/wizard/components/TemplatesDrawerWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { FC, ReactNode } from 'react';
+import React, { type FC, type ReactNode } from 'react';
 import { useWatch } from 'react-hook-form';
 
 import { Drawer, DrawerContent, DrawerContentBody } from '@patternfly/react-core';
@@ -20,7 +20,7 @@ const TemplatesDrawerWrapper: FC<{ children?: ReactNode }> = ({ children }) => {
     ],
   });
 
-  const handleDrawerClose = () => {
+  const handleDrawerClose = (): void => {
     setValue(CREATE_VM_FORM_FIELDS_UI_STATE.IS_TEMPLATES_DRAWER_OPEN, false);
   };
 

--- a/src/views/virtualmachines/wizard/state/vm-wizard-form/consts.ts
+++ b/src/views/virtualmachines/wizard/state/vm-wizard-form/consts.ts
@@ -51,7 +51,7 @@ export const createInitialVMWizardFormValues = ({
   },
 });
 
-export const CREATE_VM_FORM_FIELDS_VM_DATA: Record<string, FieldPath<VMWizardFormValues>> = {
+export const CREATE_VM_FORM_FIELDS_VM_DATA = {
   AUTO_LABELS_MERGED: 'vmData.autoLabelsMerged',
   CLUSTER: 'vmData.cluster',
   CREATION_METHOD: 'vmData.creationMethod',
@@ -61,27 +61,21 @@ export const CREATE_VM_FORM_FIELDS_VM_DATA: Record<string, FieldPath<VMWizardFor
   PROJECT: 'vmData.project',
   ROOT: 'vmData',
   SELECTED_TEMPLATE: 'vmData.selectedTemplate',
-};
+} as const satisfies Record<string, FieldPath<VMWizardFormValues>>;
 
-export const CREATE_VM_FORM_FIELDS_UI_STATE: Record<string, FieldPath<VMWizardFormValues>> = {
+export const CREATE_VM_FORM_FIELDS_UI_STATE = {
   IS_TEMPLATES_DRAWER_OPEN: 'uiState.isTemplatesDrawerOpen',
   LAST_PROCESSED_TEMPLATE_KEY: 'uiState.lastProcessedTemplateKey',
   SHOULD_CHECK_VM_NAME_PROPERLY: 'uiState.shouldCheckVMNameProperly',
   TEMPLATE_PROCESS_ERROR: 'uiState.templateProcessError',
-};
+} as const satisfies Record<string, FieldPath<VMWizardFormValues>>;
 
-export const CREATE_VM_FORM_FIELDS_STEP_NAVIGATION: Record<
-  string,
-  FieldPath<VMWizardFormValues>
-> = {
+export const CREATE_VM_FORM_FIELDS_STEP_NAVIGATION = {
   CURRENT_STEP: 'stepNavigation.currentStep',
   VISITED_STEPS: 'stepNavigation.visitedSteps',
-};
+} as const satisfies Record<string, FieldPath<VMWizardFormValues>>;
 
-export const CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA: Record<
-  string,
-  FieldPath<VMWizardFormValues>
-> = {
+export const CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA = {
   CUSTOM_DISK_SIZE: 'instanceTypeData.customDiskSize',
   DV_SOURCE: 'instanceTypeData.dvSource',
   OPERATING_SYSTEM_TYPE: 'instanceTypeData.operatingSystemType',
@@ -94,4 +88,4 @@ export const CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA: Record<
   SELECTED_SIZE: 'instanceTypeData.selectedSize',
   USE_BOOT_SOURCE: 'instanceTypeData.useBootSource',
   VOLUME_LIST_NAMESPACE: 'instanceTypeData.volumeListNamespace',
-};
+} as const satisfies Record<string, FieldPath<VMWizardFormValues>>;

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/BootableVolumeRow/BootableVolumeRow.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import ArchitectureLabel from '@kubevirt-utils/components/ArchitectureLabel/ArchitectureLabel';
 import { PREFERENCE_DISPLAY_NAME_KEY } from '@kubevirt-utils/constants/instancetypes-and-preferences';
@@ -8,21 +8,17 @@ import {
   getPVCStorageClassName,
   getVolumeSnapshotStorageClass,
 } from '@kubevirt-utils/resources/bootableresources/selectors';
-import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
+import { type BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { getAnnotation, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { ANNOTATIONS } from '@kubevirt-utils/resources/template';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { ARCHITECTURE_ID, getArchitecture } from '@kubevirt-utils/utils/architecture';
 import { getHumanizedSize } from '@kubevirt-utils/utils/units';
 import { TableText, Tr, WrapModifier } from '@patternfly/react-table';
-import {
-  getTemplateOSIcon,
-  getVolumeNameOSIcon,
-} from '@virtualmachines/wizard/utils/os-icons/os-icons';
-import { ApplySelectedBootableVolumeToForm } from '@virtualmachines/wizard/utils/types';
+import { getBootableVolumeOSIcon } from '@virtualmachines/wizard/utils/os-icons/os-icons';
+import { type ApplySelectedBootableVolumeToForm } from '@virtualmachines/wizard/utils/types';
 
-import { BootableVolumeRowData } from '../../../../types';
-
+import { type BootableVolumeRowData } from '../../../../types';
 import BootableVolumeRowNameCell from './components/BootableVolumeRowNameCell';
 import TableData from './TableData';
 
@@ -60,7 +56,7 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
     getName(selectedBootableVolume) === bootVolumeName &&
     getNamespace(selectedBootableVolume) === bootVolumeNamespace;
 
-  const handleClick = () => {
+  const handleClick = (): void => {
     onSelectBootableVolume({
       dvSource,
       pvcSource,
@@ -70,7 +66,7 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
   };
 
   const sizeData = getHumanizedSize(getDiskSize(dvSource, pvcSource, volumeSnapshotSource)).string;
-  const icon = getVolumeNameOSIcon(bootVolumeName) || getTemplateOSIcon(preference);
+  const icon = getBootableVolumeOSIcon(preference, bootVolumeName);
 
   return (
     <Tr isClickable isRowSelected={isSelected} isSelectable onClick={handleClick}>
@@ -93,8 +89,8 @@ const BootableVolumeRow: FC<BootableVolumeRowProps> = ({
         {getAnnotation(preference, PREFERENCE_DISPLAY_NAME_KEY, NO_DATA_DASH)}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="storage-class" width={15}>
-        {getVolumeSnapshotStorageClass(volumeSnapshotSource) ||
-          getPVCStorageClassName(pvcSource) ||
+        {getVolumeSnapshotStorageClass(volumeSnapshotSource) ??
+          getPVCStorageClassName(pvcSource) ??
           NO_DATA_DASH}
       </TableData>
       <TableData activeColumnIDs={activeColumnIDs} id="size" width={10}>

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/TemplatesCatalog.tsx
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/TemplatesCatalog.tsx
@@ -1,12 +1,12 @@
-import React, { FC, useCallback } from 'react';
+import React, { type FC, useCallback } from 'react';
 import { useWatch } from 'react-hook-form';
 
 import TemplatesFilter from '@kubevirt-utils/components/TemplatesFilter/TemplatesFilter';
 import { TemplatesFilterVariant } from '@kubevirt-utils/components/TemplatesFilter/types';
 import { logTemplateFlowEvent, TEMPLATE_SELECTED } from '@kubevirt-utils/extensions/telemetry';
+import { type Template } from '@kubevirt-utils/resources/template';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Card, Split, SplitItem } from '@patternfly/react-core';
-import { Template } from '@kubevirt-utils/resources/template';
 import { useVMWizard } from '@virtualmachines/wizard/state/vm-wizard-context/VMWizardContext';
 import {
   CREATE_VM_FORM_FIELDS_UI_STATE,
@@ -27,6 +27,7 @@ const TemplatesCatalog: FC = () => {
     availableTemplatesUID,
     bootSourcesLoaded,
     clearAll,
+    clusterPreferencesByName,
     filterDefinitions,
     filteredTemplates,
     filters,
@@ -34,6 +35,7 @@ const TemplatesCatalog: FC = () => {
     loaded,
     namespace,
     onSetFilters,
+    osDisplayNames,
     setIsList,
     setNamespace,
   } = useTemplatesCatalog();
@@ -84,9 +86,11 @@ const TemplatesCatalog: FC = () => {
               availableDatasources={availableDataSources}
               availableTemplatesUID={availableTemplatesUID}
               bootSourcesLoaded={bootSourcesLoaded}
+              clusterPreferencesByName={clusterPreferencesByName}
               isList={isList}
               loaded={loaded}
               onTemplateClick={handleTemplateSelect}
+              osDisplayNames={osDisplayNames}
               selectedTemplate={selectedTemplate}
               templates={filteredTemplates}
             />

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesCatalogItems/TemplatesCatalogItems.tsx
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesCatalogItems/TemplatesCatalogItems.tsx
@@ -1,21 +1,24 @@
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 
-import { V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
-import { getUID } from '@kubevirt-utils/resources/shared';
-import { getTemplateName, sortTemplates, Template } from '@kubevirt-utils/resources/template';
+import { type V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { getUID, type ResourceMap } from '@kubevirt-utils/resources/shared';
+import { getTemplateName, sortTemplates, type Template } from '@kubevirt-utils/resources/template';
 import { Gallery, StackItem } from '@patternfly/react-core';
 
+import { getTemplateClusterPreference } from '../../../../utils/getTemplateClusterPreference';
 import TemplatesTable from '../TemplatesTable/TemplatesTable';
-
 import TemplatesCatalogTile from './components/TemplatesCatalogTile';
 
 type TemplatesCatalogItemsProps = {
   availableDatasources: Record<string, V1beta1DataSource>;
   availableTemplatesUID: Set<string>;
   bootSourcesLoaded: boolean;
+  clusterPreferencesByName: ResourceMap<V1beta1VirtualMachineClusterPreference>;
   isList: boolean;
   loaded: boolean;
   onTemplateClick: (template: Template) => void;
+  osDisplayNames: Record<string, string>;
   selectedTemplate?: Template;
   templates: Template[];
 };
@@ -24,9 +27,11 @@ const TemplatesCatalogItems: FC<TemplatesCatalogItemsProps> = ({
   availableDatasources,
   availableTemplatesUID,
   bootSourcesLoaded,
+  clusterPreferencesByName,
   isList,
   loaded,
   onTemplateClick,
+  osDisplayNames,
   selectedTemplate,
   templates,
 }) => {
@@ -38,6 +43,7 @@ const TemplatesCatalogItems: FC<TemplatesCatalogItemsProps> = ({
         availableDatasources={availableDatasources}
         availableTemplatesUID={availableTemplatesUID}
         bootSourcesLoaded={bootSourcesLoaded}
+        clusterPreferencesByName={clusterPreferencesByName}
         loaded={loaded}
         onTemplateClick={onTemplateClick}
         templates={sortedTemplates}
@@ -48,9 +54,11 @@ const TemplatesCatalogItems: FC<TemplatesCatalogItemsProps> = ({
       <Gallery className="vm-catalog-grid" hasGutter id="vm-catalog-grid">
         {sortedTemplates.map((template) => (
           <TemplatesCatalogTile
+            clusterPreference={getTemplateClusterPreference(template, clusterPreferencesByName)}
             isSelected={getUID(selectedTemplate) === getUID(template)}
             key={getUID(template) ?? getTemplateName(template)}
             onClick={onTemplateClick}
+            osDisplayNames={osDisplayNames}
             template={template}
           />
         ))}

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesCatalogItems/components/TemplatesCatalogTile.tsx
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesCatalogItems/components/TemplatesCatalogTile.tsx
@@ -1,18 +1,17 @@
-import React, { type FC, memo, useMemo } from 'react';
+import React, { type FC, memo } from 'react';
 
+import { type V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DeprecatedBadge from '@kubevirt-utils/components/badges/DeprecatedBadge/DeprecatedBadge';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { getAnnotations, getName, getNamespace, getUID } from '@kubevirt-utils/resources/shared';
+import { getName, getNamespace, getUID } from '@kubevirt-utils/resources/shared';
 import {
   getTemplateCategoryDisplay,
   getTemplateFlavorData,
-  getTemplateOSLabelName,
   isDeprecatedTemplate,
   isVirtualMachineTemplate,
   type Template,
 } from '@kubevirt-utils/resources/template';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm';
-import { getOperatingSystemName } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import {
   Badge,
@@ -25,18 +24,21 @@ import {
   StackItem,
 } from '@patternfly/react-core';
 import { getTemplateArchitecture } from '@templates/utils/utils';
+import { getTemplateOSName } from '@virtualmachines/wizard/steps/TemplateStep/utils/getTemplateOSName';
 import { getTemplateOSIcon } from '@virtualmachines/wizard/utils/os-icons/os-icons';
 
 import './TemplatesCatalogTile.scss';
 
 export type TemplatesCatalogTileProps = {
+  clusterPreference: null | V1beta1VirtualMachineClusterPreference;
   isSelected?: boolean;
   onClick: (template: Template) => void;
+  osDisplayNames: Record<string, string>;
   template: Template;
 };
 
 const TemplatesCatalogTile: FC<TemplatesCatalogTileProps> = memo(
-  ({ isSelected, onClick, template }) => {
+  ({ clusterPreference, isSelected, onClick, osDisplayNames, template }) => {
     const { t } = useKubevirtTranslation();
 
     const isDeprecated = isDeprecatedTemplate(template);
@@ -44,13 +46,8 @@ const TemplatesCatalogTile: FC<TemplatesCatalogTileProps> = memo(
     const templateName = getName(template);
     const { cpuCount, memory } = getTemplateFlavorData(template);
     const architecture = getTemplateArchitecture(template);
-    const osName =
-      getOperatingSystemName(template) || getTemplateOSLabelName(template) || NO_DATA_DASH;
-
-    const icon = useMemo(() => {
-      return getTemplateOSIcon(template);
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [getAnnotations(template)?.iconClass]);
+    const osName = getTemplateOSName(template, clusterPreference, osDisplayNames) ?? NO_DATA_DASH;
+    const icon = getTemplateOSIcon(template, clusterPreference);
 
     return (
       <Card

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesTable/TemplatesTable.tsx
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesTable/TemplatesTable.tsx
@@ -2,14 +2,16 @@ import React, { type FC, useMemo } from 'react';
 import { useWatch } from 'react-hook-form';
 
 import { type V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { getUID } from '@kubevirt-utils/resources/shared';
+import { getUID, type ResourceMap } from '@kubevirt-utils/resources/shared';
 import { getTemplateName, type Template } from '@kubevirt-utils/resources/template';
 import { ARCHITECTURE_ID, ARCHITECTURE_TITLE } from '@kubevirt-utils/utils/architecture';
 import { Table, TableVariant, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
 import { useVMWizard } from '@virtualmachines/wizard/state/vm-wizard-context/VMWizardContext';
 import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/wizard/state/vm-wizard-form/consts';
 
+import { getTemplateClusterPreference } from '../../../../utils/getTemplateClusterPreference';
 import TemplatesTableRow from './TemplatesTableRow';
 
 import './TemplatesTable.scss';
@@ -18,6 +20,7 @@ type TemplatesTableProps = {
   availableDatasources: Record<string, V1beta1DataSource>;
   availableTemplatesUID: Set<string>;
   bootSourcesLoaded: boolean;
+  clusterPreferencesByName: ResourceMap<V1beta1VirtualMachineClusterPreference>;
   loaded: boolean;
   onTemplateClick: (template: Template) => void;
   templates: Template[];
@@ -27,6 +30,7 @@ const TemplatesTable: FC<TemplatesTableProps> = ({
   availableDatasources,
   availableTemplatesUID,
   bootSourcesLoaded,
+  clusterPreferencesByName,
   loaded,
   onTemplateClick,
   templates,
@@ -81,6 +85,7 @@ const TemplatesTable: FC<TemplatesTableProps> = ({
             activeColumnIDs={activeColumnIDs}
             availableDatasources={availableDatasources}
             availableTemplatesUID={availableTemplatesUID}
+            clusterPreference={getTemplateClusterPreference(template, clusterPreferencesByName)}
             key={getUID(template) ?? getTemplateName(template)}
             onSelectTemplate={onTemplateClick}
             selectedTemplate={selectedTemplate}

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesTable/TemplatesTableRow.tsx
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesTable/TemplatesTableRow.tsx
@@ -1,6 +1,7 @@
 import React, { type FC } from 'react';
 
 import { type V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ArchitectureLabel from '@kubevirt-utils/components/ArchitectureLabel/ArchitectureLabel';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getAnnotation, getName, getUID } from '@kubevirt-utils/resources/shared';
@@ -27,6 +28,7 @@ type TemplatesTableRowProps = {
   activeColumnIDs: string[];
   availableDatasources: Record<string, V1beta1DataSource>;
   availableTemplatesUID: Set<string>;
+  clusterPreference: null | V1beta1VirtualMachineClusterPreference;
   onSelectTemplate: (template: Template) => void;
   selectedTemplate?: Template;
   template: Template;
@@ -36,6 +38,7 @@ const TemplatesTableRow: FC<TemplatesTableRowProps> = ({
   activeColumnIDs,
   availableDatasources,
   availableTemplatesUID,
+  clusterPreference,
   onSelectTemplate,
   selectedTemplate,
   template,
@@ -68,7 +71,11 @@ const TemplatesTableRow: FC<TemplatesTableRowProps> = ({
     >
       <TemplatesTableRowCell activeColumnIDs={activeColumnIDs} id="name" width={35}>
         <Flex alignItems={{ default: 'alignItemsCenter' }} columnGap={{ default: 'columnGapXs' }}>
-          <img alt="os-icon" className="vm-catalog-row-icon" src={getTemplateOSIcon(template)} />
+          <img
+            alt="os-icon"
+            className="vm-catalog-row-icon"
+            src={getTemplateOSIcon(template, clusterPreference)}
+          />
           <FlexItem>
             <Content component={ContentVariants.small}>{getTemplateName(template)}</Content>
           </FlexItem>

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useTemplatesCatalog.ts
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useTemplatesCatalog.ts
@@ -1,24 +1,60 @@
 import { useMemo } from 'react';
 import { useWatch } from 'react-hook-form';
 
+import { type V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import useClusterPreferencesByName from '@kubevirt-utils/hooks/useClusterPreferencesByName';
 import useIsWindowsSupportedArchitecture from '@kubevirt-utils/hooks/useIsWindowsSupportedArchitecture';
+import {
+  type KubevirtFilter,
+  type KubevirtFilterState,
+  type OnSetFilters,
+} from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import useKubevirtDataViewFilters from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/useKubevirtDataViewFilters';
-import { OS_NAME_TYPES, type Template } from '@kubevirt-utils/resources/template';
+import { type ResourceMap } from '@kubevirt-utils/resources/shared';
+import {
+  OS_NAME_TYPES,
+  type Template,
+  type TemplateOrRequest,
+} from '@kubevirt-utils/resources/template';
 import { getTemplateOS } from '@kubevirt-utils/resources/template/utils/selectors';
 import useVirtualMachineTemplatesFilters from '@templates/list/filters/useVirtualMachineTemplatesFilters';
 import { useVMWizard } from '@virtualmachines/wizard/state/vm-wizard-context/VMWizardContext';
 import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/wizard/state/vm-wizard-form/consts';
 import useTemplatesWithAvailableSource from '@virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useTemplatesWithAvailableSource/useTemplatesWithAvailableSource';
 
+import { buildOSDisplayNameMap } from '../../../utils/buildOSDisplayNameMap';
 import useCatalogUIState from './useCatalogUIState';
 
-const useTemplatesCatalog = () => {
+type UseTemplatesCatalogReturn = {
+  availableDataSources: Record<string, V1beta1DataSource>;
+  availableTemplatesUID: Set<string>;
+  bootSourcesLoaded: boolean;
+  clearAll: () => void;
+  clusterPreferencesByName: ResourceMap<V1beta1VirtualMachineClusterPreference>;
+  filterDefinitions: KubevirtFilter<TemplateOrRequest>[];
+  filteredTemplates: Template[];
+  filters: KubevirtFilterState;
+  isList: boolean;
+  loaded: boolean;
+  namespace: string;
+  onSetFilters: OnSetFilters;
+  osDisplayNames: Record<string, string>;
+  setIsList: (value: boolean) => void;
+  setNamespace: (value: string) => void;
+};
+
+const useTemplatesCatalog = (): UseTemplatesCatalogReturn => {
   const { control } = useVMWizard();
   const cluster = useWatch({ control, name: CREATE_VM_FORM_FIELDS_VM_DATA.CLUSTER });
   const { isList, namespace, setIsList, setNamespace } = useCatalogUIState();
 
   const { availableDataSources, availableTemplatesUID, bootSourcesLoaded, loaded, templates } =
     useTemplatesWithAvailableSource({ clusterOverride: cluster, namespace });
+
+  const clusterPreferencesByName = useClusterPreferencesByName(cluster);
+
+  const osDisplayNames = useMemo(() => buildOSDisplayNameMap(templates), [templates]);
 
   const isWindowsSupported = useIsWindowsSupportedArchitecture(cluster);
 
@@ -43,6 +79,7 @@ const useTemplatesCatalog = () => {
     availableTemplatesUID,
     bootSourcesLoaded,
     clearAll: clearAllFilters,
+    clusterPreferencesByName,
     filterDefinitions,
     filteredTemplates: filteredData,
     filters,
@@ -50,6 +87,7 @@ const useTemplatesCatalog = () => {
     loaded,
     namespace,
     onSetFilters,
+    osDisplayNames,
     setIsList,
     setNamespace,
   };

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/TemplatesCatalogDrawer.tsx
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/TemplatesCatalogDrawer.tsx
@@ -1,19 +1,10 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { getName } from '@kubevirt-utils/resources/shared';
-import { Template } from '@kubevirt-utils/resources/template';
-import { getTemplateName } from '@kubevirt-utils/resources/template/utils/selectors';
-import { CatalogItemHeader } from '@patternfly/react-catalog-view-extension';
-import {
-  DrawerActions,
-  DrawerCloseButton,
-  DrawerHead,
-  DrawerPanelBody,
-  DrawerPanelContent,
-} from '@patternfly/react-core';
+import { type Template } from '@kubevirt-utils/resources/template';
+import { DrawerPanelBody, DrawerPanelContent } from '@patternfly/react-core';
 import { WIZARD_DRAWER_SIZE } from '@settings/constants';
-import { getTemplateOSIcon } from '@virtualmachines/wizard/utils/os-icons/os-icons';
 
+import TemplatesCatalogDrawerHeader from './components/TemplatesCatalogDrawerHeader';
 import TemplatesCatalogDrawerPanel from './components/TemplatesCatalogDrawerPanel/TemplatesCatalogDrawerPanel';
 import { DrawerContextProvider } from './hooks/useDrawerContext';
 
@@ -21,15 +12,11 @@ import './TemplateCatalogDrawer.scss';
 
 type TemplatesCatalogDrawerProps = {
   onClose: () => void;
-  template: Template | undefined;
+  template: null | Template;
 };
 
 export const TemplatesCatalogDrawer: FC<TemplatesCatalogDrawerProps> = ({ onClose, template }) => {
   if (!template) return null;
-
-  const name = getName(template);
-  const displayName = getTemplateName(template);
-  const osIcon = getTemplateOSIcon(template);
 
   return (
     <DrawerContextProvider template={template}>
@@ -38,17 +25,7 @@ export const TemplatesCatalogDrawer: FC<TemplatesCatalogDrawerProps> = ({ onClos
         maxSize={WIZARD_DRAWER_SIZE}
         minSize={WIZARD_DRAWER_SIZE}
       >
-        <DrawerHead>
-          <CatalogItemHeader
-            className="co-catalog-page__overlay-header"
-            iconImg={osIcon}
-            title={name}
-            vendor={displayName}
-          />
-          <DrawerActions>
-            <DrawerCloseButton onClick={onClose} />
-          </DrawerActions>
-        </DrawerHead>
+        <TemplatesCatalogDrawerHeader onClose={onClose} />
         <DrawerPanelBody>
           <TemplatesCatalogDrawerPanel />
         </DrawerPanelBody>

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/components/TemplateInfoSection.tsx
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/components/TemplateInfoSection.tsx
@@ -21,12 +21,12 @@ import {
 import { isVirtualMachineTemplate } from '@kubevirt-utils/resources/template/utils/types';
 import { getCPU } from '@kubevirt-utils/resources/vm';
 import { networksHavePodNetwork } from '@kubevirt-utils/resources/vm/utils/network/utils';
-import { getOperatingSystemName } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
 import { OLSPromptType } from '@lightspeed/utils/prompts';
 import { Alert, DescriptionList } from '@patternfly/react-core';
 import useWizardDisksTableData from '@virtualmachines/wizard/components/DisksReviewTable/hooks/useWizardDisksTableData/useWizardDisksTableData';
 import { useVMWizard } from '@virtualmachines/wizard/state/vm-wizard-context/VMWizardContext';
 import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/wizard/state/vm-wizard-form/consts';
+import { getTemplateOSName } from '@virtualmachines/wizard/steps/TemplateStep/utils/getTemplateOSName';
 import { useDrawerContext } from '@virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/hooks/useDrawerContext';
 
 import TemplateExpandableDescription from './TemplateExpandableDescription';
@@ -36,7 +36,7 @@ const TemplateInfoSection: FC = memo(() => {
   const { control } = useVMWizard();
   const cluster = useWatch({ control, name: CREATE_VM_FORM_FIELDS_VM_DATA.CLUSTER });
   const isIPv6SingleStack = useIsIPv6SingleStackCluster(cluster);
-  const { template, vm } = useDrawerContext();
+  const { clusterPreference, osDisplayNames, template, vm } = useDrawerContext();
   const [disks] = useWizardDisksTableData(vm);
 
   const notAvailable = t('N/A');
@@ -49,7 +49,8 @@ const TemplateInfoSection: FC = memo(() => {
 
   const hasPodNetwork = networksHavePodNetwork(networks);
 
-  const operatingSystem = getOperatingSystemName(template) || notAvailable;
+  const operatingSystem =
+    getTemplateOSName(template, clusterPreference, osDisplayNames) ?? notAvailable;
   const categoryOrWorkload = isVMTemplate
     ? getTemplateCategoryDisplay(template, t)
     : `${WORKLOADS_LABELS[workload] ?? t('Other')} ${isDefaultTemplate ? t('(default)') : ''}`;

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/components/TemplatesCatalogDrawerHeader.tsx
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/components/TemplatesCatalogDrawerHeader.tsx
@@ -1,0 +1,36 @@
+import React, { type FC } from 'react';
+
+import { getName } from '@kubevirt-utils/resources/shared';
+import { getTemplateName } from '@kubevirt-utils/resources/template/utils/selectors';
+import { CatalogItemHeader } from '@patternfly/react-catalog-view-extension';
+import { DrawerActions, DrawerCloseButton, DrawerHead } from '@patternfly/react-core';
+import { getTemplateOSIcon } from '@virtualmachines/wizard/utils/os-icons/os-icons';
+
+import { useDrawerContext } from '../hooks/useDrawerContext';
+
+type TemplatesCatalogDrawerHeaderProps = {
+  onClose: () => void;
+};
+
+const TemplatesCatalogDrawerHeader: FC<TemplatesCatalogDrawerHeaderProps> = ({ onClose }) => {
+  const { clusterPreference, template } = useDrawerContext();
+  const name = getName(template);
+  const displayName = getTemplateName(template);
+  const osIcon = getTemplateOSIcon(template, clusterPreference);
+
+  return (
+    <DrawerHead>
+      <CatalogItemHeader
+        className="co-catalog-page__overlay-header"
+        iconImg={osIcon}
+        title={name}
+        vendor={displayName}
+      />
+      <DrawerActions>
+        <DrawerCloseButton onClick={onClose} />
+      </DrawerActions>
+    </DrawerHead>
+  );
+};
+
+export default TemplatesCatalogDrawerHeader;

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/hooks/useDrawerContext.tsx
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/hooks/useDrawerContext.tsx
@@ -1,18 +1,34 @@
-import React, { createContext, FC, ReactNode, useContext, useEffect, useMemo } from 'react';
+import React, {
+  createContext,
+  type FC,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+} from 'react';
 import { useWatch } from 'react-hook-form';
-import { Updater, useImmer } from 'use-immer';
+import { type Updater, useImmer } from 'use-immer';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  type V1beta1VirtualMachineClusterPreference,
+  type V1VirtualMachine,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import useClusterPreferencesByName from '@kubevirt-utils/hooks/useClusterPreferencesByName';
 import {
   getTemplateVirtualMachineObject,
-  Template,
+  type Template,
   useVMTemplateSource,
 } from '@kubevirt-utils/resources/template';
+import { useOpenShiftTemplates } from '@templates/list/hooks/useOpenShiftTemplates';
 import { useVMWizard } from '@virtualmachines/wizard/state/vm-wizard-context/VMWizardContext';
 import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/wizard/state/vm-wizard-form/consts';
 import useVMTemplateGeneratedParams from '@virtualmachines/wizard/steps/TemplateStep/hooks/useVMTemplateGeneratedParams';
+import { buildOSDisplayNameMap } from '@virtualmachines/wizard/steps/TemplateStep/utils/buildOSDisplayNameMap';
+import { getTemplateClusterPreference } from '@virtualmachines/wizard/steps/TemplateStep/utils/getTemplateClusterPreference';
 
 export type DrawerContext = {
+  clusterPreference: null | V1beta1VirtualMachineClusterPreference;
+  osDisplayNames: Record<string, string>;
   setTemplate: Updater<Template>;
   template: Template;
   templateDataLoaded: boolean;
@@ -20,13 +36,34 @@ export type DrawerContext = {
   vm: V1VirtualMachine;
 };
 
-const useDrawer = (initialTemplate: Template) => {
+type DrawerContextProviderProps = {
+  children?: ReactNode;
+  template: Template;
+};
+
+const useDrawer = (initialTemplate: Template): DrawerContext => {
   const [template, setTemplate] = useImmer(initialTemplate);
   const { control } = useVMWizard();
   const cluster = useWatch({ control, name: CREATE_VM_FORM_FIELDS_VM_DATA.CLUSTER });
   const [templateWithGeneratedParams, loading, error] =
     useVMTemplateGeneratedParams(initialTemplate);
   const { loaded: bootSourceLoaded } = useVMTemplateSource(initialTemplate, cluster);
+
+  const clusterPreferencesByName = useClusterPreferencesByName(cluster);
+  const { templates: openShiftTemplates } = useOpenShiftTemplates({
+    clusterOverride: cluster,
+  });
+
+  const osDisplayNames = useMemo(
+    () => buildOSDisplayNameMap(openShiftTemplates),
+    [openShiftTemplates],
+  );
+
+  const resolvedTemplate = template || initialTemplate;
+  const clusterPreference = useMemo(
+    () => getTemplateClusterPreference(resolvedTemplate, clusterPreferencesByName),
+    [clusterPreferencesByName, resolvedTemplate],
+  );
 
   // reset drawer template state when selected template changes
   useEffect(() => {
@@ -41,16 +78,33 @@ const useDrawer = (initialTemplate: Template) => {
 
   const vm = useMemo(() => getTemplateVirtualMachineObject(template), [template]);
 
-  return {
-    setTemplate,
-    template: template || initialTemplate,
-    templateDataLoaded: !!templateWithGeneratedParams && !loading && bootSourceLoaded,
-    templateLoadingError: error,
-    vm,
-  };
+  return useMemo(
+    () => ({
+      clusterPreference,
+      osDisplayNames,
+      setTemplate,
+      template: resolvedTemplate,
+      templateDataLoaded: !!templateWithGeneratedParams && !loading && bootSourceLoaded,
+      templateLoadingError: error,
+      vm,
+    }),
+    [
+      bootSourceLoaded,
+      clusterPreference,
+      error,
+      loading,
+      osDisplayNames,
+      resolvedTemplate,
+      setTemplate,
+      templateWithGeneratedParams,
+      vm,
+    ],
+  );
 };
 
 const initialValue: DrawerContext = {
+  clusterPreference: null,
+  osDisplayNames: {},
   setTemplate: () => null,
   template: null,
   templateDataLoaded: false,
@@ -60,12 +114,9 @@ const initialValue: DrawerContext = {
 
 export const DrawerContext = createContext<DrawerContext>(initialValue);
 
-export const DrawerContextProvider: FC<{ children?: ReactNode; template: Template }> = ({
-  children,
-  template,
-}) => {
+export const DrawerContextProvider: FC<DrawerContextProviderProps> = ({ children, template }) => {
   const context = useDrawer(template);
   return <DrawerContext.Provider value={context}>{children}</DrawerContext.Provider>;
 };
 
-export const useDrawerContext = () => useContext(DrawerContext);
+export const useDrawerContext: () => DrawerContext = () => useContext(DrawerContext);

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/utils/buildOSDisplayNameMap.ts
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/utils/buildOSDisplayNameMap.ts
@@ -1,0 +1,29 @@
+import { getAnnotations } from '@kubevirt-utils/resources/shared';
+import { isOpenShiftTemplate, type Template } from '@kubevirt-utils/resources/template';
+import { NAME_OS_TEMPLATE_ANNOTATION } from '@kubevirt-utils/resources/vm';
+
+const NAME_OS_PREFIX = `${NAME_OS_TEMPLATE_ANNOTATION}/`;
+
+/**
+ * Builds a map from OS key (e.g. "centos-stream9") to human-readable name
+ * (e.g. "CentOS Stream 9") by extracting name.os.template.kubevirt.io/*
+ * annotations from all OpenShift templates.
+ */
+export const buildOSDisplayNameMap = (templates: Template[]): Record<string, string> => {
+  const map: Record<string, string> = {};
+
+  for (const template of templates) {
+    if (!isOpenShiftTemplate(template)) continue;
+
+    const annotations = getAnnotations(template);
+    if (!annotations) continue;
+
+    for (const [key, value] of Object.entries(annotations)) {
+      if (key.startsWith(NAME_OS_PREFIX) && value) {
+        const osKey = key.slice(NAME_OS_PREFIX.length);
+        map[osKey] ??= value;
+      }
+    }
+  }
+  return map;
+};

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/utils/getTemplateClusterPreference.ts
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/utils/getTemplateClusterPreference.ts
@@ -1,0 +1,22 @@
+import { type V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type ResourceMap } from '@kubevirt-utils/resources/shared';
+import {
+  getTemplateVirtualMachineObject,
+  isOpenShiftTemplate,
+  type Template,
+} from '@kubevirt-utils/resources/template';
+import { getPreferenceMatcher } from '@kubevirt-utils/resources/vm';
+
+export const getTemplateClusterPreference = (
+  template: Template,
+  clusterPreferencesByName: ResourceMap<V1beta1VirtualMachineClusterPreference>,
+): null | V1beta1VirtualMachineClusterPreference => {
+  if (isOpenShiftTemplate(template)) {
+    return null;
+  }
+
+  const vmObject = getTemplateVirtualMachineObject(template);
+  const preferenceName = getPreferenceMatcher(vmObject)?.name ?? '';
+
+  return clusterPreferencesByName[preferenceName];
+};

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/utils/getTemplateOSName.ts
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/utils/getTemplateOSName.ts
@@ -1,0 +1,55 @@
+import { type V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { getDisplayName } from '@kubevirt-utils/resources/shared';
+import {
+  getTemplateOSAnnotation,
+  type Template,
+  WINDOWS,
+} from '@kubevirt-utils/resources/template';
+import {
+  getOperatingSystemName,
+  OS_WINDOWS_PREFIX,
+} from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
+
+/**
+ * Looks up a human-readable OS name from the map built by buildOSDisplayNameMap.
+ *
+ * Handles known convention mismatches between vm.kubevirt.io/os values
+ * and name.os.template.kubevirt.io/* annotation keys:
+ *  - Exact match: centos-stream9 → centos-stream9
+ *  - Prefix match: rhel8 → rhel8.0 (OS key is a prefix of the template key)
+ *  - Windows alias: windows2k16 → win2k16 (vm.kubevirt.io/os uses "windows" prefix,
+ *    while OpenShift templates use "win" prefix)
+ */
+const lookupOSDisplayName = (osKey: string, map: Record<string, string>): string | undefined => {
+  const newOSKey = osKey.startsWith(WINDOWS) ? osKey.replace(WINDOWS, OS_WINDOWS_PREFIX) : osKey;
+
+  if (map[newOSKey]) return map[newOSKey];
+
+  const prefixMatch = Object.keys(map).find((key) => key.startsWith(newOSKey));
+  if (prefixMatch) return map[prefixMatch];
+
+  return undefined;
+};
+
+export const getTemplateOSName = (
+  template: Template,
+  clusterPreference: null | V1beta1VirtualMachineClusterPreference,
+  osDisplayNames?: Record<string, string>,
+): string | undefined => {
+  const osNameFromAnnotation = getOperatingSystemName(template);
+  if (osNameFromAnnotation) return osNameFromAnnotation;
+
+  const preferenceDisplayName = clusterPreference
+    ? getDisplayName(clusterPreference as K8sResourceCommon)
+    : undefined;
+  if (preferenceDisplayName) return preferenceDisplayName;
+
+  const osKey = getTemplateOSAnnotation(template);
+
+  if (osKey && osDisplayNames) {
+    const displayName = lookupOSDisplayName(osKey, osDisplayNames);
+    if (displayName) return displayName;
+  }
+
+  return osKey;
+};

--- a/src/views/virtualmachines/wizard/utils/os-icons/os-icons.tsx
+++ b/src/views/virtualmachines/wizard/utils/os-icons/os-icons.tsx
@@ -1,17 +1,24 @@
-import { isValidTemplateIconUrl, OS_NAME_TYPES } from '@kubevirt-utils/resources/template';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { type V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { getIconClass } from '@kubevirt-utils/resources/shared';
+import {
+  getTemplateOSAnnotation,
+  isValidTemplateIconUrl,
+  type OS_NAME_TYPES,
+  type Template,
+} from '@kubevirt-utils/resources/template';
+import { OS_WINDOWS_PREFIX } from '@kubevirt-utils/resources/vm/utils/operation-system/operationSystem';
 
-const bsd = require('./svg/bsd.svg') as string;
-const centos = require('./svg/centos.svg') as string;
-const debian = require('./svg/debian.svg') as string;
-const fedora = require('./svg/fedora.svg') as string;
-const opensuse = require('./svg/opensuse.svg') as string;
-const rhel = require('./svg/rhel.svg') as string;
-const ubuntu = require('./svg/ubuntu.svg') as string;
-const windows = require('./svg/windows.svg') as string;
-const linux = require('./svg/linux.svg') as string;
+import bsd from './svg/bsd.svg';
+import centos from './svg/centos.svg';
+import debian from './svg/debian.svg';
+import fedora from './svg/fedora.svg';
+import linux from './svg/linux.svg';
+import opensuse from './svg/opensuse.svg';
+import rhel from './svg/rhel.svg';
+import ubuntu from './svg/ubuntu.svg';
+import windows from './svg/windows.svg';
 
-const iconMap = {
+const iconMap: Record<string, string> = {
   'icon-bsd': bsd,
   'icon-centos': centos,
   'icon-debian': debian,
@@ -24,17 +31,55 @@ const iconMap = {
   'icon-windows': windows,
 };
 
-export const getTemplateOSIcon = (template: K8sResourceCommon): string => {
-  const icon = template?.metadata?.annotations?.iconClass;
+const ICON_OTHER = iconMap['icon-other'];
+
+/**
+ * Get the icon from the operating system shortcut.
+ * Example shortcuts: "rhel8", "centos-stream9", "windows2k16"
+ */
+const getOSIconFromOSShortcut = (osShortcut: string): string | undefined => {
+  if (osShortcut.startsWith(OS_WINDOWS_PREFIX)) {
+    return iconMap['icon-windows'];
+  }
+  const icon = 'icon-'.concat(osShortcut.replace(/\d/, '').split('-')[0]);
+  return iconMap[icon];
+};
+
+export const getTemplateOSIcon = (
+  template: Template,
+  clusterPreference?: null | V1beta1VirtualMachineClusterPreference,
+): string => {
+  const icon =
+    getIconClass(template) ??
+    (clusterPreference ? getIconClass(clusterPreference as K8sResourceCommon) : undefined);
+
+  if (!icon) {
+    const osAnnotation = getTemplateOSAnnotation(template);
+    return (osAnnotation && getOSIconFromOSShortcut(osAnnotation)) ?? ICON_OTHER;
+  }
+
   if (isValidTemplateIconUrl(icon)) {
     return icon;
   }
-  return iconMap[icon] || iconMap['icon-other'];
+  return iconMap[icon] ?? ICON_OTHER;
 };
 
-export const getVolumeNameOSIcon = (volumeName: string): string => {
-  const icon = 'icon-'.concat(volumeName.replace(/\d/, '').split('-')[0]);
-  return iconMap[icon];
+export const getBootableVolumeOSIcon = (
+  clusterPreference?: null | V1beta1VirtualMachineClusterPreference,
+  volumeName?: string,
+): string => {
+  const icon = getIconClass(clusterPreference as K8sResourceCommon);
+
+  if (icon) {
+    if (isValidTemplateIconUrl(icon)) return icon;
+    if (iconMap[icon]) return iconMap[icon] ?? ICON_OTHER;
+  }
+
+  if (volumeName) {
+    return getOSIconFromOSShortcut(volumeName) ?? ICON_OTHER;
+  }
+
+  return ICON_OTHER;
 };
 
 export const getIconByOSName = (osName: OS_NAME_TYPES | string): string =>


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Show correct OS and icon for `VirtualMachineTemplates` in VM wizard

- `VirtualMachineTemplates` don't have `iconClass` or OS name annotation -> we need a fallback
  - use preference name if there is one to match `iconClass` / display name on the preference
  - use OS shortcut name (e.g. rhel8, centos-stream9) to match the icon or original OpenShift template - and use its readable OS name
  
TODO:
- currently only Cluster Preferences are used - we also need to match by User Preference namespace/name

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-96216

## 🎥 Demo

Setup 

- `custom-vm` is created with `rhel.10` preference
- `template-vm` is created from `centos-stream9` OpenShift Template

https://github.com/user-attachments/assets/22317cea-0200-4ddd-ac5c-3d1557a71b0a


Before:

https://github.com/user-attachments/assets/59101ee7-92da-4e41-aadb-8a8ff0970317



After:

https://github.com/user-attachments/assets/e113e436-dad0-4307-a79c-640361607a1f



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Template catalogs now display more accurate operating-system names and icons.
  - Operating-system information can be resolved from template settings, cluster preferences, and available template metadata.
  - Template details drawers show consistent names and icons in their headers and information sections.
  - Bootable volume icons now support additional operating systems, custom icons, and improved fallback handling.
- **Improvements**
  - Template and volume displays handle missing or unavailable metadata more gracefully.
  - Added Fedora icon support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->