### PR TITLE
CNV-96480: fix recommended capabillities links and status

### DIFF
--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/hooks/useOperatorResources/usePackageManifests.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/hooks/useOperatorResources/usePackageManifests.ts
@@ -7,7 +7,11 @@ import { type PackageManifestKind } from '@overview/utils/types';
 
 import { PACKAGE_MANIFESTS_WATCH_KEY } from './utils/constants';
 import { type UsePackageManifestsParams, type UsePackageManifestsReturn } from './utils/types';
-import { getPackageManifestWatchResources } from './utils/utils';
+import {
+  getPackageManifestWatchResources,
+  mapWatchResourceErrors,
+  selectPreferredPackageManifests,
+} from './utils/utils';
 
 const usePackageManifests = ({
   cluster,
@@ -24,18 +28,20 @@ const usePackageManifests = ({
     useKubevirtWatchResources<Record<string, PackageManifestKind[]>>(packageManifestResources);
 
   const packageManifestWatch = packageManifestData?.[PACKAGE_MANIFESTS_WATCH_KEY];
-  const allManifests = (packageManifestWatch?.data ?? []) as PackageManifestKind[];
   const loaded = packageManifestWatch?.loaded ?? false;
-  const loadError = packageManifestWatch?.loadError;
 
   const packageManifests = useMemo(() => {
     if (!loaded) return [];
 
+    const allManifests = packageManifestWatch?.data ?? [];
     const nameSet = new Set(memoizedPackageNames);
-    return allManifests.filter((pkg) => nameSet.has(getName(pkg)));
-  }, [allManifests, loaded, memoizedPackageNames]);
+    return selectPreferredPackageManifests(allManifests.filter((pkg) => nameSet.has(getName(pkg))));
+  }, [loaded, memoizedPackageNames, packageManifestWatch?.data]);
 
-  const loadErrors = useMemo(() => (loadError ? [loadError] : []), [loadError]);
+  const loadErrors = useMemo(
+    () => mapWatchResourceErrors([PACKAGE_MANIFESTS_WATCH_KEY], packageManifestData),
+    [packageManifestData],
+  );
 
   return useMemo(
     () => ({ loaded, loadErrors, packageManifests }),

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/hooks/useOperatorResources/utils/utils.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/hooks/useOperatorResources/utils/utils.ts
@@ -14,11 +14,35 @@ import {
 } from '@overview/utils/types';
 import { type FleetWatchK8sResource } from '@stolostron/multicluster-sdk';
 
-import { OPENSHIFT_MARKETPLACE_NAMESPACE } from '../../../utils/constants';
-import { RED_HAT_CATALOG_SOURCE } from '../../../utils/createOperator/constants';
+import { OPENSHIFT_MARKETPLACE_NAMESPACE, RED_HAT } from '../../../utils/constants';
+import {
+  isRedHatCatalogSource,
+  RED_HAT_CATALOG_SOURCE,
+} from '../../../utils/createOperator/constants';
 import { getSubscriptionInstalledCSV, subscriptionFor } from '../../../utils/operatorResolution';
 import { PACKAGE_MANIFESTS_WATCH_KEY } from './constants';
 import { type OperatorWatchResourceResult } from './types';
+
+const catalogSourceOf = (pkg: PackageManifestKind): string => pkg.status?.catalogSource ?? '';
+
+const pickPreferred = (candidates: PackageManifestKind[]): PackageManifestKind | undefined =>
+  candidates.find((pkg) => catalogSourceOf(pkg) === RED_HAT_CATALOG_SOURCE) ??
+  candidates.find((pkg) => isRedHatCatalogSource(catalogSourceOf(pkg))) ??
+  candidates.find((pkg) => pkg.status?.provider?.name?.includes(RED_HAT)) ??
+  candidates[0];
+
+/** One PackageManifest per package name, preferring redhat-operators then redhat-operators*. */
+export const selectPreferredPackageManifests = (
+  manifests: PackageManifestKind[],
+): PackageManifestKind[] => {
+  const names = [
+    ...new Set(manifests.map(getName).filter((name): name is string => Boolean(name))),
+  ];
+
+  return names
+    .map((name) => pickPreferred(manifests.filter((pkg) => getName(pkg) === name)))
+    .filter((pkg): pkg is PackageManifestKind => Boolean(pkg));
+};
 
 export const getCsvResourceKey = (packageName: string): string =>
   `clusterServiceVersion_${packageName}`;
@@ -77,7 +101,6 @@ export const getPackageManifestWatchResources = (
     groupVersionKind: getGroupVersionKindForModel(PackageManifestModel),
     isList: true,
     namespace: OPENSHIFT_MARKETPLACE_NAMESPACE,
-    selector: { matchLabels: { catalog: RED_HAT_CATALOG_SOURCE } },
   },
 });
 

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/createOperator/constants.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/createOperator/constants.ts
@@ -6,6 +6,9 @@ export const OPERATOR_MONITORING_DEFAULT_ANNOTATION_KEY =
 
 export const RED_HAT_CATALOG_SOURCE = 'redhat-operators';
 
+export const isRedHatCatalogSource = (catalogSource: string | undefined): boolean =>
+  Boolean(catalogSource?.startsWith(RED_HAT_CATALOG_SOURCE));
+
 export const OPENSHIFT_OPERATORS_NAMESPACE = 'openshift-operators';
 
 export const HTTP_CONFLICT_CODE = 409;

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/createOperator/helpers.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/createOperator/helpers.ts
@@ -20,7 +20,7 @@ import {
 } from '@overview/utils/types';
 
 import { CONSOLE_OPERATOR_CONFIG_NAME } from '../constants';
-import { RED_HAT_CATALOG_SOURCE } from './constants';
+import { isRedHatCatalogSource } from './constants';
 
 export enum OLMAnnotation {
   ActionText = 'marketplace.openshift.io/action-text',
@@ -120,7 +120,7 @@ export const getClusterServiceVersionPlugins: AnnotationParser<string[]> = (
   }) ?? [];
 
 export const isCatalogSourceTrusted = (catalogSource: string): boolean =>
-  catalogSource === RED_HAT_CATALOG_SOURCE;
+  isRedHatCatalogSource(catalogSource);
 
 export const getPrometheusRole = (namespace: string) => {
   return {


### PR DESCRIPTION


## 📝 Description

Recommended Capabilities treated operators as missing unless their `PackageManifest` came from the exact redhat-operators catalog. Watch all marketplace manifests and prefer `redhat-operators` / `redhat-operators* `so install status and OperatorHub links work when Red Hat operators are published from versioned or alternate catalog sources.

## 🔗 Links

> Add JIRA, Docs, and other PR/Issue links

Jira: https://redhat.atlassian.net/browse/CNV-96480

## 🎥 Demo

Before:
<img width="1174" height="584" alt="Screenshot at Sep 07 13-43-32" src="https://github.com/user-attachments/assets/dea15744-f966-4e65-83d1-7e000415eaf4" />
<img width="1247" height="526" alt="Screenshot at Sep 07 13-43-11" src="https://github.com/user-attachments/assets/c17fc7fe-8b56-4d07-beff-ef098e9c3ede" />

After:
<img width="1327" height="747" alt="Screenshot at Sep 07 13-42-24" src="https://github.com/user-attachments/assets/e1a5952c-4e1a-46ca-b7b8-a5c496317a22" />
<img width="1202" height="515" alt="Screenshot at Sep 07 13-42-48" src="https://github.com/user-attachments/assets/9b70605c-784c-4a1d-8609-d5d425c1ae07" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Recommended capabilities now consider marketplace package manifests from multiple catalog sources.
  * When multiple manifests are available for a package, the most appropriate manifest is selected, prioritizing Red Hat sources.
  * Red Hat catalog source recognition now supports catalog variants consistently.

* **Bug Fixes**
  * Improved error reporting when loading package-manifest data, providing more accurate watch-resource errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->