### PR TITLE
CNV-96723: Display error message when vm to clone does not exist - Testing

### DIFF
--- a/playwright/src/components/vm-wizard/vm-wizard-navigation-component.ts
+++ b/playwright/src/components/vm-wizard/vm-wizard-navigation-component.ts
@@ -1,6 +1,6 @@
 import BaseComponent from '@/components/shared/base-component';
 import { TestTimeouts } from '@/utils/test-config';
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 export default class VmWizardNavigationComponent extends BaseComponent {
   private readonly _buttonEditVMCreationLocation = this.locator(
@@ -25,6 +25,9 @@ export default class VmWizardNavigationComponent extends BaseComponent {
   private readonly _wizardFooterCreateButton = this.page
     .getByTestId('wizard-create-button')
     .filter({ hasText: 'Create VirtualMachine' });
+  private readonly _wizardFooterCloneButton = this.page
+    .getByTestId('wizard-create-button')
+    .filter({ hasText: 'Clone VirtualMachine' });
   private readonly _wizardFooterNextButton = this.page
     .getByTestId('wizard-next-button')
     .filter({ hasText: 'Next' });
@@ -102,6 +105,10 @@ export default class VmWizardNavigationComponent extends BaseComponent {
   async clickCreateVm(): Promise<void> {
     await this.collapseSidebarIfExpanded();
     const createBtn = this._wizardFooterCreateButton;
+    await this.clickCreateVMButton(createBtn);
+  }
+
+  async clickCreateVMButton(createBtn: Locator): Promise<void> {
     await createBtn.waitFor({
       state: 'visible',
       timeout: TestTimeouts.SHORT_WAIT,
@@ -117,6 +124,22 @@ export default class VmWizardNavigationComponent extends BaseComponent {
 
     await this.robustClick(createBtn);
     await this.page.waitForTimeout(2000);
+  }
+
+  async clickCloneVm(): Promise<void> {
+    await this.collapseSidebarIfExpanded();
+    const cloneBtn = this._wizardFooterCloneButton;
+    await this.clickCreateVMButton(cloneBtn);
+  }
+
+  async getWizardErrorAlertMessage(): Promise<string> {
+    try {
+      const alert = this._wizardContainer.locator('.pf-v6-c-alert.pf-m-danger');
+      await alert.waitFor({ state: 'visible', timeout: TestTimeouts.SHORT_WAIT });
+      return (await alert.textContent())?.trim() || '';
+    } catch {
+      return '';
+    }
   }
 
   async clickNext(): Promise<void> {
@@ -358,7 +381,9 @@ export default class VmWizardNavigationComponent extends BaseComponent {
 
     await this.openEditLocationPanel();
 
-    const toggle = this.locator('.vm-creation-wizard').getByTestId('namespace-dropdown-menu-toggle');
+    const toggle = this.locator('.vm-creation-wizard').getByTestId(
+      'namespace-dropdown-menu-toggle',
+    );
     await toggle.first().waitFor({ state: 'visible', timeout: TestTimeouts.ELEMENT_WAIT });
     await this.robustClick(toggle.first());
 

--- a/playwright/tests/tier2/create-vm/create-vm-wizard-clone-deleted-source.spec.ts
+++ b/playwright/tests/tier2/create-vm/create-vm-wizard-clone-deleted-source.spec.ts
@@ -1,0 +1,105 @@
+import { ADMIN_ONLY_TAG, T2, T2_TAG } from '@/data-models/allure-constants';
+import { expect, test } from '@/fixtures/create-vm-fixture';
+import VmDetailPage from '@/page-objects/vm/vm-detail-page';
+import { TEMPLATE_METADATA_NAMES } from '@/utils/template-constants';
+import { setupTestNamespace } from '@/utils/test-setup-helpers';
+
+const SUITE = 'VM Creation Wizard';
+
+test.describe(
+  'VM Creation Wizard — Clone existing VirtualMachine',
+  { tag: [T2_TAG, '@catalog-wizard', ADMIN_ONLY_TAG] },
+  () => {
+    test('Shows an error when the source VM is deleted before cloning completes', async ({
+      apiClient,
+      context,
+      vmListPage,
+      vmWizardNavigationPage,
+      vmWizardComputePage,
+      utils,
+    }) => {
+      test.setTimeout(utils.TestTimeouts.TEST_EXTENDED);
+      await utils.withAllure({
+        suite: SUITE,
+        feature: T2,
+        tags: [T2_TAG],
+      });
+
+      const cloneNs = await setupTestNamespace(apiClient, 'wizard-clone-del');
+      const sourceVmName = utils.generateRandomVmName('clone-src');
+      await test.step('Precondition: Create a running source VM via K8s API', async () => {
+        await apiClient.createVmFromTemplate(
+          TEMPLATE_METADATA_NAMES.RHEL9,
+          sourceVmName,
+          cloneNs,
+          'openshift',
+          true,
+        );
+        apiClient.trackResource('VirtualMachine', sourceVmName, cloneNs);
+        await utils.waitForVirtualMachineReady(
+          apiClient,
+          sourceVmName,
+          cloneNs,
+          utils.TestTimeouts.VM_BOOTUP,
+        );
+      });
+
+      await vmListPage.switchToVirtualizationPerspective();
+
+      await test.step('Open Create VM wizard and select Clone existing VirtualMachine', async () => {
+        await vmListPage.navigateToProjectVmListViaUI(cloneNs);
+        await vmWizardNavigationPage.openWizardFromCreateDropdown();
+
+        const wizardVisible = await vmWizardNavigationPage.verifyWizardVisible();
+        expect(wizardVisible, 'Wizard should open').toBe(true);
+
+        await vmWizardNavigationPage.selectCreationMethod('cloneVm');
+        await vmWizardNavigationPage.clickNext();
+      });
+
+      await test.step('Select the source VM and advance to Review and create', async () => {
+        const sourceStepVisible = await vmWizardNavigationPage.verifyCloneSourceStepVisible();
+        expect(sourceStepVisible, 'Source step should be visible').toBe(true);
+
+        await vmWizardNavigationPage.searchCloneSourceByName(sourceVmName);
+        await vmWizardNavigationPage.selectCloneSourceVm(sourceVmName);
+        await vmWizardNavigationPage.clickNext();
+
+        const reviewVisible = await vmWizardComputePage.verifyReviewStepVisible();
+        expect(reviewVisible, 'Review and create step should be visible').toBe(true);
+      });
+
+      await test.step('In a second console tab, stop and delete the source VM', async () => {
+        const secondTab = await context.newPage();
+        const vmDetailPage = new VmDetailPage(secondTab);
+
+        await vmDetailPage.navigateToVirtualMachineDetail(sourceVmName, cloneNs);
+        await vmDetailPage.stopVmFromActionsDropdown();
+        await utils.waitForVirtualMachineStopped(
+          apiClient,
+          sourceVmName,
+          cloneNs,
+          utils.TestTimeouts.VM_BOOTUP,
+        );
+        await vmDetailPage.clickVmActionsDropdown();
+        await vmDetailPage.deleteVm();
+        await apiClient.waitForVmDeleted(sourceVmName, cloneNs);
+        await secondTab.close();
+      });
+
+      await test.step('Submit clone and verify an error is shown', async () => {
+        await vmWizardNavigationPage.clickCloneVm();
+        const errorAlert = await vmWizardNavigationPage.getWizardErrorAlertMessage();
+        expect
+          .soft(errorAlert, 'Wizard should show a danger alert after clone failure')
+          .toContain('An error occurred');
+        expect(errorAlert, `Error should mention that ${sourceVmName} no longer exists`).toContain(
+          `${sourceVmName} VirtualMachine no longer exists`,
+        );
+
+        const reviewStillVisible = await vmWizardComputePage.verifyReviewStepVisible();
+        expect(reviewStillVisible, 'Wizard should remain on Review and create').toBe(true);
+      });
+    });
+  },
+);


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

* Added test file to verify that error message is displayed when selected vm to clone no longer exists
## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-96723

## 🎥 Demo

No visual changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated coverage for cloning a virtual machine when the selected source is deleted before submission.
  - Verified that the creation wizard displays an appropriate error message and keeps the user on the review step.
  - Improved test coverage for VM creation and cloning navigation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->