### PR TITLE
CNV-96421: Add spacing between volume project and name fields

### DIFF
--- a/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/DiskSourcePVCSelect.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/DiskSourcePVCSelect.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useMemo } from 'react';
+import React, { type FC, useCallback, useMemo } from 'react';
 
 import useProjects from '@kubevirt-utils/hooks/useProjects';
 import usePVCs from '@kubevirt-utils/hooks/usePVCs';
@@ -30,7 +30,7 @@ const DiskSourcePVCSelect: FC<DiskSourcePVCSelectProps> = ({
 
   const onSelectProject = useCallback(
     (newProject) => {
-      selectPVCNamespace && selectPVCNamespace(newProject);
+      selectPVCNamespace?.(newProject);
       selectPVCName(undefined);
     },
     [selectPVCNamespace, selectPVCName],
@@ -40,18 +40,22 @@ const DiskSourcePVCSelect: FC<DiskSourcePVCSelectProps> = ({
     (selection) => {
       selectPVCName(selection);
       const selectedPVC = pvcs?.find((pvc) => pvc?.metadata?.name === selection);
-      setDiskSize && setDiskSize(formatQuantityString(getPVCSize(selectedPVC)));
+      setDiskSize?.(formatQuantityString(getPVCSize(selectedPVC)));
     },
     [selectPVCName, pvcs, setDiskSize],
   );
 
   const pvcNames = useMemo(
-    () => pvcs?.map((pvc) => pvc?.metadata?.name)?.sort((a, b) => a?.localeCompare(b)),
+    () =>
+      pvcs
+        ?.map((pvc) => pvc?.metadata?.name)
+        ?.filter((name): name is string => Boolean(name))
+        ?.sort((a, b) => a.localeCompare(b)),
     [pvcs],
   );
 
   return (
-    <div>
+    <>
       <DiskSourcePVCSelectNamespace
         isDisabled={!selectPVCNamespace}
         onChange={onSelectProject}
@@ -66,7 +70,7 @@ const DiskSourcePVCSelect: FC<DiskSourcePVCSelectProps> = ({
         pvcNameSelected={pvcNameSelected}
         pvcsLoaded={pvcsLoaded}
       />
-    </div>
+    </>
   );
 };
 

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/DiskSourcePVCSelectNamespace.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeSource/components/DiskSourcePVCSelectNamespace.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FC, SetStateAction } from 'react';
+import React, { type Dispatch, type FC, type SetStateAction } from 'react';
 
 import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
@@ -27,13 +27,7 @@ const DiskSourcePVCSelectNamespace: FC<DiskSourcePVCSelectNamespaceProps> = ({
   const fieldId = 'pvc-project-select';
 
   return (
-    <FormGroup
-      className="pvc-selection-formgroup"
-      fieldId={fieldId}
-      id={fieldId}
-      isRequired
-      label={t('Volume project')}
-    >
+    <FormGroup fieldId={fieldId} id={fieldId} isRequired label={t('Volume project')}>
       {projectsLoaded ? (
         <>
           <InlineFilterSelect
@@ -42,13 +36,13 @@ const DiskSourcePVCSelectNamespace: FC<DiskSourcePVCSelectNamespaceProps> = ({
               groupVersionKind: modelToGroupVersionKind(ProjectModel),
               value: name,
             }))}
+            placeholder={t('Select volume project')}
+            selected={selectedProject}
+            setSelected={onChange}
             toggleProps={{
               isDisabled,
               isFullWidth: true,
             }}
-            placeholder={t('Select volume project')}
-            selected={selectedProject}
-            setSelected={onChange}
           />
           <FormGroupHelperText>{t('Location of the existing volume')}</FormGroupHelperText>
         </>


### PR DESCRIPTION
## 📝 Description

Fixes missing spacing between the **Volume project** and **Volume name** fields in the Add volume form when source type is **Use existing → Volume**.



## 🔗 Links

Jira: https://issues.redhat.com/browse/CNV-96421

## 🎥 Demo

Before: Volume project and Volume name fields rendered with no vertical gap.

<img width="628" height="797" alt="Screenshot 2026-09-07 at 16 07 18" src="https://github.com/user-attachments/assets/d32f3558-7213-46fc-88f6-aafec04f5e33" />


After: Standard medium spacing between the two fields, matching other form groups in the modal.

<img width="607" height="807" alt="Screenshot 2026-09-07 at 16 09 21" src="https://github.com/user-attachments/assets/9f25ae12-630a-4fab-b9a7-38c0281297fa" />



## Test plan

- [ ] Open Bootable volumes → Add volume → With form
- [ ] Select Source type: Use existing → Volume
- [ ] Verify spacing between Volume project and Volume name fields matches other fields in the form

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bootable volume selection by excluding PVC entries without names.
  - Prevented errors when optional disk-size or namespace selection controls are unavailable.
  - Improved stability when selecting PVC-based disk sources.

- **UI Improvements**
  - Simplified the volume source selection layout without changing its visible functionality.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->