### PR TITLE
CNV-96254: make empty state create buttons consistent for non-priv users

### DIFF
--- a/src/multicluster/hooks/useClusterParam.ts
+++ b/src/multicluster/hooks/useClusterParam.ts
@@ -4,11 +4,11 @@ import { useMatch } from 'react-router';
 import { FLEET_BASE_PATH } from '@multicluster/constants';
 import useIsACMPage from '@multicluster/useIsACMPage';
 
-const useClusterParam = () => {
+const useClusterParam = (): string | undefined => {
   const isACMPage = useIsACMPage();
   const pathMatch = useMatch(`${FLEET_BASE_PATH}/:page/cluster/:cluster/*`);
 
-  if (!isACMPage) return null;
+  if (!isACMPage) return undefined;
 
   return pathMatch?.params?.cluster;
 };

--- a/src/utils/components/NoPermissionButton/NoPermissionButton.tsx
+++ b/src/utils/components/NoPermissionButton/NoPermissionButton.tsx
@@ -1,0 +1,22 @@
+import React, { type FC, type PropsWithChildren } from 'react';
+
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { Button, Tooltip } from '@patternfly/react-core';
+
+type NoPermissionButtonProps = PropsWithChildren;
+
+const NoPermissionButton: FC<NoPermissionButtonProps> = ({ children }) => {
+  const { t } = useKubevirtTranslation();
+
+  return (
+    <Tooltip
+      content={t(
+        'To perform this action you must get permission from your organization administrator.',
+      )}
+    >
+      <Button isAriaDisabled>{children}</Button>
+    </Tooltip>
+  );
+};
+
+export default NoPermissionButton;

--- a/src/utils/hooks/useCanCreateResource.ts
+++ b/src/utils/hooks/useCanCreateResource.ts
@@ -1,0 +1,26 @@
+import { type K8sModel } from '@openshift-console/dynamic-plugin-sdk';
+import { useFleetAccessReview } from '@stolostron/multicluster-sdk';
+
+type UseCanCreateResourceProps = {
+  cluster?: string;
+  model: K8sModel;
+  namespace?: string;
+};
+
+const useCanCreateResource = ({
+  cluster,
+  model,
+  namespace,
+}: UseCanCreateResourceProps): boolean => {
+  const [canCreateResource] = useFleetAccessReview({
+    cluster,
+    group: model.apiGroup,
+    namespace,
+    resource: model.plural,
+    verb: 'create',
+  });
+
+  return canCreateResource;
+};
+
+export default useCanCreateResource;

--- a/src/utils/hooks/useSelectedCluster.ts
+++ b/src/utils/hooks/useSelectedCluster.ts
@@ -6,13 +6,13 @@ import useListClusters from './useListClusters';
 
 /**
  * Returns a cluster name that a user has selected or the hub cluster if none have been selected yet.
- * @returns a cluster name if the page is an ACM page, otherwise null
+ * @returns a cluster name if the page is an ACM page, otherwise undefined
  */
-const useSelectedCluster = () => {
+const useSelectedCluster = (): string | undefined => {
   const isACMPage = useIsACMPage();
   const clusters = useListClusters();
   const [hubClusterName] = useHubClusterName();
-  return isACMPage ? clusters?.[0] || hubClusterName : null;
+  return isACMPage ? (clusters?.[0] ?? hubClusterName) : undefined;
 };
 
 export default useSelectedCluster;

--- a/src/views/bootablevolumes/list/components/BootableVolumeAddButton.tsx
+++ b/src/views/bootablevolumes/list/components/BootableVolumeAddButton.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router';
 
 import AddBootableVolumeModal from '@kubevirt-utils/components/AddBootableVolumeModal/AddBootableVolumeModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import NoPermissionButton from '@kubevirt-utils/components/NoPermissionButton/NoPermissionButton';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useSelectedCluster from '@kubevirt-utils/hooks/useSelectedCluster';
@@ -12,11 +13,10 @@ import useIsACMPage from '@multicluster/useIsACMPage';
 import { ListPageCreateDropdown } from '@openshift-console/dynamic-plugin-sdk';
 
 type BootableVolumeAddButtonProps = {
-  buttonText?: string;
   namespace: string;
 };
 
-const BootableVolumeAddButton: FC<BootableVolumeAddButtonProps> = ({ buttonText, namespace }) => {
+const BootableVolumeAddButton: FC<BootableVolumeAddButtonProps> = ({ namespace }) => {
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
   const navigate = useNavigate();
@@ -34,7 +34,7 @@ const BootableVolumeAddButton: FC<BootableVolumeAddButtonProps> = ({ buttonText,
 
   const onCreate = (type: string): void => {
     if (type === 'form') {
-      createModal((props) => <AddBootableVolumeModal {...props} />);
+      createModal?.((props) => <AddBootableVolumeModal {...props} />);
       return;
     }
     const url = isACMPage
@@ -43,15 +43,17 @@ const BootableVolumeAddButton: FC<BootableVolumeAddButtonProps> = ({ buttonText,
     navigate(url);
   };
 
+  const createButtonText = t('Add volume');
+
   if ((canCreateDS || canCreatePVC) && canListInstanceTypesPreference) {
     return (
       <ListPageCreateDropdown items={createItems} onClick={onCreate}>
-        {buttonText ?? t('Add volume')}
+        {createButtonText}
       </ListPageCreateDropdown>
     );
   }
 
-  return <></>;
+  return <NoPermissionButton>{createButtonText}</NoPermissionButton>;
 };
 
 export default BootableVolumeAddButton;

--- a/src/views/bootablevolumes/list/components/BootableVolumesEmptyState.tsx
+++ b/src/views/bootablevolumes/list/components/BootableVolumesEmptyState.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import ListEmptyState from '@kubevirt-utils/components/ListEmptyState/ListEmptyState';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -18,10 +18,8 @@ const BootableVolumesEmptyState: FC<BootableVolumesEmptyStateProps> = ({ namespa
       <ListPageHeader title={t('Bootable volumes')} />
       <ListPageBody>
         <ListEmptyState
-          buttonAction={
-            <BootableVolumeAddButton buttonText={t('Add volume')} namespace={namespace} />
-          }
           bodyContent={t('To get started, add a bootable volume.')}
+          buttonAction={<BootableVolumeAddButton namespace={namespace} />}
           titleText={t("You don't have any bootable volumes yet")}
         />
       </ListPageBody>

--- a/src/views/datasources/list/DataSourcesList.tsx
+++ b/src/views/datasources/list/DataSourcesList.tsx
@@ -1,14 +1,10 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
-import { useNavigate } from 'react-router';
+import React, { type FC, useMemo } from 'react';
 
 import { DataSourceModelRef } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import KubevirtFilterToolbar from '@kubevirt-utils/components/KubevirtFilterToolbar/KubevirtFilterToolbar';
 import KubevirtTable from '@kubevirt-utils/components/KubevirtTable/KubevirtTable';
 import { buildColumnLayout } from '@kubevirt-utils/components/KubevirtTable/utils';
-import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
-import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import useKubevirtDataViewFilters from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/useKubevirtDataViewFilters';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtTableColumns from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtTableColumns';
@@ -18,13 +14,12 @@ import { EXPORT_TABLE_KEYS, KubevirtTableExport } from '@kubevirt-utils/hooks/us
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   ListPageBody,
-  ListPageCreateDropdown,
   ListPageHeader,
   useK8sWatchResource,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { Pagination } from '@patternfly/react-core';
 
-import { CreateDataSourceModal } from './CreateDataSourceModal/CreateDataSourceModal';
+import DataSourceCreateButton from './components/DataSourceCreateButton/DataSourceCreateButton';
 import { getDataSourceColumns, getDataSourceRowId } from './dataSourcesDefinition';
 import { getDataImportCronFilter } from './DataSourcesListFilters';
 
@@ -38,15 +33,13 @@ type DataSourcesListProps = {
 
 const DataSourcesList: FC<DataSourcesListProps> = ({ kind, namespace }) => {
   const { t } = useKubevirtTranslation();
-  const { createModal } = useModal();
-  const navigate = useNavigate();
 
   const [dataSources, loaded, loadError] = useK8sWatchResource<V1beta1DataSource[]>({
     isList: true,
     kind,
     namespace,
     namespaced: true,
-  });
+  }) as [V1beta1DataSource[], boolean, Error];
 
   const filterDefinitions = useMemo(() => getDataImportCronFilter(t), [t]);
   const { clearAllFilters, filteredData, filters, onSetFilters } = useKubevirtDataViewFilters({
@@ -55,10 +48,10 @@ const DataSourcesList: FC<DataSourcesListProps> = ({ kind, namespace }) => {
   });
 
   const {
+    handleFilterChange: handleSetFilters,
     handlePerPageSelect,
     handleSetPage,
     pagination,
-    handleFilterChange: handleSetFilters,
   } = usePaginationWithFilters(filteredData?.length ?? 0, onSetFilters);
 
   const columns = useMemo(() => getDataSourceColumns(t, namespace), [t, namespace]);
@@ -73,29 +66,12 @@ const DataSourcesList: FC<DataSourcesListProps> = ({ kind, namespace }) => {
     [columns, activeColumnKeys, t],
   );
 
-  const createItems = {
-    form: t('With form'),
-    yaml: t('With YAML'),
-  };
-
-  const onCreate = (type: string) => {
-    return type === 'form'
-      ? createModal((props) => <CreateDataSourceModal namespace={namespace} {...props} />)
-      : navigate(`/k8s/ns/${namespace || DEFAULT_NAMESPACE}/${DataSourceModelRef}/~new`);
-  };
-
   const isLoaded = loaded && loadedColumns;
 
   return (
     <>
       <ListPageHeader title={t('DataSources')}>
-        <ListPageCreateDropdown
-          createAccessReview={{ groupVersionKind: DataSourceModelRef, namespace: namespace }}
-          items={createItems}
-          onClick={onCreate}
-        >
-          {t('Create DataSource')}
-        </ListPageCreateDropdown>
+        <DataSourceCreateButton namespace={namespace} />
       </ListPageHeader>
       <ListPageBody>
         <div className="list-managment-group">

--- a/src/views/datasources/list/components/DataSourceCreateButton/DataSourceCreateButton.tsx
+++ b/src/views/datasources/list/components/DataSourceCreateButton/DataSourceCreateButton.tsx
@@ -1,45 +1,47 @@
 import React, { type FC } from 'react';
 import { useNavigate } from 'react-router';
-import { getMigrationPolicyURL } from 'src/views/migrationpolicies/utils/utils';
 
-import { MigrationPolicyModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { DataSourceModel, DataSourceModelRef } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import NoPermissionButton from '@kubevirt-utils/components/NoPermissionButton/NoPermissionButton';
+import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import useCanCreateResource from '@kubevirt-utils/hooks/useCanCreateResource';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import useSelectedCluster from '@kubevirt-utils/hooks/useSelectedCluster';
 import { ListPageCreateDropdown } from '@openshift-console/dynamic-plugin-sdk';
 
-import MigrationPolicyCreateModal from '../../../components/MigrationPolicyCreateModal/MigrationPolicyCreateModal';
+import { CreateDataSourceModal } from '../../CreateDataSourceModal/CreateDataSourceModal';
 
-const MigrationPoliciesCreateButton: FC = () => {
+type DataSourceCreateButtonProps = {
+  namespace: string;
+};
+
+const DataSourceCreateButton: FC<DataSourceCreateButtonProps> = ({ namespace }) => {
   const { t } = useKubevirtTranslation();
-  const selectedCluster = useSelectedCluster();
-  const navigate = useNavigate();
   const { createModal } = useModal();
+  const navigate = useNavigate();
+
+  const canCreateDataSource = useCanCreateResource({
+    model: DataSourceModel,
+    namespace,
+  });
 
   const createItems = {
     form: t('With form'),
     yaml: t('With YAML'),
   };
 
-  const canCreateMigrationPolicy = useCanCreateResource({
-    cluster: selectedCluster,
-    model: MigrationPolicyModel,
-  });
-
   const onCreate = (type: string): void => {
     if (type === 'form') {
-      return createModal?.(({ isOpen, onClose }) => (
-        <MigrationPolicyCreateModal isOpen={isOpen} onClose={onClose} />
-      ));
+      createModal?.((props) => <CreateDataSourceModal namespace={namespace} {...props} />);
+      return;
     }
-    navigate(getMigrationPolicyURL('~new', selectedCluster));
+
+    navigate(`/k8s/ns/${namespace || DEFAULT_NAMESPACE}/${DataSourceModelRef}/~new`);
   };
 
-  const createButtonText = t('Create MigrationPolicy');
+  const createButtonText = t('Create DataSource');
 
-  if (!canCreateMigrationPolicy) {
+  if (!canCreateDataSource) {
     return <NoPermissionButton>{createButtonText}</NoPermissionButton>;
   }
 
@@ -50,4 +52,4 @@ const MigrationPoliciesCreateButton: FC = () => {
   );
 };
 
-export default MigrationPoliciesCreateButton;
+export default DataSourceCreateButton;

--- a/src/views/instancetypes/list/components/InstancetypeCreateButton/InstancetypeCreateButton.tsx
+++ b/src/views/instancetypes/list/components/InstancetypeCreateButton/InstancetypeCreateButton.tsx
@@ -1,13 +1,16 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { useLocation } from 'react-router';
 
-import { VirtualMachineInstancetypeModelRef } from '@kubevirt-ui-ext/kubevirt-api/console';
 import {
-  VirtualMachineClusterInstancetypeModel,
-  VirtualMachineClusterInstancetypeModelRef,
+  VirtualMachineClusterInstancetypeModelGroupVersionKind,
+  VirtualMachineInstancetypeModel,
+  VirtualMachineInstancetypeModelGroupVersionKind,
 } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { VirtualMachineClusterInstancetypeModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import NoPermissionButton from '@kubevirt-utils/components/NoPermissionButton/NoPermissionButton';
+import useCanCreateResource from '@kubevirt-utils/hooks/useCanCreateResource';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { ListPageCreate } from '@openshift-console/dynamic-plugin-sdk';
 
 type UserInstancetypeEmptyStateProps = {
@@ -21,27 +24,32 @@ const InstancetypeCreateButton: FC<UserInstancetypeEmptyStateProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
   const location = useLocation();
+  const cluster = useClusterParam();
 
-  const activeTabKey = location?.pathname.includes(VirtualMachineClusterInstancetypeModel.kind)
-    ? 0
-    : 1;
-
-  const groupVersionKind =
-    activeTabKey === 0
-      ? VirtualMachineClusterInstancetypeModelRef
-      : VirtualMachineInstancetypeModelRef;
-
-  return (
-    <ListPageCreate
-      createAccessReview={{
-        groupVersionKind,
-        ...(activeTabKey !== 0 && { namespace: namespace }),
-      }}
-      groupVersionKind={groupVersionKind}
-    >
-      {buttonText || t('Create')}
-    </ListPageCreate>
+  const isClusterInstancetypePage = location?.pathname.includes(
+    VirtualMachineClusterInstancetypeModel.kind,
   );
+
+  const [model, groupVersionKind] = isClusterInstancetypePage
+    ? [
+        VirtualMachineClusterInstancetypeModel,
+        VirtualMachineClusterInstancetypeModelGroupVersionKind,
+      ]
+    : [VirtualMachineInstancetypeModel, VirtualMachineInstancetypeModelGroupVersionKind];
+
+  const canCreateInstancetype = useCanCreateResource({
+    cluster,
+    model,
+    namespace,
+  });
+
+  const createButtonText = buttonText ?? t('Create');
+
+  if (!canCreateInstancetype) {
+    return <NoPermissionButton>{createButtonText}</NoPermissionButton>;
+  }
+
+  return <ListPageCreate groupVersionKind={groupVersionKind}>{createButtonText}</ListPageCreate>;
 };
 
 export default InstancetypeCreateButton;

--- a/src/views/preferences/list/components/PreferenceCreateButton.tsx
+++ b/src/views/preferences/list/components/PreferenceCreateButton.tsx
@@ -1,11 +1,14 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { useLocation } from 'react-router';
 
 import {
+  VirtualMachineClusterPreferenceModel,
   VirtualMachineClusterPreferenceModelGroupVersionKind,
+  VirtualMachinePreferenceModel,
   VirtualMachinePreferenceModelGroupVersionKind,
 } from '@kubevirt-ui-ext/kubevirt-api/console';
+import NoPermissionButton from '@kubevirt-utils/components/NoPermissionButton/NoPermissionButton';
+import useCanCreateResource from '@kubevirt-utils/hooks/useCanCreateResource';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ListPageCreate } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -17,27 +20,27 @@ type PreferenceCreateButtonProps = {
 const PreferenceCreateButton: FC<PreferenceCreateButtonProps> = ({ buttonText, namespace }) => {
   const { t } = useKubevirtTranslation();
   const location = useLocation();
-  const activeTabKey = location?.pathname.includes(
-    VirtualMachineClusterPreferenceModelGroupVersionKind.kind,
-  )
-    ? 0
-    : 1;
-  const groupVersionKind =
-    activeTabKey === 0
-      ? VirtualMachineClusterPreferenceModelGroupVersionKind
-      : VirtualMachinePreferenceModelGroupVersionKind;
 
-  return (
-    <ListPageCreate
-      createAccessReview={{
-        groupVersionKind,
-        ...(activeTabKey !== 0 && { namespace: namespace }),
-      }}
-      groupVersionKind={groupVersionKind}
-    >
-      {buttonText || t('Create')}
-    </ListPageCreate>
+  const isClusterPreferencePage = location?.pathname.includes(
+    VirtualMachineClusterPreferenceModel.kind,
   );
+
+  const [model, groupVersionKind] = isClusterPreferencePage
+    ? [VirtualMachineClusterPreferenceModel, VirtualMachineClusterPreferenceModelGroupVersionKind]
+    : [VirtualMachinePreferenceModel, VirtualMachinePreferenceModelGroupVersionKind];
+
+  const canCreatePreference = useCanCreateResource({
+    model,
+    namespace,
+  });
+
+  const createButtonText = buttonText ?? t('Create');
+
+  if (!canCreatePreference) {
+    return <NoPermissionButton>{createButtonText}</NoPermissionButton>;
+  }
+
+  return <ListPageCreate groupVersionKind={groupVersionKind}>{createButtonText}</ListPageCreate>;
 };
 
 export default PreferenceCreateButton;

--- a/src/views/quotas/list/components/QuotasCreateButton.tsx
+++ b/src/views/quotas/list/components/QuotasCreateButton.tsx
@@ -1,12 +1,11 @@
 import React, { type FC, useCallback } from 'react';
 import { useNavigate } from 'react-router';
 
+import NoPermissionButton from '@kubevirt-utils/components/NoPermissionButton/NoPermissionButton';
 import { EditorType } from '@kubevirt-utils/components/SyncedEditor/utils/types';
+import useCanCreateResource from '@kubevirt-utils/hooks/useCanCreateResource';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import {
-  ApplicationAwareResourceQuotaModel,
-  modelToGroupVersionKind,
-} from '@kubevirt-utils/models';
+import { ApplicationAwareResourceQuotaModel } from '@kubevirt-utils/models';
 import { ListPageCreateDropdown } from '@openshift-console/dynamic-plugin-sdk';
 
 import { getQuotaCreateFormURL, getQuotaCreateFormYAMLURL } from '../../utils/url';
@@ -34,16 +33,20 @@ const QuotasCreateButton: FC<QuotasCreateButtonProps> = ({ namespace }) => {
     [navigate, namespace],
   );
 
+  const canCreateQuota = useCanCreateResource({
+    model: ApplicationAwareResourceQuotaModel,
+    namespace,
+  });
+
+  const createButtonText = t('Create quota');
+
+  if (!canCreateQuota) {
+    return <NoPermissionButton>{createButtonText}</NoPermissionButton>;
+  }
+
   return (
-    <ListPageCreateDropdown
-      createAccessReview={{
-        groupVersionKind: modelToGroupVersionKind(ApplicationAwareResourceQuotaModel),
-        namespace,
-      }}
-      items={createItems}
-      onClick={onCreate}
-    >
-      {t('Create quota')}
+    <ListPageCreateDropdown items={createItems} onClick={onCreate}>
+      {createButtonText}
     </ListPageCreateDropdown>
   );
 };

--- a/src/views/templates/list/components/VirtualMachineTemplatesCreateButton/VirtualMachineTemplatesCreateButton.tsx
+++ b/src/views/templates/list/components/VirtualMachineTemplatesCreateButton/VirtualMachineTemplatesCreateButton.tsx
@@ -1,11 +1,12 @@
-/* eslint-disable */
-import React, { FC, MouseEvent, Ref, useCallback, useState } from 'react';
+import React, { type FC, type MouseEvent, type Ref, useCallback, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import { TemplateModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import CloneTemplateModal from '@kubevirt-utils/components/CloneTemplateModal/CloneTemplateModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import NoPermissionButton from '@kubevirt-utils/components/NoPermissionButton/NoPermissionButton';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
+import useCanCreateResource from '@kubevirt-utils/hooks/useCanCreateResource';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useListNamespaces from '@kubevirt-utils/hooks/useListNamespaces';
 import useSelectedCluster from '@kubevirt-utils/hooks/useSelectedCluster';
@@ -18,13 +19,12 @@ import {
   DropdownItem,
   DropdownList,
   MenuToggle,
-  MenuToggleElement,
+  type MenuToggleElement,
 } from '@patternfly/react-core';
-import { useFleetAccessReview } from '@stolostron/multicluster-sdk';
 import { VM_LIST_TAB_PARAM, VM_LIST_TAB_VMS } from '@virtualmachines/navigator/constants';
 
-import useAddCreateFromVMToast from './hooks/useAddCreateFromVMToast';
 import { CreateTemplateItems } from './constants';
+import useAddCreateFromVMToast from './hooks/useAddCreateFromVMToast';
 
 const VirtualMachineTemplatesCreateButton: FC = () => {
   const { t } = useKubevirtTranslation();
@@ -37,14 +37,12 @@ const VirtualMachineTemplatesCreateButton: FC = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   const currentNamespace = selectedNamespaces?.[0];
-  const namespace = currentNamespace || DEFAULT_NAMESPACE;
+  const namespace = currentNamespace ?? DEFAULT_NAMESPACE;
 
-  const [canCreateTemplate] = useFleetAccessReview({
+  const canCreateTemplate = useCanCreateResource({
     cluster,
-    group: TemplateModel.apiGroup,
+    model: TemplateModel,
     namespace,
-    resource: TemplateModel.plural,
-    verb: 'create',
   });
 
   const onSelect = useCallback(
@@ -52,7 +50,7 @@ const VirtualMachineTemplatesCreateButton: FC = () => {
       setIsOpen(false);
       if (value === CreateTemplateItems.yaml) {
         return navigate(
-          isACMPage
+          isACMPage && cluster
             ? `${getFleetTemplatesURL(cluster, namespace)}/~new`
             : `${getTemplateListURL(namespace)}/~new`,
         );
@@ -66,7 +64,7 @@ const VirtualMachineTemplatesCreateButton: FC = () => {
       }
 
       if (value === CreateTemplateItems.fromTemplate) {
-        return createModal(({ isOpen: isModalOpen, onClose }) => (
+        return createModal?.(({ isOpen: isModalOpen, onClose }) => (
           <CloneTemplateModal isOpen={isModalOpen} onClose={onClose} />
         ));
       }
@@ -74,9 +72,23 @@ const VirtualMachineTemplatesCreateButton: FC = () => {
     [cluster, isACMPage, namespace, navigate, createModal, currentNamespace, addCreateFromVMToast],
   );
 
+  const createButtonText = t('Create template');
+
+  if (!canCreateTemplate) {
+    return (
+      <span id="tour-step-create-template">
+        <NoPermissionButton>{createButtonText}</NoPermissionButton>
+      </span>
+    );
+  }
+
   return (
     <span id="tour-step-create-template">
       <Dropdown
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        onSelect={onSelect}
+        popperProps={{ position: 'end' }}
         toggle={(toggleRef: Ref<MenuToggleElement>) => (
           <MenuToggle
             data-test="item-create"
@@ -85,18 +97,13 @@ const VirtualMachineTemplatesCreateButton: FC = () => {
             ref={toggleRef}
             variant="primary"
           >
-            {t('Create template')}
+            {createButtonText}
           </MenuToggle>
         )}
-        isOpen={isOpen}
-        onOpenChange={setIsOpen}
-        onSelect={onSelect}
-        popperProps={{ position: 'end' }}
       >
         <DropdownList>
           <DropdownItem
             description={t('Clone and customize a template.')}
-            isDisabled={!canCreateTemplate}
             key={CreateTemplateItems.fromTemplate}
             value={CreateTemplateItems.fromTemplate}
           >
@@ -110,11 +117,7 @@ const VirtualMachineTemplatesCreateButton: FC = () => {
           >
             {t('From a virtual machine')}
           </DropdownItem>
-          <DropdownItem
-            isDisabled={!canCreateTemplate}
-            key={CreateTemplateItems.yaml}
-            value={CreateTemplateItems.yaml}
-          >
+          <DropdownItem key={CreateTemplateItems.yaml} value={CreateTemplateItems.yaml}>
             {t('With YAML')}
           </DropdownItem>
         </DropdownList>

--- a/src/views/virtualmachines/list/components/VirtualMachineEmptyState/VirtualMachineEmptyState.tsx
+++ b/src/views/virtualmachines/list/components/VirtualMachineEmptyState/VirtualMachineEmptyState.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { Trans } from 'react-i18next';
 
 import { ProjectRequestModel, VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
@@ -76,7 +76,7 @@ const VirtualMachineEmptyState: FC<VirtualMachineEmptyStateProps> = ({ namespace
             </>
           )}
         </EmptyStateBody>
-        {!loading && canCreateVM && (
+        {!loading && (
           <EmptyStateFooter>
             <EmptyStateActions>
               <VirtualMachinesCreateButton

--- a/src/views/vmnetworks/list/VMNetworkList.tsx
+++ b/src/views/vmnetworks/list/VMNetworkList.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 
 import KubevirtFilterToolbar from '@kubevirt-utils/components/KubevirtFilterToolbar/KubevirtFilterToolbar';
 import KubevirtTable from '@kubevirt-utils/components/KubevirtTable/KubevirtTable';
@@ -9,15 +9,10 @@ import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { ListPageBody } from '@openshift-console/dynamic-plugin-sdk';
 
 import useVMNetworks from '../hooks/useVMNetworks';
-
 import LocalnetEmptyState from './components/LocalnetEmptyState/LocalnetEmptyState';
 import { getVMNetworkListColumns, getVMNetworkRowId } from './vmNetworkListDefinition';
 
-type VMNetworkListProps = {
-  onCreate: () => void;
-};
-
-const VMNetworkList: FC<VMNetworkListProps> = ({ onCreate }) => {
+const VMNetworkList: FC = () => {
   const { t } = useKubevirtTranslation();
   const [vmNetworks, loaded, error] = useVMNetworks();
   const { clearAllFilters, filteredData, filters, onSetFilters } = useKubevirtDataViewFilters({
@@ -34,7 +29,7 @@ const VMNetworkList: FC<VMNetworkListProps> = ({ onCreate }) => {
       withBullseye
     >
       {loaded && isEmpty(vmNetworks) ? (
-        <LocalnetEmptyState onCreate={onCreate} />
+        <LocalnetEmptyState />
       ) : (
         <ListPageBody>
           <KubevirtFilterToolbar

--- a/src/views/vmnetworks/list/VMNetworksPage.tsx
+++ b/src/views/vmnetworks/list/VMNetworksPage.tsx
@@ -6,12 +6,10 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { NetworkAttachmentDefinitionModel } from '@kubevirt-utils/models';
 import PopoverContentWithLightspeedButton from '@lightspeed/components/PopoverContentWithLightspeedButton/PopoverContentWithLightspeedButton';
 import { OLSPromptType } from '@lightspeed/utils/prompts';
-import { ListPageCreateButton, ListPageHeader } from '@openshift-console/dynamic-plugin-sdk';
+import { ListPageHeader } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, PopoverPosition, Stack, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 
-import { VM_NETWORKS_PATH } from '../constants';
-
-import useCanCreateVMNetwork from '../hooks/useCanCreateVMNetwork';
+import CreateNetworkButton from './components/CreateNetworkButton';
 import { NADS_LIST_PATH, PATH_BY_TAB_INDEX, TAB_INDEX_BY_PATH, TAB_INDEXES } from './constants';
 import VMNetworkList from './VMNetworkList';
 import VMNetworkOtherTypesList from './VMNetworkOtherTypesList';
@@ -20,20 +18,13 @@ const VMNetworksPage: FC = () => {
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
   const location = useLocation();
-  const { canCreate } = useCanCreateVMNetwork();
 
   const locationTabKey = TAB_INDEX_BY_PATH[location?.pathname] as number | undefined;
-
-  const onCreate = (): void => {
-    navigate(`${VM_NETWORKS_PATH}/~new`);
-  };
 
   return (
     <>
       <ListPageHeader title={t('Virtual machine networks')}>
-        <ListPageCreateButton isDisabled={!canCreate} onClick={onCreate}>
-          {t('Create network')}
-        </ListPageCreateButton>
+        <CreateNetworkButton />
       </ListPageHeader>
       <Tabs
         activeKey={locationTabKey}
@@ -47,7 +38,7 @@ const VMNetworksPage: FC = () => {
           eventKey={TAB_INDEXES.OVN_LOCALNET}
           title={<TabTitleText>{t('OVN localnet')}</TabTitleText>}
         >
-          <VMNetworkList onCreate={onCreate} />
+          <VMNetworkList />
         </Tab>
         <Tab
           eventKey={TAB_INDEXES.OTHER_VM_NETWORK_TYPES}

--- a/src/views/vmnetworks/list/components/CreateNetworkButton.tsx
+++ b/src/views/vmnetworks/list/components/CreateNetworkButton.tsx
@@ -1,0 +1,30 @@
+import React, { type FC } from 'react';
+import { useNavigate } from 'react-router';
+
+import NoPermissionButton from '@kubevirt-utils/components/NoPermissionButton/NoPermissionButton';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { Button } from '@patternfly/react-core';
+
+import { VM_NETWORKS_PATH } from '../../constants';
+import useCanCreateVMNetwork from '../../hooks/useCanCreateVMNetwork';
+
+const CreateNetworkButton: FC = () => {
+  const { t } = useKubevirtTranslation();
+  const navigate = useNavigate();
+
+  const { canCreate } = useCanCreateVMNetwork();
+
+  const onCreate = (): void => {
+    navigate(`${VM_NETWORKS_PATH}/~new`);
+  };
+
+  const createButtonText = t('Create network');
+
+  if (!canCreate) {
+    return <NoPermissionButton>{createButtonText}</NoPermissionButton>;
+  }
+
+  return <Button onClick={onCreate}>{createButtonText}</Button>;
+};
+
+export default CreateNetworkButton;

--- a/src/views/vmnetworks/list/components/LocalnetEmptyState/LocalnetEmptyState.tsx
+++ b/src/views/vmnetworks/list/components/LocalnetEmptyState/LocalnetEmptyState.tsx
@@ -1,25 +1,21 @@
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import useCanCreateVMNetwork from 'src/views/vmnetworks/hooks/useCanCreateVMNetwork';
 
 import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
 import ListEmptyState from '@kubevirt-utils/components/ListEmptyState/ListEmptyState';
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { Button } from '@patternfly/react-core';
+
+import CreateNetworkButton from '../CreateNetworkButton';
 
 import NoPhysicalNetworkAlert from './NoPhysicalNetworkAlert';
 
-type LocalnetEmptyStateProps = {
-  onCreate: () => void;
-};
-
-const LocalnetEmptyState: FC<LocalnetEmptyStateProps> = ({ onCreate }) => {
+const LocalnetEmptyState: FC = () => {
   const { t } = useKubevirtTranslation();
 
   const kind = t('OVN localnet network');
-  const createButtonText = t('Create network');
 
-  const { canCreate, showNoPhysicalNetworkAlert } = useCanCreateVMNetwork();
+  const { showNoPhysicalNetworkAlert } = useCanCreateVMNetwork();
 
   return (
     <ListEmptyState
@@ -30,11 +26,7 @@ const LocalnetEmptyState: FC<LocalnetEmptyStateProps> = ({ onCreate }) => {
           t('To get started, create a network.')
         )
       }
-      buttonAction={
-        <Button isDisabled={!canCreate} onClick={onCreate}>
-          {createButtonText}
-        </Button>
-      }
+      buttonAction={<CreateNetworkButton />}
       learnMoreLink={
         <ExternalLink href={documentationURL.NETWORKING}>
           {t('Learn more about {{ kind }}', { kind })}


### PR DESCRIPTION


<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PR title MUST start with a Jira ticket ID: "CNV-XXXXX: short description"
  - For release branches: "[release-4.XX] CNV-XXXXX: short description"
  - The Jira ticket must have: story points > 1, fix version set, component "CNV User Interface", product type set
- PRs that adds new external dependencies might take a while to review.
- PRs that modify `.cursor/`, `.claude/`, `.vscode/`, or `.github/scripts/` require **strict security review**, CodeRabbit approval of findings, and the **`ai-config-reviewed`** label before merge.
- PRs that modify `locales/` require the **`i18n-reviewed`** label (`.github/OWNERS` via `/i18n-approved`) before merge.
- Keep your PR as small as possible.
- Limit your PR to one type (feature, refactoring, ci, or bugfix)
-->

## 📝 Description

Make empty state create buttons consistent for non-priv users

- users that cannot create a resource will see the Create button, but it will be disabled with a tooltip message

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-96254

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/4c22c6ed-c252-4378-8226-57f0fe28cda4




After:

https://github.com/user-attachments/assets/598941ef-40f5-4206-b9eb-f7d2c060fe06



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent permission-aware creation controls across data sources, instancetypes, migration policies, preferences, quotas, templates, bootable volumes, and VM networks.
  - Users without administrator permissions now see an explanatory disabled button instead of missing or inconsistently disabled controls.
  - Added VM network creation navigation and data source creation options, including form and YAML workflows.
  - Creation actions now appear consistently in relevant empty states after loading completes.

- **Bug Fixes**
  - Improved cluster selection handling for pages outside the cluster management context.
  - Preserved explicit button labels and improved modal handling when unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->