### PR TITLE
CNV-96422: Prevent guest OS type toggle flicker on card switch

### DIFF
--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/components/OperatingSystemTileGroup/OperatingSystemTileGroup.tsx
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/components/OperatingSystemTileGroup/OperatingSystemTileGroup.tsx
@@ -32,7 +32,6 @@ const OperatingSystemTileGroup: FC = () => {
             isSelected={operatingSystemType === osType}
             onClick={() => {
               setValue(CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.OPERATING_SYSTEM_TYPE, osType);
-              setValue(CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.PREFERENCE, null);
               resetBootableVolumeFields(getValues, setValue);
             }}
             operatingSystem={osType}

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/components/PreferenceSelectMenu/hooks/usePreferenceSelectOptions/usePreferenceSelectOptions.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/components/PreferenceSelectMenu/hooks/usePreferenceSelectOptions/usePreferenceSelectOptions.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import { useWatch } from 'react-hook-form';
 
-import { PreferenceOption } from '@kubevirt-utils/components/AddBootableVolumeModal/types';
+import { type PreferenceOption } from '@kubevirt-utils/components/AddBootableVolumeModal/types';
 import useClusterPreferences from '@kubevirt-utils/hooks/useClusterPreferences';
 import useHcoWorkloadArchitectures from '@kubevirt-utils/hooks/useHcoWorkloadArchitectures';
 import useUserPreferences from '@kubevirt-utils/hooks/useUserPreferences';
@@ -11,7 +11,7 @@ import {
   getDefaultPreference,
   getSortedPreferencesByOSType,
 } from '@virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/components/PreferenceSelectMenu/hooks/usePreferenceSelectOptions/utils/utils';
-import { OperatingSystemType } from '@virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/utils/constants';
+import { type OperatingSystemType } from '@virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/utils/constants';
 
 type UsePreferenceSelectOptions = (
   namespace: string,
@@ -53,7 +53,10 @@ const usePreferenceSelectOptions: UsePreferenceSelectOptions = (
     if (!isPreferencesLoaded) return;
 
     const defaultPref = getDefaultPreference(preferences, operatingSystemType, architectures);
-    if (!preference && defaultPref) {
+    const isCurrentPreferenceValid =
+      preference && preferences.some((pref) => pref.name === preference.name);
+
+    if (!isCurrentPreferenceValid && defaultPref) {
       setValue(CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA.PREFERENCE, defaultPref);
     }
   }, [architectures, isPreferencesLoaded, operatingSystemType, preference, preferences, setValue]);


### PR DESCRIPTION
## 📝 Description

Fixes a brief flicker of "Select guest operating system type" in the Guest operating system type toggle when switching between guest OS cards in the Create VM wizard.

Switching OS cards was clearing the preference to `null` before the new default preference was applied, causing the toggle to briefly fall back to the placeholder text. The fix keeps the previous selection visible until the new OS-type default is ready.

## 🔗 Links

Jira: https://issues.redhat.com/browse/CNV-96422

## 🎥 Demo

Before: Switching from RHEL to Windows or Other Linux briefly shows "Select guest operating system type" in the toggle.

https://github.com/user-attachments/assets/2479d512-5cf9-48d5-ace7-8781483f8afa


After: Toggle keeps the previous preference label until the new default preference is applied.


https://github.com/user-attachments/assets/02c28d85-9cb3-4f8a-8ab9-6de056ab6565


## Test plan

- [ ] Open Create VM wizard → Guest OS step
- [ ] Select RHEL card and note the Guest operating system type toggle label
- [ ] Switch to Microsoft Windows card — toggle should not briefly show the placeholder
- [ ] Switch to Other Linux card — same behavior
- [ ] Verify the toggle updates to the correct default preference for each OS type

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Instance type preferences are now preserved when selecting a different operating system.
  - Bootable volume selections continue to reset when required.
  - If a selected preference is unavailable for the current options, the system now automatically selects the applicable default preference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->