### PR TITLE
CNV-85796: recommended capabilities e2e tests

### DIFF
--- a/playwright/src/components/overview/overview-settings-component.ts
+++ b/playwright/src/components/overview/overview-settings-component.ts
@@ -809,6 +809,11 @@ export default class OverviewSettingsComponent extends BaseComponent {
     }
   }
 
+  async navigateToRecommendedCapabilities(): Promise<void> {
+    await this.navigateToSettingsViaSidebar();
+    await this.navigateToTab(this.testId('settings-tab-recommended'));
+  }
+
   async navigateToSettings() {
     await this.navigateToSettingsViaSidebar();
   }

--- a/playwright/src/components/settings/recommended-capabilities-component.ts
+++ b/playwright/src/components/settings/recommended-capabilities-component.ts
@@ -1,0 +1,256 @@
+/**
+ * Locators and interactions for the Recommended capabilities Settings tab.
+ */
+
+import BaseComponent from '@/components/shared/base-component';
+import { CAPABILITY_STATUS } from '@/data-models/recommended-capabilities-constants';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Locator, Page } from '@playwright/test';
+
+export default class RecommendedCapabilitiesComponent extends BaseComponent {
+  private readonly _additionalCardTitle = this.page.getByText(
+    'Additional capabilities (manual setup required)',
+    { exact: true },
+  );
+
+  private readonly _autoCardTitle = this.page.getByText('Install capabilities automatically', {
+    exact: true,
+  });
+
+  private readonly _content = this.testId('recommended-capabilities');
+  private readonly _count = this.testId('capabilities-count');
+  private readonly _heading = this.page.getByRole('heading', {
+    name: 'Manage Virtualization capabilities',
+  });
+
+  private readonly _installSelected = this.testId('install-selected-capabilities');
+  private readonly _reviewModal = this.testId('review-recommendation-modal');
+  private readonly _search = this.testId('search-capabilities');
+  private readonly _statusFilter = this.testId('capability-status-filter');
+  private readonly _tab = this.testId('settings-tab-recommended');
+
+  constructor(page: Page) {
+    super(page);
+  }
+
+  get additionalCardTitleLocator(): Locator {
+    return this._additionalCardTitle;
+  }
+
+  get autoCardTitleLocator(): Locator {
+    return this._autoCardTitle;
+  }
+
+  get contentLocator(): Locator {
+    return this._content;
+  }
+
+  get countLocator(): Locator {
+    return this._count;
+  }
+
+  get headingLocator(): Locator {
+    return this._heading;
+  }
+
+  get installSelectedLocator(): Locator {
+    return this._installSelected;
+  }
+
+  get reviewModalLocator(): Locator {
+    return this._reviewModal;
+  }
+
+  get reviewRecommendationLocator(): Locator {
+    return this.testId('review-recommendation');
+  }
+
+  get tabLocator(): Locator {
+    return this._tab;
+  }
+
+  capabilityLocator(id: string): Locator {
+    return this.testId(`capability-${id}`);
+  }
+
+  capabilityRow(id: string): Locator {
+    return this.page.locator('tr, [role="row"]', { has: this.testId(`capability-${id}`) }).first();
+  }
+
+  operatorLocator(packageName: string): Locator {
+    return this.testId(`operator-${packageName}`);
+  }
+
+  operatorRow(packageName: string): Locator {
+    return this.page
+      .locator('tr, [role="row"]', { has: this.testId(`operator-${packageName}`) })
+      .first();
+  }
+
+  kebabInRow(row: Locator): Locator {
+    return row.getByTestId('kebab-button');
+  }
+
+  configurationStatusInRow(row: Locator): Locator {
+    return row.getByTestId('configuration-status');
+  }
+
+  async getOperatorConfigStatus(packageName: string): Promise<string> {
+    const status = this.configurationStatusInRow(this.operatorRow(packageName));
+    return ((await status.textContent()) ?? '').trim();
+  }
+
+  async findOperatorPackageByConfigStatus(
+    packageNames: readonly string[],
+    status: string,
+  ): Promise<string | undefined> {
+    for (const packageName of packageNames) {
+      if (
+        !(await this.operatorLocator(packageName)
+          .isVisible()
+          .catch(() => false))
+      ) {
+        continue;
+      }
+      if ((await this.getOperatorConfigStatus(packageName)) === status) {
+        return packageName;
+      }
+    }
+    return undefined;
+  }
+
+  async waitForLoaded(): Promise<void> {
+    await this._content.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await this.capabilityLocator('load-balancing').waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+  }
+
+  async searchCapabilities(term: string): Promise<void> {
+    const input = this._search.locator('input');
+    await input.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await input.fill(term);
+  }
+
+  async clearSearch(): Promise<void> {
+    const clearButton = this._search.locator(
+      'button[aria-label="Reset"], button[aria-label="Clear"]',
+    );
+    if (await clearButton.isVisible().catch(() => false)) {
+      await this.robustClick(clearButton);
+      return;
+    }
+    await this._search.locator('input').fill('');
+  }
+
+  async filterByStatus(statusLabel: string): Promise<void> {
+    await this.robustClick(this._statusFilter.locator('button').first());
+    const option = this.page
+      .getByRole('menuitem', { name: statusLabel })
+      .or(this.page.getByRole('checkbox', { name: statusLabel }))
+      .or(this.page.locator('[role="option"]', { hasText: statusLabel }));
+    await this.robustClick(option.first());
+    await this.page.keyboard.press('Escape');
+  }
+
+  async expandCapability(id: string): Promise<void> {
+    const row = this.capabilityRow(id);
+    const toggle = row
+      .locator('button[aria-expanded]')
+      .or(row.locator('.pf-v6-c-table__toggle button'))
+      .first();
+    await toggle.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    if ((await toggle.getAttribute('aria-expanded')) !== 'true') {
+      await this.robustClick(toggle);
+    }
+  }
+
+  async selectCapability(id: string): Promise<void> {
+    const checkbox = this.capabilityRow(id).getByRole('checkbox');
+    await checkbox.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    if (!(await checkbox.isChecked())) {
+      await this.robustClick(checkbox);
+    }
+  }
+
+  async clickInstallSelected(): Promise<void> {
+    await this.robustClick(this._installSelected);
+  }
+
+  async hoverInstallSelected(): Promise<void> {
+    await this._installSelected.hover({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+  }
+
+  async openCapabilityKebab(id: string): Promise<void> {
+    await this.robustClick(this.kebabInRow(this.capabilityRow(id)));
+  }
+
+  async openOperatorKebab(packageName: string): Promise<void> {
+    await this.robustClick(this.kebabInRow(this.operatorRow(packageName)));
+  }
+
+  kebabActionLocator(actionId: string): Locator {
+    return this.testId(actionId);
+  }
+
+  async clickKebabAction(actionId: string): Promise<void> {
+    await this.robustClick(this.kebabActionLocator(actionId));
+  }
+
+  async closeKebab(): Promise<void> {
+    await this.page.keyboard.press('Escape');
+  }
+
+  async clickOperatorLink(packageName: string): Promise<void> {
+    await this.robustClick(this.operatorLocator(packageName));
+  }
+
+  async clickReviewRecommendation(): Promise<void> {
+    await this.robustClick(this.reviewRecommendationLocator.first());
+  }
+
+  async cancelReviewModal(): Promise<void> {
+    await this.robustClick(this.testId('cancel-button'));
+  }
+
+  async getCapabilityStatus(id: string): Promise<string> {
+    const row = this.capabilityRow(id);
+    if (
+      await row
+        .getByLabel(CAPABILITY_STATUS.INSTALLING)
+        .isVisible()
+        .catch(() => false)
+    ) {
+      return CAPABILITY_STATUS.INSTALLING;
+    }
+    const status = row.locator('.pf-v6-c-label').first();
+    return ((await status.textContent()) ?? '').trim();
+  }
+
+  async findCapabilityIdByStatus(
+    ids: readonly string[],
+    status: string,
+  ): Promise<string | undefined> {
+    for (const id of ids) {
+      if (
+        !(await this.capabilityLocator(id)
+          .isVisible()
+          .catch(() => false))
+      ) {
+        continue;
+      }
+      if ((await this.getCapabilityStatus(id)) === status) {
+        return id;
+      }
+    }
+    return undefined;
+  }
+
+  installationToastLocator(capabilityTitle?: string): Locator {
+    const toast = this.page.locator('[role="alert"], .pf-v6-c-alert').filter({
+      hasText: 'Installation started',
+    });
+    return capabilityTitle ? toast.filter({ hasText: capabilityTitle }) : toast;
+  }
+}

--- a/playwright/src/data-models/allure-constants.ts
+++ b/playwright/src/data-models/allure-constants.ts
@@ -93,3 +93,6 @@ export const AUTO_LABELS_TAG = '@auto-labels';
 
 /** Allure feature label for auto-applied labels tests. */
 export const AUTO_LABELS_FEATURE = 'Auto-Applied Labels';
+
+/** Playwright/Allure tag for Recommended capabilities tab tests. */
+export const RECOMMENDED_CAPABILITIES_TAG = '@tier2-recommended-capabilities';

--- a/playwright/src/data-models/recommended-capabilities-constants.ts
+++ b/playwright/src/data-models/recommended-capabilities-constants.ts
@@ -1,0 +1,83 @@
+/**
+ * Capability IDs and titles for the Recommended capabilities Settings tab.
+ * IDs match `capabilityFeatures.ts` in product code.
+ */
+
+export const AUTO_CAPABILITY_IDS = [
+  'load-balancing',
+  'migrate-vms',
+  'virtualization-dashboards',
+] as const;
+
+export const AUTO_CAPABILITY_TITLES = [
+  'Load balancing',
+  'Migrate VMs',
+  'Virtualization dashboards',
+] as const;
+
+export const MANUAL_CAPABILITY_IDS = [
+  'backup-and-recovery',
+  'hardware-aware-scheduling',
+  'high-availability',
+  'host-network-management',
+  'isolated-workloads',
+  'manage-clusters-from-hub',
+  'numa-aware-scheduling',
+  'storage-on-local-disks',
+] as const;
+
+export const MANUAL_CAPABILITY_TITLES = [
+  'Backup and recovery',
+  'Hardware-aware scheduling',
+  'High availability',
+  'Host network management',
+  'Isolated workloads (Kata)',
+  'Manage clusters from a hub',
+  'NUMA-aware scheduling',
+  'Storage on local disks',
+] as const;
+
+export const PREFERRED_INSTALL_CAPABILITY_ID = 'migrate-vms';
+
+export const LOAD_BALANCING_OPERATORS = [
+  { displayName: 'Descheduler', packageName: 'cluster-kube-descheduler-operator' },
+  { displayName: 'MetalLB', packageName: 'metallb-operator' },
+] as const;
+
+export const AUTO_CAPABILITY_OPERATORS: Record<string, readonly string[]> = {
+  'load-balancing': ['cluster-kube-descheduler-operator', 'metallb-operator'],
+  'migrate-vms': ['mtv-operator'],
+  'virtualization-dashboards': [
+    'cluster-observability-operator',
+    'loki-operator',
+    'cluster-logging',
+  ],
+};
+
+export const HIGH_AVAILABILITY_OPERATORS = [
+  { displayName: 'Node health check', packageName: 'node-healthcheck-operator' },
+  { displayName: 'Fence agents remediation', packageName: 'fence-agents-remediation' },
+  { displayName: 'Node maintenance', packageName: 'node-maintenance-operator' },
+] as const;
+
+export const AUTOPILOT_PACKAGE_NAMES = [
+  'cluster-kube-descheduler-operator',
+  'metallb-operator',
+  'mtv-operator',
+  'cluster-observability-operator',
+  'loki-operator',
+  'cluster-logging',
+] as const;
+
+export const CAPABILITY_STATUS = {
+  INSTALLED: 'Installed',
+  NOT_INSTALLED: 'Not installed',
+  PARTIALLY_INSTALLED: 'Partially installed',
+  INSTALLING: 'Installing',
+} as const;
+
+export const CONFIGURATION_STATUS = {
+  MANUAL: 'Manual',
+  NONE: '-',
+  RECOMMENDED: 'Recommended',
+} as const;

--- a/playwright/src/fixtures/recommended-capabilities-fixture.ts
+++ b/playwright/src/fixtures/recommended-capabilities-fixture.ts
@@ -1,0 +1,21 @@
+/**
+ * Recommended capabilities test fixture.
+ *
+ * Provides RecommendedCapabilitiesPage for Settings → Recommended capabilities specs.
+ */
+
+import RecommendedCapabilitiesPage from '@/page-objects/settings/recommended-capabilities-page';
+
+import { baseTest, expect } from './scenario-test-fixture';
+
+interface RecommendedCapabilitiesFixtures {
+  recommendedCapabilitiesPage: RecommendedCapabilitiesPage;
+}
+
+const test = baseTest.extend<RecommendedCapabilitiesFixtures>({
+  recommendedCapabilitiesPage: async ({ page }, use) => {
+    await use(new RecommendedCapabilitiesPage(page));
+  },
+});
+
+export { expect, test };

--- a/playwright/src/fixtures/settings-fixture.ts
+++ b/playwright/src/fixtures/settings-fixture.ts
@@ -1,8 +1,8 @@
 /**
  * Settings test fixture.
  *
- * Provides SettingsPage — the standalone page object covering all three
- * Virtualization Settings tabs (Cluster, User, Preview features).
+ * Provides SettingsPage — the standalone page object covering Virtualization
+ * Settings tabs (Cluster, User, Recommended capabilities, Preview features).
  *
  * All settings specs must use this fixture and be tagged @cnv-settings.
  */

--- a/playwright/src/page-objects/settings/recommended-capabilities-page.ts
+++ b/playwright/src/page-objects/settings/recommended-capabilities-page.ts
@@ -1,0 +1,81 @@
+/**
+ * Page object for Virtualization Settings → Recommended capabilities.
+ */
+
+import RecommendedCapabilitiesComponent from '@/components/settings/recommended-capabilities-component';
+import OverviewSettingsPage from '@/page-objects/overview/overview-settings-page';
+import { TestTimeouts } from '@/utils/test-config';
+import type { Page } from '@playwright/test';
+
+import BasePage from '../base-page';
+
+export default class RecommendedCapabilitiesPage extends BasePage {
+  private readonly _capabilities: RecommendedCapabilitiesComponent;
+  private readonly _settings: OverviewSettingsPage;
+
+  constructor(page: Page) {
+    super(page);
+    this._capabilities = new RecommendedCapabilitiesComponent(page);
+    this._settings = new OverviewSettingsPage(page);
+  }
+
+  get capabilities(): RecommendedCapabilitiesComponent {
+    return this._capabilities;
+  }
+
+  async navigateViaSidebar(): Promise<void> {
+    await this._settings.navigateToRecommendedCapabilities();
+    await this._capabilities.waitForLoaded();
+  }
+
+  async navigateViaSearch(): Promise<void> {
+    await this._settings.navigateToSettingsViaSidebar();
+    await this._settings.fillConfigurationSearchInput(
+      'Recommended capabilities',
+      'Recommended capabilities',
+    );
+    await this._capabilities.waitForLoaded();
+  }
+
+  async navigateToSettingsViaSidebar(): Promise<void> {
+    await this._settings.navigateToSettingsViaSidebar();
+  }
+
+  async navigateBackToTab(): Promise<void> {
+    const content = this._capabilities.contentLocator;
+    const recommendedPath = '/virtualization-settings/recommended';
+
+    // Software Catalog often appends &version= as a second history entry after selectedId.
+    await this.page
+      .waitForURL(/\/catalog\/.*[?&]version=/, { timeout: TestTimeouts.SHORT_WAIT })
+      .catch(() => undefined);
+
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const onTab =
+        this.page.url().includes(recommendedPath) && (await content.isVisible().catch(() => false));
+      if (onTab) {
+        await this._capabilities.waitForLoaded();
+        return;
+      }
+
+      const urlBefore = this.page.url();
+      await this.page.goBack();
+      await this.page
+        .waitForURL((url) => url.toString() !== urlBefore, { timeout: TestTimeouts.SHORT_WAIT })
+        .catch(() => undefined);
+    }
+
+    throw new Error(
+      `Browser back did not return to Recommended capabilities (url: ${this.page.url()})`,
+    );
+  }
+
+  async getVisibleSettingsTabTestIds(): Promise<string[]> {
+    const tabs = this.page.locator('[data-test^="settings-tab-"]:visible');
+    await tabs.first().waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    const ids = await tabs.evaluateAll((nodes) =>
+      nodes.map((node) => node.getAttribute('data-test')),
+    );
+    return ids.filter((id): id is string => Boolean(id));
+  }
+}

--- a/playwright/src/page-objects/settings/settings-page.ts
+++ b/playwright/src/page-objects/settings/settings-page.ts
@@ -1,9 +1,10 @@
 /**
  * SettingsPage — standalone page object for the Virtualization Settings area.
  *
- * Covers all three tabs reachable from Virtualization → Settings:
+ * Covers Settings tabs reachable from Virtualization → Settings:
  *   /k8s/all-namespaces/virtualization-settings/cluster
  *   /k8s/all-namespaces/virtualization-settings/user
+ *   /k8s/all-namespaces/virtualization-settings/recommended
  *   /k8s/all-namespaces/virtualization-settings/features
  *
  * Composes the existing sub-page-objects without going through OverviewPage.
@@ -342,6 +343,12 @@ export default class SettingsPage extends BasePage {
     ...args: Parameters<OverviewSettingsPage['navigateToPreviewFeatures']>
   ): ReturnType<OverviewSettingsPage['navigateToPreviewFeatures']> {
     return this._settings.navigateToPreviewFeatures(...args);
+  }
+
+  navigateToRecommendedCapabilities(
+    ...args: Parameters<OverviewSettingsPage['navigateToRecommendedCapabilities']>
+  ): ReturnType<OverviewSettingsPage['navigateToRecommendedCapabilities']> {
+    return this._settings.navigateToRecommendedCapabilities(...args);
   }
 
   // ── Cluster tab — Resource management section ────────────────────────────────

--- a/playwright/tests/settings/cluster-settings.spec.ts
+++ b/playwright/tests/settings/cluster-settings.spec.ts
@@ -10,14 +10,14 @@ test.describe('Cluster Settings', { tag: [CNV_SETTINGS_TAG, '@adminOnly'] }, () 
 
   // ── Page-level ────────────────────────────────────────────────────────────────
 
-  test('Settings page shows Cluster, User, and Preview features tabs', async ({
+  test('Settings page shows Cluster, User, Recommended capabilities, and Preview features tabs', async ({
     settingsPage,
     utils,
   }) => {
     utils.withAllure({ suite: SUITE, feature: CNV_SETTINGS_FEATURE, tags: [CNV_SETTINGS_TAG] });
 
     const tabs = await settingsPage.getSettingsTabNames();
-    for (const expected of ['Cluster', 'User', 'Preview features']) {
+    for (const expected of ['Cluster', 'User', 'Recommended capabilities', 'Preview features']) {
       expect
         .soft(
           tabs.some((t) => t.includes(expected)),

--- a/playwright/tests/tier2/recommended-capabilities/recommended-capabilities-actions.spec.md
+++ b/playwright/tests/tier2/recommended-capabilities/recommended-capabilities-actions.spec.md
@@ -1,0 +1,140 @@
+# Software Test Description (STD): Recommended capabilities — Actions
+
+## 1. Project Overview
+
+- **Project Name:** KubeVirt UI — Playwright E2E Tests
+- **Feature Area:** Tier2 — Recommended capabilities
+- **Latest version:** CNV 5.1.0
+- **Latest update:** 2026-09-08
+- **Document Status:** Draft
+
+## 2. Introduction
+
+### 2.1 Purpose
+
+Verify kebab actions on the Recommended capabilities tab: Install all operators is offered for
+not-installed capabilities (and is not clicked), View operator details opens Software Catalog and
+browser back returns to the tab, Autopilot configuration status (Recommended / Manual), Use
+recommended configuration kebab, and the review recommendation modal shows both YAML panes and
+closes on Cancel.
+
+### 2.2 Scope
+
+- **In-Scope:** Not-installed capability kebab, View operator details, Autopilot configuration
+  status, Use recommended configuration kebab, review recommendation modal Cancel.
+- **Out-of-Scope:** Clicking Install all operators, clicking Apply or Use recommended configuration
+  (mutating YAML), creating Subscriptions. See the install STD.
+
+## 3. Test Environment & Prerequisites
+
+- **Environment:** OpenShift with CNV operator; Playwright `Tier2` project.
+- **Configuration:** Cluster-admin user.
+- **Initial Setup:** None. Tests skip when the cluster has no not-installed autopilot capability,
+  no Recommended/Manual Autopilot configuration, or no Manual operator for the kebab assertion.
+
+---
+
+## 4. Test Case Definitions
+
+**Spec file:** `tests/tier2/recommended-capabilities/recommended-capabilities-actions.spec.ts`
+**Describe:** `Recommended capabilities actions` — **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+**Allure:** suite `Recommended capabilities`, feature `Tier 2`
+
+---
+
+### `001`: Not-installed capability kebab shows Install all operators
+
+- **Objective:** Verify a not-installed autopilot capability kebab offers Install all operators without installing.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-87133
+- **Pre-conditions:** At least one autopilot capability is Not installed; skipped otherwise.
+- **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+
+| Step | Action                            | Expected Result       |
+| :--- | :-------------------------------- | :-------------------- |
+| 1    | Open kebab on a Not installed row | Menu is visible       |
+| 2    | Assert Install all operators      | Menu item is visible  |
+| 3    | Dismiss the menu                  | No install is started |
+
+---
+
+### `002`: View operator details opens Software Catalog and back returns to the tab
+
+- **Objective:** Verify View operator details navigates to Software Catalog and browser back returns to the tab.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-85806
+- **Pre-conditions:** Cluster-admin user.
+- **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+
+| Step | Action                                                     | Expected Result                                           |
+| :--- | :--------------------------------------------------------- | :-------------------------------------------------------- |
+| 1    | Expand Load balancing and open the Descheduler kebab       | Menu is visible                                           |
+| 2    | Click View operator details                                | URL includes `/catalog/` and the Descheduler `selectedId` |
+| 3    | Browser back (catalog may add a `&version=` history entry) | Recommended capabilities tab is visible                   |
+
+---
+
+### `003`: Installed Autopilot operator shows Recommended or Manual configuration
+
+- **Objective:** Verify an installed Autopilot operator shows Recommended or Manual in the configuration column.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-85806
+- **Pre-conditions:** At least one Autopilot operator is Recommended or Manual; skipped otherwise.
+- **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+
+| Step | Action                                  | Expected Result                                  |
+| :--- | :-------------------------------------- | :----------------------------------------------- |
+| 1    | Expand auto capabilities                | Operator rows are shown                          |
+| 2    | Find a Recommended or Manual operator   | Configuration cell text matches that status      |
+| 3    | If Manual, assert Review recommendation | Review recommendation link is visible in the row |
+
+---
+
+### `004`: Manual operator kebab shows Use recommended configuration
+
+- **Objective:** Verify a Manual Autopilot operator kebab offers Use recommended configuration without applying it.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-85806
+- **Pre-conditions:** At least one Autopilot operator is Manual; skipped otherwise.
+- **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+
+| Step | Action                               | Expected Result         |
+| :--- | :----------------------------------- | :---------------------- |
+| 1    | Expand auto capabilities             | Operator rows are shown |
+| 2    | Open kebab on a Manual operator      | Menu is visible         |
+| 3    | Assert Use recommended configuration | Menu item is visible    |
+| 4    | Dismiss the menu                     | YAML is not applied     |
+
+---
+
+### `005`: Review recommendation modal shows both YAML panes and Cancel closes it
+
+- **Objective:** Verify the review recommendation modal content and that Cancel does not apply YAML.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-85806
+- **Pre-conditions:** At least one Autopilot operator is in Manual configuration; skipped otherwise.
+- **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+
+| Step | Action                                                  | Expected Result                             |
+| :--- | :------------------------------------------------------ | :------------------------------------------ |
+| 1    | Expand auto capabilities and open Review recommendation | Modal title and both YAML panes are visible |
+| 2    | Assert Apply and Cancel                                 | Both footer buttons are visible             |
+| 3    | Click Cancel                                            | Modal closes; Apply is not clicked          |
+
+---
+
+## 5. Requirements Traceability Matrix
+
+| Jira Ticket | Test Case ID | Coverage Type    | Status |
+| ----------- | ------------ | ---------------- | ------ |
+| CNV-87133   | `001`        | Feature coverage | Draft  |
+| CNV-85806   | `002`        | Feature coverage | Draft  |
+| CNV-85806   | `003`        | Feature coverage | Draft  |
+| CNV-85806   | `004`        | Feature coverage | Draft  |
+| CNV-85806   | `005`        | Feature coverage | Draft  |
+
+## 6. Approvals
+
+- **Prepared By:** Test automation / QE
+- **Reviewed By:** **\*\***\_\_\_\_**\*\***
+- **Approval Signature:** **\*\***\_\_\_\_**\*\***

--- a/playwright/tests/tier2/recommended-capabilities/recommended-capabilities-actions.spec.ts
+++ b/playwright/tests/tier2/recommended-capabilities/recommended-capabilities-actions.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * Recommended capabilities — kebab actions and review recommendation modal.
+ */
+
+import {
+  ADMIN_ONLY_TAG,
+  RECOMMENDED_CAPABILITIES_TAG,
+  T2,
+  T2_TAG,
+} from '@/data-models/allure-constants';
+import {
+  AUTO_CAPABILITY_IDS,
+  AUTOPILOT_PACKAGE_NAMES,
+  CAPABILITY_STATUS,
+  CONFIGURATION_STATUS,
+} from '@/data-models/recommended-capabilities-constants';
+import { expect, test } from '@/fixtures/recommended-capabilities-fixture';
+
+const SUITE = 'Recommended capabilities';
+const TAGS = [T2_TAG, RECOMMENDED_CAPABILITIES_TAG];
+
+test.describe(
+  'Recommended capabilities actions',
+  { tag: [T2_TAG, ADMIN_ONLY_TAG, RECOMMENDED_CAPABILITIES_TAG] },
+  () => {
+    test.beforeEach(async ({ recommendedCapabilitiesPage, utils }) => {
+      utils.withAllure({ suite: SUITE, feature: T2, tags: TAGS });
+      await recommendedCapabilitiesPage.navigateViaSidebar();
+    });
+
+    test('Not-installed capability kebab shows Install all operators', async ({
+      recommendedCapabilitiesPage,
+    }) => {
+      const { capabilities } = recommendedCapabilitiesPage;
+      const notInstalledId = await capabilities.findCapabilityIdByStatus(
+        AUTO_CAPABILITY_IDS,
+        CAPABILITY_STATUS.NOT_INSTALLED,
+      );
+      if (!notInstalledId) {
+        test.skip(
+          true,
+          'No not-installed autopilot capability on this cluster to assert Install all operators',
+        );
+        return;
+      }
+
+      await capabilities.openCapabilityKebab(notInstalledId);
+      await expect(
+        capabilities.kebabActionLocator(`install-all-${notInstalledId}`),
+        `Kebab for "${notInstalledId}" should offer Install all operators`,
+      ).toBeVisible();
+      await capabilities.closeKebab();
+    });
+
+    test('View operator details opens Software Catalog and back returns to the tab', async ({
+      recommendedCapabilitiesPage,
+    }) => {
+      const { capabilities } = recommendedCapabilitiesPage;
+      await capabilities.expandCapability('load-balancing');
+      await capabilities.openOperatorKebab('cluster-kube-descheduler-operator');
+      await capabilities.clickKebabAction('view-details-cluster-kube-descheduler-operator');
+
+      await expect(
+        recommendedCapabilitiesPage.page,
+        'View operator details should open Software Catalog',
+      ).toHaveURL(/\/catalog\/.*selectedId=cluster-kube-descheduler-operator/);
+
+      await recommendedCapabilitiesPage.navigateBackToTab();
+      await expect(
+        capabilities.headingLocator,
+        'Browser back should return to Recommended capabilities',
+      ).toBeVisible();
+    });
+
+    test('Installed Autopilot operator shows Recommended or Manual configuration', async ({
+      recommendedCapabilitiesPage,
+    }) => {
+      const { capabilities } = recommendedCapabilitiesPage;
+      for (const id of AUTO_CAPABILITY_IDS) {
+        await capabilities.expandCapability(id);
+      }
+
+      const recommendedPackage = await capabilities.findOperatorPackageByConfigStatus(
+        AUTOPILOT_PACKAGE_NAMES,
+        CONFIGURATION_STATUS.RECOMMENDED,
+      );
+      if (recommendedPackage) {
+        await expect(
+          capabilities.configurationStatusInRow(capabilities.operatorRow(recommendedPackage)),
+          `Operator "${recommendedPackage}" should show Recommended configuration`,
+        ).toHaveText(CONFIGURATION_STATUS.RECOMMENDED);
+        return;
+      }
+
+      const manualPackage = await capabilities.findOperatorPackageByConfigStatus(
+        AUTOPILOT_PACKAGE_NAMES,
+        CONFIGURATION_STATUS.MANUAL,
+      );
+      if (manualPackage) {
+        const row = capabilities.operatorRow(manualPackage);
+        await expect(
+          capabilities.configurationStatusInRow(row),
+          `Operator "${manualPackage}" should show Manual configuration`,
+        ).toHaveText(CONFIGURATION_STATUS.MANUAL);
+        await expect(
+          row.getByTestId('review-recommendation'),
+          `Manual operator "${manualPackage}" should offer Review recommendation`,
+        ).toBeVisible();
+        return;
+      }
+
+      test.skip(true, 'No installed Autopilot operator with Recommended or Manual configuration');
+    });
+
+    test('Manual operator kebab shows Use recommended configuration', async ({
+      recommendedCapabilitiesPage,
+    }) => {
+      const { capabilities } = recommendedCapabilitiesPage;
+      for (const id of AUTO_CAPABILITY_IDS) {
+        await capabilities.expandCapability(id);
+      }
+
+      const manualPackage = await capabilities.findOperatorPackageByConfigStatus(
+        AUTOPILOT_PACKAGE_NAMES,
+        CONFIGURATION_STATUS.MANUAL,
+      );
+      if (!manualPackage) {
+        test.skip(true, 'No Manual Autopilot operator on this cluster');
+        return;
+      }
+
+      await capabilities.openOperatorKebab(manualPackage);
+      await expect(
+        capabilities.kebabActionLocator(`use-recommended-${manualPackage}`),
+        `Kebab for "${manualPackage}" should offer Use recommended configuration`,
+      ).toBeVisible();
+      await capabilities.closeKebab();
+    });
+
+    test('Review recommendation modal shows both YAML panes and Cancel closes it', async ({
+      recommendedCapabilitiesPage,
+    }) => {
+      const { capabilities } = recommendedCapabilitiesPage;
+      for (const id of AUTO_CAPABILITY_IDS) {
+        await capabilities.expandCapability(id);
+      }
+
+      const reviewButton = capabilities.reviewRecommendationLocator.first();
+      if (!(await reviewButton.isVisible().catch(() => false))) {
+        test.skip(true, 'No Manual configuration with Review recommendation on this cluster');
+        return;
+      }
+
+      await capabilities.clickReviewRecommendation();
+      await expect(
+        capabilities.reviewModalLocator,
+        'Review recommendation modal content should be visible',
+      ).toBeVisible();
+      await expect(
+        recommendedCapabilitiesPage.page.getByText('Recommended settings for', { exact: false }),
+        'Modal title should describe recommended settings for the operator',
+      ).toBeVisible();
+      await expect(
+        capabilities.reviewModalLocator.getByText('Current configuration'),
+        'Current configuration YAML pane should be visible',
+      ).toBeVisible();
+      await expect(
+        capabilities.reviewModalLocator.getByText('Recommended configuration'),
+        'Recommended configuration YAML pane should be visible',
+      ).toBeVisible();
+      await expect(
+        recommendedCapabilitiesPage.page.getByTestId('save-button'),
+        'Apply should be present in the review modal footer',
+      ).toBeVisible();
+      await expect(
+        recommendedCapabilitiesPage.page.getByTestId('cancel-button'),
+        'Cancel should be present in the review modal footer',
+      ).toBeVisible();
+
+      await capabilities.cancelReviewModal();
+      await expect(
+        capabilities.reviewModalLocator,
+        'Cancel should close the review recommendation modal without applying',
+      ).toBeHidden();
+    });
+  },
+);

--- a/playwright/tests/tier2/recommended-capabilities/recommended-capabilities-install.spec.md
+++ b/playwright/tests/tier2/recommended-capabilities/recommended-capabilities-install.spec.md
@@ -1,0 +1,73 @@
+# Software Test Description (STD): Recommended capabilities — Install
+
+## 1. Project Overview
+
+- **Project Name:** KubeVirt UI — Playwright E2E Tests
+- **Feature Area:** Tier2 — Recommended capabilities
+- **Latest version:** CNV 5.1.0
+- **Latest update:** 2026-09-08
+- **Document Status:** Draft
+
+## 2. Introduction
+
+### 2.1 Purpose
+
+Verify that Install selected creates an OLM Subscription for a single not-installed autopilot
+capability, that the UI leaves Not installed, and that created Subscriptions are deleted after the
+test. Prefer Migrate VMs because it maps to one operator.
+
+### 2.2 Scope
+
+- **In-Scope:** Selecting one not-installed autopilot capability, Install selected, toast or
+  Installing spinner, status poll, Subscription cleanup.
+- **Out-of-Scope:** Installing the full default bundle, clicking Apply in the review recommendation
+  modal, installing additional/manual capabilities.
+
+## 3. Test Environment & Prerequisites
+
+- **Environment:** OpenShift with CNV operator; Playwright `Tier2` project.
+- **Configuration:** Cluster-admin user. Run this spec with `--workers=1` so it cannot overlap
+  other Recommended capabilities tests.
+- **Initial Setup:** Snapshot existing Subscription UIDs. After each test, delete newly created
+  Subscriptions whose package name is an Autopilot operator. Failed deletions fail `afterEach`
+  (404 Not Found is ignored). Skip if every autopilot capability is already installed.
+
+---
+
+## 4. Test Case Definitions
+
+**Spec file:** `tests/tier2/recommended-capabilities/recommended-capabilities-install.spec.ts`
+**Describe:** `Recommended capabilities install` — **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+**Allure:** suite `Recommended capabilities`, feature `Tier 2`
+
+---
+
+### `001`: Install selected starts install for one not-installed autopilot capability
+
+- **Objective:** Verify Install selected starts OLM install for one not-installed autopilot capability.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-87133, CNV-85806
+- **Pre-conditions:** At least one autopilot capability is Not installed (prefer Migrate VMs); skipped otherwise.
+- **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+
+| Step | Action                                                  | Expected Result                                          |
+| :--- | :------------------------------------------------------ | :------------------------------------------------------- |
+| 1    | Select the first not-installed autopilot capability     | Install selected becomes enabled                         |
+| 2    | Click Install selected                                  | Toast "Installation started …" and/or Installing spinner |
+| 3    | Poll capability status until `OPERATOR_INSTALL` timeout | Status is no longer Not installed                        |
+| 4    | afterEach deletes new Autopilot Subscriptions           | Cluster is restored                                      |
+
+---
+
+## 5. Requirements Traceability Matrix
+
+| Jira Ticket | Test Case ID | Coverage Type    | Status |
+| ----------- | ------------ | ---------------- | ------ |
+| CNV-87133   | `001`        | Feature coverage | Draft  |
+| CNV-85806   | `001`        | Feature coverage | Draft  |
+
+## 6. Approvals
+
+- **Prepared By:** Test automation / QE
+- **Reviewed By:** **\*\***\_\_\_\_**\*\***
+- **Approval Signature:** **\*\***\_\_\_\_**\*\***

--- a/playwright/tests/tier2/recommended-capabilities/recommended-capabilities-install.spec.ts
+++ b/playwright/tests/tier2/recommended-capabilities/recommended-capabilities-install.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * Recommended capabilities — guarded single-capability install with Subscription cleanup.
+ */
+
+import RequestContextClient from '@/clients/request-context-client';
+import {
+  ADMIN_ONLY_TAG,
+  RECOMMENDED_CAPABILITIES_TAG,
+  T2,
+  T2_TAG,
+} from '@/data-models/allure-constants';
+import type { KubernetesResource } from '@/data-models/kubernetes-types';
+import {
+  AUTO_CAPABILITY_IDS,
+  AUTOPILOT_PACKAGE_NAMES,
+  CAPABILITY_STATUS,
+  PREFERRED_INSTALL_CAPABILITY_ID,
+} from '@/data-models/recommended-capabilities-constants';
+import { expect, test } from '@/fixtures/recommended-capabilities-fixture';
+import { TestTimeouts } from '@/utils/test-config';
+
+const SUITE = 'Recommended capabilities';
+const TAGS = [T2_TAG, RECOMMENDED_CAPABILITIES_TAG];
+const SUBSCRIPTION_GROUP = 'operators.coreos.com';
+const SUBSCRIPTION_VERSION = 'v1alpha1';
+const SUBSCRIPTION_PLURAL = 'subscriptions';
+
+const listSubscriptions = async (
+  apiClient: RequestContextClient,
+): Promise<KubernetesResource[]> => {
+  const result = await apiClient.listResources(
+    SUBSCRIPTION_GROUP,
+    SUBSCRIPTION_VERSION,
+    SUBSCRIPTION_PLURAL,
+  );
+  return result?.items ?? [];
+};
+
+const subscriptionPackageName = (sub: KubernetesResource): string =>
+  typeof sub.spec?.name === 'string' ? sub.spec.name : '';
+
+const isNotFoundError = (reason: unknown): boolean => {
+  const err = reason as { response?: { status?: number }; message?: string };
+  const message = err?.message ?? String(reason);
+  return err?.response?.status === 404 || message.includes('404') || message.includes('NotFound');
+};
+
+test.describe(
+  'Recommended capabilities install',
+  { tag: [T2_TAG, ADMIN_ONLY_TAG, RECOMMENDED_CAPABILITIES_TAG] },
+  () => {
+    const snapshotUids = new Set<string>();
+
+    test.beforeEach(async ({ apiClient, recommendedCapabilitiesPage, utils }) => {
+      utils.withAllure({ suite: SUITE, feature: T2, tags: TAGS });
+      snapshotUids.clear();
+      for (const sub of await listSubscriptions(apiClient)) {
+        if (sub.metadata?.uid) snapshotUids.add(sub.metadata.uid);
+      }
+      await recommendedCapabilitiesPage.navigateViaSidebar();
+    });
+
+    test.afterEach(async ({ apiClient }) => {
+      const current = await listSubscriptions(apiClient);
+      const created = current.filter((sub) => {
+        const uid = sub.metadata?.uid;
+        const packageName = subscriptionPackageName(sub);
+        return (
+          Boolean(uid) &&
+          !snapshotUids.has(uid) &&
+          (AUTOPILOT_PACKAGE_NAMES as readonly string[]).includes(packageName)
+        );
+      });
+
+      const deletions = created.flatMap((sub) => {
+        const name = sub.metadata?.name;
+        const namespace = sub.metadata?.namespace;
+        if (!name || !namespace) return [];
+        return [
+          apiClient.deleteResource(
+            SUBSCRIPTION_GROUP,
+            SUBSCRIPTION_VERSION,
+            SUBSCRIPTION_PLURAL,
+            name,
+            namespace,
+          ),
+        ];
+      });
+
+      const results = await Promise.allSettled(deletions);
+      const failures = results.filter(
+        (result): result is PromiseRejectedResult =>
+          result.status === 'rejected' && !isNotFoundError(result.reason),
+      );
+      if (failures.length > 0) {
+        throw new AggregateError(
+          failures.map((failure) => failure.reason),
+          'Failed to delete test-created Subscriptions',
+        );
+      }
+    });
+
+    test('Install selected starts install for one not-installed autopilot capability', async ({
+      recommendedCapabilitiesPage,
+    }) => {
+      const { capabilities } = recommendedCapabilitiesPage;
+      const preferredStatus = await capabilities.getCapabilityStatus(
+        PREFERRED_INSTALL_CAPABILITY_ID,
+      );
+      const capabilityId =
+        preferredStatus === CAPABILITY_STATUS.NOT_INSTALLED
+          ? PREFERRED_INSTALL_CAPABILITY_ID
+          : await capabilities.findCapabilityIdByStatus(
+              AUTO_CAPABILITY_IDS,
+              CAPABILITY_STATUS.NOT_INSTALLED,
+            );
+
+      if (!capabilityId) {
+        test.skip(
+          true,
+          'No not-installed autopilot capability on this cluster; skipping install to avoid changing an already-installed operator',
+        );
+        return;
+      }
+
+      await capabilities.selectCapability(capabilityId);
+      await expect(
+        capabilities.installSelectedLocator,
+        'Install selected should be enabled after checking a not-installed capability',
+      ).not.toHaveAttribute('aria-disabled', 'true');
+
+      await capabilities.clickInstallSelected();
+
+      const toast = capabilities.installationToastLocator();
+      const installing = capabilities
+        .capabilityRow(capabilityId)
+        .getByLabel(CAPABILITY_STATUS.INSTALLING);
+      await expect(
+        toast.or(installing).first(),
+        'Install should show a started toast or an Installing spinner',
+      ).toBeVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+
+      await expect
+        .poll(async () => capabilities.getCapabilityStatus(capabilityId), {
+          timeout: TestTimeouts.OPERATOR_INSTALL,
+        })
+        .not.toBe(CAPABILITY_STATUS.NOT_INSTALLED);
+    });
+  },
+);

--- a/playwright/tests/tier2/recommended-capabilities/recommended-capabilities-navigation.spec.md
+++ b/playwright/tests/tier2/recommended-capabilities/recommended-capabilities-navigation.spec.md
@@ -1,0 +1,119 @@
+# Software Test Description (STD): Recommended capabilities — Navigation
+
+## 1. Project Overview
+
+- **Project Name:** KubeVirt UI — Playwright E2E Tests
+- **Feature Area:** Tier2 — Recommended capabilities
+- **Latest version:** CNV 5.1.0
+- **Latest update:** 2026-09-08
+- **Document Status:** Draft
+
+## 2. Introduction
+
+### 2.1 Purpose
+
+Verify that cluster admins can open the Recommended capabilities Settings tab from the sidebar
+and from Settings search, that installed autopilot rows stay view-only, and that non-privileged
+users do not see admin-only Settings tabs.
+
+### 2.2 Scope
+
+- **In-Scope:** Sidebar navigation, Settings search, page heading and capability cards, installed
+  row kebab absence, non-privileged tab visibility.
+- **Out-of-Scope:** Capability install, Software Catalog navigation, review recommendation modal. See
+  the colocated actions, tables, and install STDs.
+
+## 3. Test Environment & Prerequisites
+
+- **Environment:** OpenShift with CNV operator; Playwright `Tier2` project.
+- **Configuration:** Admin specs require cluster-admin. The non-privileged spec requires `NON_PRIV=1`.
+- **Initial Setup:** None. No operators are installed or removed.
+
+---
+
+## 4. Test Case Definitions
+
+**Spec file:** `tests/tier2/recommended-capabilities/recommended-capabilities-navigation.spec.ts`
+**Describe:** `Recommended capabilities navigation` / `Recommended capabilities is hidden from non-privileged users` — **Tags:** `@tier2`, `@tier2-recommended-capabilities`, `@adminOnly`, `@nonpriv`
+**Allure:** suite `Recommended capabilities`, feature `Tier 2`
+
+---
+
+### `001`: Sidebar Settings tab shows heading and both capability cards
+
+- **Objective:** Verify the Recommended capabilities tab loads with the page heading and both cards.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-87133
+- **Pre-conditions:** Cluster-admin user.
+- **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+
+| Step | Action                                        | Expected Result                                               |
+| :--- | :-------------------------------------------- | :------------------------------------------------------------ |
+| 1    | Open Settings from the Virtualization sidebar | Settings page loads                                           |
+| 2    | Click the Recommended capabilities tab        | Tab content is visible                                        |
+| 3    | Assert heading and both card titles           | Manage Virtualization capabilities; auto and additional cards |
+
+---
+
+### `002`: Settings search for Recommended capabilities opens the tab
+
+- **Objective:** Verify Settings search navigates to the Recommended capabilities tab.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-87133
+- **Pre-conditions:** Cluster-admin user.
+- **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+
+| Step | Action                                                          | Expected Result                                      |
+| :--- | :-------------------------------------------------------------- | :--------------------------------------------------- |
+| 1    | Open Settings from the sidebar                                  | Settings page loads                                  |
+| 2    | Search for "Recommended capabilities" and select the suggestion | Tab content is visible                               |
+| 3    | Assert the URL                                                  | Path includes `/virtualization-settings/recommended` |
+
+---
+
+### `003`: Installed auto-table capability has no kebab and still expands operators
+
+- **Objective:** Verify an installed autopilot capability is view-only at the capability row and still expands.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-85806
+- **Pre-conditions:** At least one autopilot capability is Installed; skipped otherwise.
+- **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+
+| Step | Action                                         | Expected Result                  |
+| :--- | :--------------------------------------------- | :------------------------------- |
+| 1    | Find an Installed capability in the auto table | A matching row is visible        |
+| 2    | Assert kebab count on that row                 | No kebab is rendered             |
+| 3    | Expand the row                                 | Operator rows are visible        |
+| 4    | Open the operator kebab                        | View operator details is present |
+
+---
+
+### `004`: Non-privileged user does not see admin-only Settings tabs
+
+- **Objective:** Verify non-privileged users do not see Recommended capabilities, Cluster, or Preview features.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-87133
+- **Pre-conditions:** `NON_PRIV=1`.
+- **Tags:** `@tier2`, `@nonpriv`, `@tier2-recommended-capabilities`
+
+| Step | Action                               | Expected Result                                                        |
+| :--- | :----------------------------------- | :--------------------------------------------------------------------- |
+| 1    | Open Settings from the sidebar       | Settings page loads                                                    |
+| 2    | Collect visible `settings-tab-*` IDs | `recommended`, `cluster`, and `features` are absent; `user` is present |
+
+---
+
+## 5. Requirements Traceability Matrix
+
+| Jira Ticket | Test Case ID | Coverage Type    | Status |
+| ----------- | ------------ | ---------------- | ------ |
+| CNV-87133   | `001`        | Feature coverage | Draft  |
+| CNV-87133   | `002`        | Feature coverage | Draft  |
+| CNV-85806   | `003`        | Feature coverage | Draft  |
+| CNV-87133   | `004`        | Feature coverage | Draft  |
+
+## 6. Approvals
+
+- **Prepared By:** Test automation / QE
+- **Reviewed By:** **\*\***\_\_\_\_**\*\***
+- **Approval Signature:** **\*\***\_\_\_\_**\*\***

--- a/playwright/tests/tier2/recommended-capabilities/recommended-capabilities-navigation.spec.ts
+++ b/playwright/tests/tier2/recommended-capabilities/recommended-capabilities-navigation.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * Recommended capabilities — navigation and admin-only visibility.
+ */
+
+import {
+  ADMIN_ONLY_TAG,
+  NONPRIV_TAG,
+  RECOMMENDED_CAPABILITIES_TAG,
+  T2,
+  T2_TAG,
+} from '@/data-models/allure-constants';
+import {
+  AUTO_CAPABILITY_IDS,
+  AUTO_CAPABILITY_OPERATORS,
+  CAPABILITY_STATUS,
+} from '@/data-models/recommended-capabilities-constants';
+import { expect, test } from '@/fixtures/recommended-capabilities-fixture';
+
+const SUITE = 'Recommended capabilities';
+const TAGS = [T2_TAG, RECOMMENDED_CAPABILITIES_TAG];
+
+test.describe(
+  'Recommended capabilities navigation',
+  { tag: [T2_TAG, ADMIN_ONLY_TAG, RECOMMENDED_CAPABILITIES_TAG] },
+  () => {
+    test.beforeEach(async ({ utils }) => {
+      utils.withAllure({ suite: SUITE, feature: T2, tags: TAGS });
+    });
+
+    test('Sidebar Settings tab shows heading and both capability cards', async ({
+      recommendedCapabilitiesPage,
+    }) => {
+      await recommendedCapabilitiesPage.navigateViaSidebar();
+      const { capabilities } = recommendedCapabilitiesPage;
+
+      await expect(
+        capabilities.headingLocator,
+        'Page heading "Manage Virtualization capabilities" should be visible',
+      ).toBeVisible();
+      await expect(
+        capabilities.autoCardTitleLocator,
+        'Install capabilities automatically card should be visible',
+      ).toBeVisible();
+      await expect(
+        capabilities.additionalCardTitleLocator,
+        'Additional capabilities card should be visible',
+      ).toBeVisible();
+    });
+
+    test('Settings search for Recommended capabilities opens the tab', async ({
+      recommendedCapabilitiesPage,
+    }) => {
+      await recommendedCapabilitiesPage.navigateViaSearch();
+
+      await expect(
+        recommendedCapabilitiesPage.capabilities.contentLocator,
+        'Recommended capabilities tab content should be visible after selecting the search suggestion',
+      ).toBeVisible();
+      expect(
+        recommendedCapabilitiesPage.page.url(),
+        'URL should include the recommended settings tab path',
+      ).toContain('/virtualization-settings/recommended');
+    });
+
+    test('Installed auto-table capability has no kebab and still expands operators', async ({
+      recommendedCapabilitiesPage,
+    }) => {
+      await recommendedCapabilitiesPage.navigateViaSidebar();
+      const { capabilities } = recommendedCapabilitiesPage;
+
+      const installedId = await capabilities.findCapabilityIdByStatus(
+        AUTO_CAPABILITY_IDS,
+        CAPABILITY_STATUS.INSTALLED,
+      );
+      if (!installedId) {
+        test.skip(
+          true,
+          'No installed autopilot capability on this cluster to assert view-only kebab',
+        );
+        return;
+      }
+
+      const row = capabilities.capabilityRow(installedId);
+      await expect(
+        capabilities.kebabInRow(row),
+        `Installed capability "${installedId}" should not render a kebab menu`,
+      ).toHaveCount(0);
+
+      await capabilities.expandCapability(installedId);
+      const operatorPackage = AUTO_CAPABILITY_OPERATORS[installedId]?.[0];
+      if (!operatorPackage) {
+        throw new Error(`Known operator mapping missing for "${installedId}"`);
+      }
+      await expect(
+        capabilities.operatorLocator(operatorPackage),
+        `Expanded installed capability "${installedId}" should list operator rows`,
+      ).toBeVisible();
+
+      await capabilities.openOperatorKebab(operatorPackage);
+      await expect(
+        capabilities.kebabActionLocator(`view-details-${operatorPackage}`),
+        `Operator kebab for "${operatorPackage}" should offer View operator details`,
+      ).toBeVisible();
+      await capabilities.closeKebab();
+    });
+  },
+);
+
+test.describe(
+  'Recommended capabilities is hidden from non-privileged users',
+  { tag: [T2_TAG, NONPRIV_TAG, RECOMMENDED_CAPABILITIES_TAG] },
+  () => {
+    test('Non-privileged user does not see admin-only Settings tabs', async ({
+      recommendedCapabilitiesPage,
+      utils,
+    }) => {
+      test.skip(!utils.EnvVariables.isNonPrivUser, 'Requires NON_PRIV=1');
+      utils.withAllure({ suite: SUITE, feature: T2, tags: [...TAGS, NONPRIV_TAG] });
+
+      await recommendedCapabilitiesPage.navigateToSettingsViaSidebar();
+      const tabIds = await recommendedCapabilitiesPage.getVisibleSettingsTabTestIds();
+
+      expect(
+        tabIds,
+        'Recommended capabilities tab should be hidden from non-privileged users',
+      ).not.toContain('settings-tab-recommended');
+      expect(tabIds, 'Cluster tab should be hidden from non-privileged users').not.toContain(
+        'settings-tab-cluster',
+      );
+      expect(
+        tabIds,
+        'Preview features tab should be hidden from non-privileged users',
+      ).not.toContain('settings-tab-features');
+      expect(tabIds, 'User tab should remain visible for non-privileged users').toContain(
+        'settings-tab-user',
+      );
+    });
+  },
+);

--- a/playwright/tests/tier2/recommended-capabilities/recommended-capabilities-tables.spec.md
+++ b/playwright/tests/tier2/recommended-capabilities/recommended-capabilities-tables.spec.md
@@ -1,0 +1,181 @@
+# Software Test Description (STD): Recommended capabilities — Tables
+
+## 1. Project Overview
+
+- **Project Name:** KubeVirt UI — Playwright E2E Tests
+- **Feature Area:** Tier2 — Recommended capabilities
+- **Latest version:** CNV 5.1.0
+- **Latest update:** 2026-09-08
+- **Document Status:** Draft
+
+## 2. Introduction
+
+### 2.1 Purpose
+
+Verify the Recommended capabilities auto and additional tables: capability names, operator
+children, search, status filter, Install selected enablement, and Software Catalog links.
+
+### 2.2 Scope
+
+- **In-Scope:** Auto table names, Load balancing operators, search, status filter, Install selected
+  disabled/enabled, additional table names, High availability operators, Software Catalog name link.
+- **Out-of-Scope:** Creating OLM Subscriptions, review recommendation Apply. See the install and
+  actions STDs.
+
+## 3. Test Environment & Prerequisites
+
+- **Environment:** OpenShift with CNV operator; Playwright `Tier2` project.
+- **Configuration:** Cluster-admin user.
+- **Initial Setup:** None. The Install selected enablement test skips if every autopilot capability
+  is already installed.
+
+---
+
+## 4. Test Case Definitions
+
+**Spec file:** `tests/tier2/recommended-capabilities/recommended-capabilities-tables.spec.ts`
+**Describe:** `Recommended capabilities tables` — **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+**Allure:** suite `Recommended capabilities`, feature `Tier 2`
+
+---
+
+### `001`: Auto table lists Load balancing, Migrate VMs, and Virtualization dashboards
+
+- **Objective:** Verify the autopilot table lists the three automatic capabilities.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-87133, CNV-85806
+- **Pre-conditions:** Cluster-admin user.
+- **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+
+| Step | Action                        | Expected Result                                        |
+| :--- | :---------------------------- | :----------------------------------------------------- |
+| 1    | Open Recommended capabilities | Auto table is visible                                  |
+| 2    | Assert capability titles      | Load balancing, Migrate VMs, Virtualization dashboards |
+
+---
+
+### `002`: Expanding Load balancing shows Descheduler and MetalLB
+
+- **Objective:** Verify Load balancing expands to its Autopilot operators.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-85806
+- **Pre-conditions:** Cluster-admin user.
+- **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+
+| Step | Action                | Expected Result                    |
+| :--- | :-------------------- | :--------------------------------- |
+| 1    | Expand Load balancing | Operator rows are shown            |
+| 2    | Assert operator names | Descheduler and MetalLB are listed |
+
+---
+
+### `003`: Searching Migrate filters the auto table and clearing restores rows
+
+- **Objective:** Verify capability search filters and restore.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-87133
+- **Pre-conditions:** Cluster-admin user.
+- **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+
+| Step | Action               | Expected Result                            |
+| :--- | :------------------- | :----------------------------------------- |
+| 1    | Search for "Migrate" | Migrate VMs visible; Load balancing hidden |
+| 2    | Clear search         | Load balancing is visible again            |
+
+---
+
+### `004`: Status filter updates the capabilities count text
+
+- **Objective:** Verify the Status filter changes the "X out of Y …" count.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-87133
+- **Pre-conditions:** Cluster-admin user.
+- **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+
+| Step | Action                      | Expected Result                     |
+| :--- | :-------------------------- | :---------------------------------- |
+| 1    | Read the default count text | Text matches "out of"               |
+| 2    | Filter by Not installed     | Count text includes "not installed" |
+
+---
+
+### `005`: Install selected stays disabled until a not-installed capability is checked
+
+- **Objective:** Verify Install selected stays disabled with the expected tooltip until a not-installed row is selected.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-87133
+- **Pre-conditions:** Skips the enablement assertion if no not-installed autopilot capability exists.
+- **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+
+| Step | Action                                        | Expected Result                             |
+| :--- | :-------------------------------------------- | :------------------------------------------ |
+| 1    | Assert Install selected with no selection     | `aria-disabled="true"`                      |
+| 2    | Hover the button                              | Tooltip "Select capabilities to install"    |
+| 3    | Check a Not installed capability (if present) | Install selected is no longer aria-disabled |
+
+---
+
+### `006`: Additional table lists the eight manual capabilities
+
+- **Objective:** Verify the additional (manual setup) table lists all eight capabilities.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-87133
+- **Pre-conditions:** Cluster-admin user.
+- **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+
+| Step | Action                        | Expected Result                                        |
+| :--- | :---------------------------- | :----------------------------------------------------- |
+| 1    | Open Recommended capabilities | Additional table is visible                            |
+| 2    | Assert all eight titles       | Backup, NFD, HA, NMState, Kata, hub, NUMA, local disks |
+
+---
+
+### `007`: Expanding High availability shows health, fence, and maintenance operators
+
+- **Objective:** Verify High availability expands to its three operators.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-87133
+- **Pre-conditions:** Cluster-admin user.
+- **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+
+| Step | Action                   | Expected Result                                               |
+| :--- | :----------------------- | :------------------------------------------------------------ |
+| 1    | Expand High availability | Operator rows are shown                                       |
+| 2    | Assert operator names    | Node health check, Fence agents remediation, Node maintenance |
+
+---
+
+### `008`: Operator name link opens Software Catalog
+
+- **Objective:** Verify an additional-table operator name navigates to Software Catalog.
+- **Target version:** CNV 5.1.0
+- **Jira References:** CNV-87133
+- **Pre-conditions:** Cluster-admin user; Node health check package is resolvable in Software Catalog.
+- **Tags:** `@tier2`, `@adminOnly`, `@tier2-recommended-capabilities`
+
+| Step | Action                           | Expected Result                                                     |
+| :--- | :------------------------------- | :------------------------------------------------------------------ |
+| 1    | Expand High availability         | Operator rows are shown                                             |
+| 2    | Click the Node health check name | URL includes `/catalog/` and `selectedId=node-healthcheck-operator` |
+
+---
+
+## 5. Requirements Traceability Matrix
+
+| Jira Ticket | Test Case ID | Coverage Type    | Status |
+| ----------- | ------------ | ---------------- | ------ |
+| CNV-87133   | `001`        | Feature coverage | Draft  |
+| CNV-85806   | `001`        | Feature coverage | Draft  |
+| CNV-85806   | `002`        | Feature coverage | Draft  |
+| CNV-87133   | `003`        | Feature coverage | Draft  |
+| CNV-87133   | `004`        | Feature coverage | Draft  |
+| CNV-87133   | `005`        | Feature coverage | Draft  |
+| CNV-87133   | `006`        | Feature coverage | Draft  |
+| CNV-87133   | `007`        | Feature coverage | Draft  |
+| CNV-87133   | `008`        | Feature coverage | Draft  |
+
+## 6. Approvals
+
+- **Prepared By:** Test automation / QE
+- **Reviewed By:** **\*\***\_\_\_\_**\*\***
+- **Approval Signature:** **\*\***\_\_\_\_**\*\***

--- a/playwright/tests/tier2/recommended-capabilities/recommended-capabilities-tables.spec.ts
+++ b/playwright/tests/tier2/recommended-capabilities/recommended-capabilities-tables.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * Recommended capabilities — auto and additional tables.
+ */
+
+import {
+  ADMIN_ONLY_TAG,
+  RECOMMENDED_CAPABILITIES_TAG,
+  T2,
+  T2_TAG,
+} from '@/data-models/allure-constants';
+import {
+  AUTO_CAPABILITY_IDS,
+  AUTO_CAPABILITY_TITLES,
+  CAPABILITY_STATUS,
+  HIGH_AVAILABILITY_OPERATORS,
+  LOAD_BALANCING_OPERATORS,
+  MANUAL_CAPABILITY_TITLES,
+} from '@/data-models/recommended-capabilities-constants';
+import { expect, test } from '@/fixtures/recommended-capabilities-fixture';
+
+const SUITE = 'Recommended capabilities';
+const TAGS = [T2_TAG, RECOMMENDED_CAPABILITIES_TAG];
+
+test.describe(
+  'Recommended capabilities tables',
+  { tag: [T2_TAG, ADMIN_ONLY_TAG, RECOMMENDED_CAPABILITIES_TAG] },
+  () => {
+    test.beforeEach(async ({ recommendedCapabilitiesPage, utils }) => {
+      utils.withAllure({ suite: SUITE, feature: T2, tags: TAGS });
+      await recommendedCapabilitiesPage.navigateViaSidebar();
+    });
+
+    test('Auto table lists Load balancing, Migrate VMs, and Virtualization dashboards', async ({
+      recommendedCapabilitiesPage,
+    }) => {
+      const { capabilities } = recommendedCapabilitiesPage;
+      for (const title of AUTO_CAPABILITY_TITLES) {
+        await expect(
+          capabilities.contentLocator.getByText(title, { exact: true }),
+          `Auto table should list "${title}"`,
+        ).toBeVisible();
+      }
+    });
+
+    test('Expanding Load balancing shows Descheduler and MetalLB', async ({
+      recommendedCapabilitiesPage,
+    }) => {
+      const { capabilities } = recommendedCapabilitiesPage;
+      await capabilities.expandCapability('load-balancing');
+
+      for (const operator of LOAD_BALANCING_OPERATORS) {
+        await expect(
+          capabilities.operatorLocator(operator.packageName),
+          `Load balancing should include operator "${operator.displayName}"`,
+        ).toBeVisible();
+      }
+    });
+
+    test('Searching Migrate filters the auto table and clearing restores rows', async ({
+      recommendedCapabilitiesPage,
+    }) => {
+      const { capabilities } = recommendedCapabilitiesPage;
+      await capabilities.searchCapabilities('Migrate');
+
+      await expect(
+        capabilities.capabilityLocator('migrate-vms'),
+        'Migrate VMs should remain visible when searching "Migrate"',
+      ).toBeVisible();
+      await expect(
+        capabilities.capabilityLocator('load-balancing'),
+        'Load balancing should be hidden when searching "Migrate"',
+      ).toBeHidden();
+
+      await capabilities.clearSearch();
+      await expect(
+        capabilities.capabilityLocator('load-balancing'),
+        'Load balancing should return after clearing search',
+      ).toBeVisible();
+    });
+
+    test('Status filter updates the capabilities count text', async ({
+      recommendedCapabilitiesPage,
+    }) => {
+      const { capabilities } = recommendedCapabilitiesPage;
+      const countBefore = (await capabilities.countLocator.textContent()) ?? '';
+      expect(countBefore, 'Count text should be populated before filtering').toMatch(/out of/);
+
+      await capabilities.filterByStatus(CAPABILITY_STATUS.NOT_INSTALLED);
+      await expect(
+        capabilities.countLocator,
+        'Count text should reflect the Not installed status filter',
+      ).toContainText(/not installed/i);
+    });
+
+    test('Install selected stays disabled until a not-installed capability is checked', async ({
+      recommendedCapabilitiesPage,
+    }) => {
+      const { capabilities } = recommendedCapabilitiesPage;
+      await expect(
+        capabilities.installSelectedLocator,
+        'Install selected should be aria-disabled with no selection',
+      ).toHaveAttribute('aria-disabled', 'true');
+
+      await capabilities.hoverInstallSelected();
+      await expect(
+        recommendedCapabilitiesPage.page.getByText('Select capabilities to install'),
+        'Disabled Install selected should show the select-capabilities tooltip',
+      ).toBeVisible();
+
+      const notInstalledId = await capabilities.findCapabilityIdByStatus(
+        AUTO_CAPABILITY_IDS,
+        CAPABILITY_STATUS.NOT_INSTALLED,
+      );
+      if (!notInstalledId) {
+        test.skip(
+          true,
+          'No not-installed autopilot capability on this cluster to enable Install selected',
+        );
+        return;
+      }
+
+      await capabilities.selectCapability(notInstalledId);
+      await expect(
+        capabilities.installSelectedLocator,
+        'Install selected should enable after checking a not-installed capability',
+      ).not.toHaveAttribute('aria-disabled', 'true');
+    });
+
+    test('Additional table lists the eight manual capabilities', async ({
+      recommendedCapabilitiesPage,
+    }) => {
+      const { capabilities } = recommendedCapabilitiesPage;
+      for (const title of MANUAL_CAPABILITY_TITLES) {
+        await expect(
+          capabilities.contentLocator.getByText(title, { exact: true }),
+          `Additional table should list "${title}"`,
+        ).toBeVisible();
+      }
+    });
+
+    test('Expanding High availability shows health, fence, and maintenance operators', async ({
+      recommendedCapabilitiesPage,
+    }) => {
+      const { capabilities } = recommendedCapabilitiesPage;
+      await capabilities.expandCapability('high-availability');
+
+      for (const operator of HIGH_AVAILABILITY_OPERATORS) {
+        await expect(
+          capabilities.operatorLocator(operator.packageName),
+          `High availability should include operator "${operator.displayName}"`,
+        ).toBeVisible();
+      }
+    });
+
+    test('Operator name link opens Software Catalog', async ({ recommendedCapabilitiesPage }) => {
+      const { capabilities } = recommendedCapabilitiesPage;
+      await capabilities.expandCapability('high-availability');
+      await capabilities.clickOperatorLink('node-healthcheck-operator');
+
+      await expect(
+        recommendedCapabilitiesPage.page,
+        'Operator name link should open Software Catalog',
+      ).toHaveURL(/\/catalog\/.*selectedId=node-healthcheck-operator/);
+    });
+  },
+);

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/ConfigurationStatusCell/ConfigurationStatusCell.tsx
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/ConfigurationStatusCell/ConfigurationStatusCell.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Button, Icon, Label } from '@patternfly/react-core';
@@ -19,7 +19,7 @@ const ConfigurationStatusCell: FC<ConfigurationStatusCellProps> = ({
 
   if (configStatus === ConfigurationStatus.Recommended) {
     return (
-      <Label color="green" isCompact>
+      <Label color="green" data-test="configuration-status" isCompact>
         {t('Recommended')}
       </Label>
     );
@@ -31,11 +31,16 @@ const ConfigurationStatusCell: FC<ConfigurationStatusCellProps> = ({
         <Icon status="warning">
           <ExclamationTriangleIcon />
         </Icon>{' '}
-        {t('Manual')}
+        <span data-test="configuration-status">{t('Manual')}</span>
         {onReviewClick && (
           <>
             {' '}
-            <Button isInline onClick={onReviewClick} variant="link">
+            <Button
+              data-test="review-recommendation"
+              isInline
+              onClick={onReviewClick}
+              variant="link"
+            >
               {t('Review recommendation')}
             </Button>
           </>
@@ -44,7 +49,7 @@ const ConfigurationStatusCell: FC<ConfigurationStatusCellProps> = ({
     );
   }
 
-  return <>-</>;
+  return <span data-test="configuration-status">-</span>;
 };
 
 export default ConfigurationStatusCell;

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/CustomSelectionToolbar.tsx
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/CustomSelectionToolbar.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useMemo } from 'react';
+import React, { type FC, useCallback, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -17,13 +17,13 @@ import {
 } from '@patternfly/react-core';
 import { DataViewCheckboxFilter, type DataViewTrTree } from '@patternfly/react-data-view';
 
-import InstallSelectedButton from '../InstallSelectedButton/InstallSelectedButton';
 import { STATUS_COUNT_TEMPLATES } from '../../utils/constants';
 import {
   type CapabilityFilterValues,
   CapabilityInstallState,
   type CapabilitySelectionState,
 } from '../../utils/types';
+import InstallSelectedButton from '../InstallSelectedButton/InstallSelectedButton';
 
 type CustomSelectionToolbarProps = {
   clearAllFilters: () => void;
@@ -106,13 +106,14 @@ const CustomSelectionToolbar: FC<CustomSelectionToolbarProps> = ({
         </ToolbarItem>
         <ToolbarItem>
           <SearchInput
+            data-test="search-capabilities"
             onChange={(_event, value) => onSetFilters({ name: value })}
             onClear={() => onSetFilters({ name: '' })}
             placeholder={t('Search capabilities')}
             value={filters.name}
           />
         </ToolbarItem>
-        <ToolbarItem>
+        <ToolbarItem data-test="capability-status-filter">
           <DataViewCheckboxFilter
             filterId="status"
             onChange={(_event, values) => onSetFilters({ status: values })}
@@ -127,7 +128,9 @@ const CustomSelectionToolbar: FC<CustomSelectionToolbarProps> = ({
         </ToolbarItem>
         <ToolbarItem className="pf-v6-u-ml-auto">
           {resourcesLoaded ? (
-            <Content component={ContentVariants.small}>{countText}</Content>
+            <Content component={ContentVariants.small} data-test="capabilities-count">
+              {countText}
+            </Content>
           ) : (
             <Skeleton width="160px" />
           )}

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/buildCapabilityRow.tsx
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/buildCapabilityRow.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import { type TFunction } from 'i18next';
 
 import ActionsDropdown from '@kubevirt-utils/components/ActionsDropdown/ActionsDropdown';
@@ -7,12 +6,13 @@ import { type ActionDropdownItemType } from '@kubevirt-utils/components/ActionsD
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Label, Spinner } from '@patternfly/react-core';
+import { type DataViewTrTree } from '@patternfly/react-data-view';
 
 import { CAPABILITY_INSTALL_STATE_CONFIG } from '../../utils/constants';
 import {
   type CapabilityFeature,
   CapabilityInstallState,
-  ConfigurationStatus,
+  type ConfigurationStatus,
 } from '../../utils/types';
 import ConfigurationStatusCell from '../ConfigurationStatusCell/ConfigurationStatusCell';
 
@@ -34,14 +34,16 @@ export const buildCapabilityRow = ({
   installState,
   isInstalling,
   t,
-}: BuildCapabilityRowParams) => {
+}: BuildCapabilityRowParams): DataViewTrTree['row'] => {
   const { color, getLabel } = CAPABILITY_INSTALL_STATE_CONFIG[installState];
 
   return [
     {
       cell: (
         <>
-          <span className="pf-v6-u-mr-xs">{feature.title}</span>
+          <span className="pf-v6-u-mr-xs" data-test={`capability-${feature.id}`}>
+            {feature.title}
+          </span>
           <HelpTextIcon bodyContent={feature.description} />
         </>
       ),

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/buildOperatorRow.tsx
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/buildOperatorRow.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import { type TFunction } from 'i18next';
 
 import ActionsDropdown from '@kubevirt-utils/components/ActionsDropdown/ActionsDropdown';
@@ -11,7 +10,7 @@ import { type DataViewTrTree } from '@patternfly/react-data-view';
 import { getOperatorInstallStatusLabel } from '../../utils/constants';
 import {
   type CapabilityFeatureOperator,
-  ConfigurationStatus,
+  type ConfigurationStatus,
   type RecommendedCapabilityOperatorDetails,
 } from '../../utils/types';
 import ConfigurationStatusCell from '../ConfigurationStatusCell/ConfigurationStatusCell';
@@ -50,11 +49,16 @@ export const buildOperatorRow = ({
     row: [
       {
         cell: operatorHubURL ? (
-          <Button isInline onClick={() => navigate(operatorHubURL)} variant="link">
+          <Button
+            data-test={`operator-${operator.packageName}`}
+            isInline
+            onClick={() => navigate(operatorHubURL)}
+            variant="link"
+          >
             {operator.displayName}
           </Button>
         ) : (
-          operator.displayName
+          <span data-test={`operator-${operator.packageName}`}>{operator.displayName}</span>
         ),
       },
       {

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/InstallSelectedButton/InstallSelectedButton.tsx
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/InstallSelectedButton/InstallSelectedButton.tsx
@@ -61,6 +61,7 @@ const InstallSelectedButton: FC = () => {
 
   const button = (
     <Button
+      data-test="install-selected-capabilities"
       isAriaDisabled={isDisabled}
       isLoading={isAnyInstalling}
       onClick={handleInstall}

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/ReviewRecommendationModal/ReviewRecommendationModal.tsx
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/ReviewRecommendationModal/ReviewRecommendationModal.tsx
@@ -1,14 +1,13 @@
-import React, { FC, Suspense } from 'react';
+import React, { type FC, Suspense } from 'react';
 import { Trans } from 'react-i18next';
 
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { type K8sResourceCommon, YAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
+import { CodeEditor, type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { Content, ContentVariants, Grid, GridItem, ModalVariant } from '@patternfly/react-core';
 
 import { type AutopilotRegistryEntry } from '../../utils/autopilotRegistry';
-
 import useApplyRecommendation from './useApplyRecommendation';
 
 import './review-recommendation-modal.scss';
@@ -53,12 +52,17 @@ const ReviewRecommendationModal: FC<ReviewRecommendationModalProps> = ({
       submitBtnText={t('Apply')}
     >
       <hr className="review-recommendation-modal__separator" />
-      <Grid hasGutter>
+      <Grid data-test="review-recommendation-modal" hasGutter>
         <GridItem span={6}>
           <Content component={ContentVariants.h4}>{t('Current configuration')}</Content>
           <div className="review-recommendation-modal__editor">
             <Suspense fallback={<Loading />}>
-              <YAMLEditor minHeight="350px" options={EDITOR_OPTIONS} value={currentYAML} />
+              <CodeEditor
+                language="yaml"
+                minHeight="350px"
+                options={EDITOR_OPTIONS}
+                value={currentYAML}
+              />
             </Suspense>
           </div>
         </GridItem>
@@ -66,7 +70,12 @@ const ReviewRecommendationModal: FC<ReviewRecommendationModalProps> = ({
           <Content component={ContentVariants.h4}>{t('Recommended configuration')}</Content>
           <div className="review-recommendation-modal__editor">
             <Suspense fallback={<Loading />}>
-              <YAMLEditor minHeight="350px" options={EDITOR_OPTIONS} value={recommendedYAML} />
+              <CodeEditor
+                language="yaml"
+                minHeight="350px"
+                options={EDITOR_OPTIONS}
+                value={recommendedYAML}
+              />
             </Suspense>
           </div>
         </GridItem>

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/hooks/useOperatorResources/utils/utils.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/hooks/useOperatorResources/utils/utils.ts
@@ -35,12 +35,11 @@ const pickPreferred = (candidates: PackageManifestKind[]): PackageManifestKind |
 export const selectPreferredPackageManifests = (
   manifests: PackageManifestKind[],
 ): PackageManifestKind[] => {
-  const names = [
-    ...new Set(manifests.map(getName).filter((name): name is string => Boolean(name))),
-  ];
+  const named = manifests.filter((pkg) => getName(pkg));
+  const names = [...new Set(named.map(getName).filter((name): name is string => Boolean(name)))];
 
   return names
-    .map((name) => pickPreferred(manifests.filter((pkg) => getName(pkg) === name)))
+    .map((name) => pickPreferred(named.filter((pkg) => getName(pkg) === name)))
     .filter((pkg): pkg is PackageManifestKind => Boolean(pkg));
 };
 


### PR DESCRIPTION

## 📝 Description

adding e-2e tests in tier-2 for recommended capabilities and auto-pilot recommendations. 
tests: 
Recommended capabilities-
- Settings tab opens from the sidebar and from search
- Auto table lists Load balancing, Migrate VMs, and Virtualization dashboards; expand, search, and status filter work
- Additional table lists the eight manual capabilities; High availability expands to its operators
- Operator name / View operator details open Software Catalog; browser back returns to the tab
- Installed rows have no install kebab; not-installed kebab shows Install all operators
- Install selected stays disabled until a not-installed capability is checked
- Install selected starts install for one not-installed capability (guarded, with cleanup)
- Non-priv users do not see admin-only Settings tabs (NON_PRIV=1)

Autopilot
- Installed operator shows Recommended or Manual configuration
- Manual row offers Review recommendation and Use recommended configuration (not applied)
- Review modal shows current vs recommended YAML; Cancel closes it without Apply

## 🔗 Links

Jira OCP auto-pilot: https://redhat.atlassian.net/browse/CNV-85796
Jira align operators (recommended capabilities): https://redhat.atlassian.net/browse/CNV-87130

## 🎥 Demo




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added navigation to the Recommended capabilities settings tab through the sidebar and Settings search.
  - Added browsing, searching, filtering, expanding, and selecting recommended capabilities.
  - Added installation actions and links to operator details in the Software Catalog.
  - Added configuration status indicators and review workflows with read-only YAML views.

- **Bug Fixes**
  - Improved preferred package selection when unnamed entries are present.

- **Tests**
  - Added coverage for navigation, access control, tables, actions, installation, and status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->