### PR TITLE
CNV-96829: Added missing automation for hostname modal in VM wizard

### DIFF
--- a/playwright/src/components/vm-wizard/vm-wizard-compute-customization-component.ts
+++ b/playwright/src/components/vm-wizard/vm-wizard-compute-customization-component.ts
@@ -19,6 +19,13 @@ export default class VmWizardComputeCustomizationComponent extends BaseComponent
   );
   private readonly _pfV6CWizardInputTypeText = this.locator('.pf-v6-c-wizard input[type="text"]');
   private readonly _roleTabpanel = this.locator('[role="tabpanel"]');
+  private readonly _hostnameModal = this.testId('dialog-modal').filter({
+    has: this.page.getByRole('heading', { name: 'Edit hostname' }),
+  });
+  private readonly _hostnameModalInput = this._hostnameModal.getByRole('textbox', {
+    name: 'Hostname',
+  });
+  private readonly _hostnameModalSaveButton = this._hostnameModal.getByTestId('save-button');
   private readonly _startAfterCreateCheckbox = this.locator('#start-after-create-checkbox');
   private readonly _startThisVirtualMachineAfterCreation = this.locator(
     'text=Start this VirtualMachine after creation',
@@ -220,6 +227,43 @@ export default class VmWizardComputeCustomizationComponent extends BaseComponent
     } catch {
       return '';
     }
+  }
+
+  async fillHostnameModal(value: string): Promise<void> {
+    await this._hostnameModalInput.fill(value);
+  }
+
+  async isHostnameModalOpen(): Promise<boolean> {
+    return this._hostnameModal.isVisible();
+  }
+
+  async isHostnameModalSaveEnabled(): Promise<boolean> {
+    return this._hostnameModalSaveButton.isEnabled();
+  }
+
+  async isHostnameModalValidationErrorVisible(expected: RegExp | string): Promise<boolean> {
+    return this._hostnameModal.getByText(expected).isVisible();
+  }
+
+  async openHostnameModal(hostname: string): Promise<void> {
+    const hostnameValue = this._roleTabpanel.getByRole('button', { exact: true, name: hostname });
+    await this.robustClick(hostnameValue);
+    await this._hostnameModal.waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+  }
+
+  async saveHostnameModal(): Promise<void> {
+    await this.robustClick(this._hostnameModalSaveButton);
+    await this._hostnameModal.waitFor({
+      state: 'hidden',
+      timeout: TestTimeouts.UI_ACTION_COMPLETE,
+    });
+  }
+
+  async submitHostnameModalWithEnter(): Promise<void> {
+    await this._hostnameModalInput.press('Enter');
   }
 
   async getReviewDescription(): Promise<string> {

--- a/playwright/tests/tier1/create-vm/create-vm-wizard-from-template.spec.md
+++ b/playwright/tests/tier1/create-vm/create-vm-wizard-from-template.spec.md
@@ -5,7 +5,7 @@
 - **Project Name:** KubeVirt UI — Playwright E2E Tests
 - **Feature Area:** Tier1 — VM creation wizard
 - **Latest version:** CNV 5.1.0
-- **Latest update:** 2026-09-03
+- **Latest update:** 2026-09-08
 - **Document Status:** Approved
 
 ## 2. Introduction
@@ -13,61 +13,76 @@
 ### 2.1 Purpose
 
 Verify the Create from Template VM creation wizard happy path: selecting From Template, picking
-`rhel9-server-small`, customization (including protection of system annotations and labels), review,
-and successful VM creation.
+`rhel9-server-small`, validating and saving a custom hostname, protecting system annotations and
+labels, reviewing the configuration, and successfully creating the VM.
 
 ### 2.2 Scope
 
-- **In-Scope:** Wizard steps 1–4 for Create from Template, Labels and annotations tab protection for
-  `vm.kubevirt.io/validations` and `vm.kubevirt.io/template`, redirect to VM details, VM resource
-  existence.
+- **In-Scope:** Wizard steps 1–4 for Create from Template; generated hostname; required and RFC 1123
+  hostname validation on submission with Enter; valid hostname persistence; Labels and annotations
+  tab protection for `vm.kubevirt.io/validations` and `vm.kubevirt.io/template`; redirect to VM
+  details; VM resource existence.
 - **Out-of-Scope:** Custom configuration and clone existing VM flows (covered by
-  `create-vm-wizard-custom-config.spec.ts` and `create-vm-wizard-clone.spec.ts`).
+  `create-vm-wizard-custom-config.spec.ts` and `create-vm-wizard-clone.spec.ts`); hostname validation
+  on blur without submission; maximum-length and trailing-hyphen hostname validation; editing the
+  hostname from an existing VM's details page.
 
 ## 3. Test Environment & Prerequisites
 
-- **Environment:** OpenShift with CNV operator installed; Playwright `Tier1` project.
-- **Configuration:** Admin access; RHEL9 template `rhel9-server-small` available in the cluster
-  template catalog.
-- **Initial Setup:** Each test creates its own namespace via `setupTestNamespace`; the created VM is
-  tracked via `apiClient.trackResource('VirtualMachine', ...)` for automatic cleanup.
+- **Environment:** OpenShift with the CNV operator installed; Playwright `Tier1` project; kubeadmin
+  or an equivalent cluster-admin session.
+- **Configuration:** RHEL9 template `rhel9-server-small` is available in the cluster template
+  catalog; the console URL and authentication credentials are configured for Playwright.
+- **Initial Setup:** Each test creates an isolated namespace via `setupTestNamespace`; the created VM
+  is tracked via `apiClient.trackResource('VirtualMachine', ...)` for automatic cleanup.
 
 ---
 
 ## 4. Test Case Definitions
 
 **Spec file:** `tests/tier1/create-vm/create-vm-wizard-from-template.spec.ts`
-**Describe:** `VM Creation Wizard — Create from Template happy path` — **Tags:** `@tier1`, `@catalog-wizard`, `@adminOnly`
-**Allure:** suite `VM Creation Wizard`, feature `Tier 1`
+**Describe:** `VM Creation Wizard — Create from Template happy path` — **Tags:** `@tier1`,
+`@catalog-wizard`, `@adminOnly`
+**Allure:** suite `VM Creation Wizard`, feature `Tier1`
 
 ---
 
-### `001`: From Template wizard creates a RHEL9 VM and protects system metadata
+### `001`: Create a RHEL9 VM from a template with validated hostname and protected system metadata
 
-- **Objective:** Verify that a VM can be created from `rhel9-server-small` and that template system
-  annotations and labels cannot be deleted from the table or the edit modal.
+- **Objective:** Verify that the template wizard rejects empty and invalid hostnames without closing
+  the modal or changing the generated value, accepts a valid hostname, prevents deletion of template
+  system annotations and labels, and creates the resulting VM.
 - **Target version:** CNV 5.1.0
-- **Jira References:** CNV-95902
-- **Pre-conditions:** `rhel9-server-small` template is available in the catalog.
-- **Tags:** `@adminOnly`
+- **Jira References:** CNV-95902, CNV-96404
+- **Pre-conditions:** `rhel9-server-small` is available in the catalog, and the user can create
+  namespaces and VirtualMachines.
+- **Tags:** `@tier1`, `@catalog-wizard`, `@adminOnly`
 
-| Step | Action                                                      | Expected Result                                                        |
-| :--- | :---------------------------------------------------------- | :--------------------------------------------------------------------- |
-| 1    | Open the create VM wizard and select From Template          | Wizard opens; Create from Template is selected                         |
-| 2    | Verify the template catalog and select `rhel9-server-small` | Catalog toolbar and cards are visible; Next is enabled after selection |
-| 3    | On Customization, open Labels and annotations               | `vm.kubevirt.io/validations` is present; table delete is disabled      |
-| 4    | Open Edit annotations and check the validations row         | Modal delete is disabled; cancel closes the modal                      |
-| 5    | Open Edit labels and check `vm.kubevirt.io/template`        | Table and modal delete are disabled; cancel closes the modal           |
-| 6    | Continue to Review and create the VM                        | Redirects to VM details; the VM resource exists                        |
+| Step | Action                                                                                 | Expected Result                                                                                       |
+| :--- | :------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------- |
+| 1    | Create an isolated namespace and open the create VM wizard from the namespaced VM list | The creation wizard is visible                                                                        |
+| 2    | Select From Template, generate a VM name, and continue                                 | From Template is selected and the wizard advances to the template catalog                             |
+| 3    | Verify the template catalog and select `rhel9-server-small`                            | Catalog controls and template cards are visible; Next becomes enabled                                 |
+| 4    | Continue to Customization and read the generated hostname                              | Customization tabs are visible and the generated hostname is non-empty                                |
+| 5    | Open Edit hostname, clear the field, and submit with Enter                             | The required-field error appears; the modal remains open and the generated hostname remains unchanged |
+| 6    | Enter `--` and submit with Enter                                                       | The RFC 1123 error appears; the modal remains open and the generated hostname remains unchanged       |
+| 7    | Enter `hostname` and save                                                              | Save becomes enabled, the modal closes, and `hostname` is displayed in Customization                  |
+| 8    | Open Labels and annotations and inspect `vm.kubevirt.io/validations`                   | The annotation is present and cannot be deleted from the table or edit modal                          |
+| 9    | Inspect `vm.kubevirt.io/template` and open Edit labels                                 | The label is present and cannot be deleted from the table or edit modal                               |
+| 10   | Continue to Review, create the VM, and verify it through the API                       | The console redirects to VM details and the VM exists in the isolated namespace                       |
 
 ---
 
 ## 5. Requirements Traceability Matrix
 
+Maps Jira tickets to the test cases that provide coverage. Tickets without a specific test case
+indicate a planned coverage gap (status: Pending).
+
 | Jira Ticket | Test Case ID | Coverage Type           | Status    |
 | ----------- | ------------ | ----------------------- | --------- |
 | —           | `001`        | Functional smoke        | Automated |
 | CNV-95902   | `001`        | Bugfix regression guard | Automated |
+| CNV-96404   | `001`        | Bugfix regression guard | Automated |
 
 **Coverage Type values:**
 

--- a/playwright/tests/tier1/create-vm/create-vm-wizard-from-template.spec.ts
+++ b/playwright/tests/tier1/create-vm/create-vm-wizard-from-template.spec.ts
@@ -62,15 +62,77 @@ test.describe(
         await vmWizardNavigationPage.clickNext();
       });
 
-      await test.step('Step 3: Customization — verify tabs and auto-generated hostname', async () => {
+      await test.step('Step 3: Customization — validate and edit hostname', async () => {
         const custVisible = await vmWizardComputePage.verifyCustomizationStepVisible();
         expect(custVisible, 'Customization step should be visible').toBe(true);
 
         const tabsVisible = await vmWizardComputePage.verifyCustomizationTabsVisible();
         expect.soft(tabsVisible, 'Customization tabs should be visible').toBe(true);
 
-        const hostname = await vmWizardComputePage.getCustomizationVmName();
-        expect.soft(hostname.length, 'Hostname should be auto-generated').toBeGreaterThan(0);
+        const generatedHostname = await vmWizardComputePage.getCustomizationVmName();
+        expect(generatedHostname.length, 'Hostname should be auto-generated').toBeGreaterThan(0);
+
+        await vmWizardComputePage.openHostnameModal(generatedHostname);
+
+        await vmWizardComputePage.fillHostnameModal('');
+        await vmWizardComputePage.submitHostnameModalWithEnter();
+
+        await expect
+          .poll(
+            () =>
+              vmWizardComputePage.isHostnameModalValidationErrorVisible('This field is required'),
+            {
+              message: 'Empty hostname should show the required validation error',
+              timeout: utils.TestTimeouts.UI_VISIBILITY_QUICK,
+            },
+          )
+          .toBe(true);
+        expect(
+          await vmWizardComputePage.isHostnameModalOpen(),
+          'Hostname modal should remain open',
+        ).toBe(true);
+        expect(
+          await vmWizardComputePage.getCustomizationVmName(),
+          'Empty hostname should not be saved',
+        ).toBe(generatedHostname);
+
+        await vmWizardComputePage.fillHostnameModal('--');
+        await vmWizardComputePage.submitHostnameModalWithEnter();
+
+        await expect
+          .poll(
+            () =>
+              vmWizardComputePage.isHostnameModalValidationErrorVisible('lowercase RFC 1123 label'),
+            {
+              message: 'Invalid hostname should show the RFC 1123 validation error',
+              timeout: utils.TestTimeouts.UI_VISIBILITY_QUICK,
+            },
+          )
+          .toBe(true);
+        expect(
+          await vmWizardComputePage.isHostnameModalOpen(),
+          'Hostname modal should remain open',
+        ).toBe(true);
+        expect(
+          await vmWizardComputePage.getCustomizationVmName(),
+          'Invalid hostname should not be saved',
+        ).toBe(generatedHostname);
+
+        await vmWizardComputePage.fillHostnameModal('hostname');
+        await expect
+          .poll(() => vmWizardComputePage.isHostnameModalSaveEnabled(), {
+            message: 'Save should be enabled for a valid hostname',
+            timeout: utils.TestTimeouts.UI_VISIBILITY_QUICK,
+          })
+          .toBe(true);
+        await vmWizardComputePage.saveHostnameModal();
+
+        await expect
+          .poll(() => vmWizardComputePage.getCustomizationVmName(), {
+            message: 'Updated hostname should be displayed',
+            timeout: utils.TestTimeouts.UI_ACTION_COMPLETE,
+          })
+          .toBe('hostname');
 
         await test.step('Template annotation vm.kubevirt.io/validations cannot be deleted', async () => {
           const validationsKey = 'vm.kubevirt.io/validations';


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Added automated tests for hostname modal in VM wizard.

The tests are covering following scenarios:

1. Hostname modal opens and submit is attempted with empty value in the hostname field
2. Invalid value is filled in submit is attempted with Enter key
3. Valid value is filled in and form is submitted
4. Written value to the VM wizard is verified

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-96829

## 🎥 Demo

<img width="1014" height="643" alt="Screenshot 2026-09-08 at 7 30 17" src="https://github.com/user-attachments/assets/61336ee9-7cb9-4b28-aaa4-d45dc97db195" />

<img width="1014" height="836" alt="Screenshot 2026-09-08 at 7 31 52" src="https://github.com/user-attachments/assets/1de9a746-d8be-4bf9-a101-6a6c8457e622" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded VM creation wizard coverage for editing generated hostnames.
  - Added validation checks for required values and lowercase RFC 1123 hostname rules.
  - Added coverage confirming valid hostname updates are saved and displayed.
  - Added verification that protected VM metadata remains unchanged.
- **Documentation**
  - Updated the related test documentation, steps, environment details, tags, traceability, and tracking reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->