### PR TITLE
CNV-96321: fix tree view last item being cut off

### DIFF
--- a/src/views/virtualmachines/tree/VirtualMachineTreeView.scss
+++ b/src/views/virtualmachines/tree/VirtualMachineTreeView.scss
@@ -72,7 +72,7 @@
 }
 
 .vms-tree-view-body {
-  --pf-v6-c-drawer__panel__body--PaddingBlockEnd: 30px;
+  --pf-v6-c-drawer__panel__body--PaddingBlockEnd: var(--pf-t--global--spacer--2xl);
   padding: 0 var(--pf-t--global--spacer--sm);
   height: 100%;
   overflow-y: auto;

--- a/src/views/virtualmachines/tree/components/TreeViewToolbar.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FC } from 'react';
+import React, { type ChangeEvent, type FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useIsACMPage from '@multicluster/useIsACMPage';
@@ -12,7 +12,6 @@ import {
 } from '@patternfly/react-core';
 
 import { TREE_VIEW_SEARCH_ID } from '../utils/constants';
-
 import ShowOnlyVMProjectsSwitch from './ShowOnlyVMProjectsSwitch';
 
 type TreeViewToolbarProps = {
@@ -25,7 +24,7 @@ const TreeViewToolbar: FC<TreeViewToolbarProps> = ({ hasVMs, onSearch }) => {
   const isACMPage = useIsACMPage();
 
   return (
-    <Toolbar className="vms-tree-view-toolbar" isSticky>
+    <Toolbar className="vms-tree-view-toolbar">
       <ToolbarContent className="vms-tree-view-toolbar-content">
         <Stack className="vms-tree-view__toolbar-section">
           <StackItem>


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

- fixes tree view - last item was being cut off in the scrollable view

- improve background styling of the tree view toolbar by removing `isSticky`  

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-96321

## 🎥 Demo

Before:
<img width="1009" height="640" alt="Screenshot 2026-09-07 at 15 41 09" src="https://github.com/user-attachments/assets/5e676659-41ba-4ca5-baab-43e037751eb8" />

After:
<img width="1009" height="640" alt="Screenshot 2026-09-07 at 15 40 23" src="https://github.com/user-attachments/assets/cfb1dbb1-a2df-4617-b974-67fc7564feb6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the virtual machine tree drawer spacing to use the platform’s standard 2XL spacing, improving visual consistency.
  - Adjusted the tree view toolbar so it no longer remains fixed while scrolling, providing more natural page movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->