### PR TITLE
CNV-96233: fix the validation on labels

### DIFF
--- a/locales/en/plugin__kubevirt-plugin.json
+++ b/locales/en/plugin__kubevirt-plugin.json
@@ -2306,6 +2306,7 @@
   "This is a network interface (NIC)": "This is a network interface (NIC)",
   "This is a vm created from snapshot {{name}}": "This is a vm created from snapshot {{name}}",
   "This is an ISO file": "This is an ISO file",
+  "This key is reserved for an auto-applied label": "This key is reserved for an auto-applied label",
   "This list only shows network definitions that are compatible with virtual machines. To view the complete list of all available networks, refer to the full NetworkAttachmentDefinition list.": "This list only shows network definitions that are compatible with virtual machines. To view the complete list of all available networks, refer to the full NetworkAttachmentDefinition list.",
   "This network is currently connected to {{count}} virtual machine._one": "This network is currently connected to {{count}} virtual machine.",
   "This network is currently connected to {{count}} virtual machine._other": "This network is currently connected to {{count}} virtual machine.",

--- a/playwright/docs/tier2/auto-applied-labels/wizard-vm-detail-auto-labels.md
+++ b/playwright/docs/tier2/auto-applied-labels/wizard-vm-detail-auto-labels.md
@@ -23,16 +23,19 @@ Consolidated tests for wizard drawer behavior, label protection, VM creation lab
 ### Test 1 — Wizard drawer and label protection
 
 Single wizard session covering:
+
 - Next button disabled when required labels have no value
 - Required labels drawer opens automatically on Customization step
 - Filling required label values and closing drawer enables Next
 - Auto-applied keys cannot be deleted from Labels tab
 - Admin-set values cannot be edited
 - Admin-empty values can be edited
+- New label key stays editable when it matches an auto-applied key; Save stays disabled until the key is corrected
 
 ### Test 2 — VM creation applies correct labels
 
 Single VM creation covering:
+
 - Required label with user-filled value appears on VM
 - Admin-set label appears on VM
 - Optional label without value is excluded from VM
@@ -40,10 +43,12 @@ Single VM creation covering:
 ### Test 3 — VM detail metadata tab enforces label restrictions
 
 Single API-created VM with all label types covering:
+
 - Auto-applied labels show correct values
 - Auto-applied keys cannot be deleted
 - Admin-empty value labels are editable
 - User-added labels remain deletable
+- New label key stays editable when it matches an auto-applied key; Save stays disabled until the key is corrected
 
 ## Requirements Traceability Matrix
 
@@ -62,3 +67,5 @@ Single API-created VM with all label types covering:
 | 011  | CNV-94368 | "Auto-applied keys cannot be deleted (detail)"   | Active |
 | 012  | CNV-94368 | "Admin-empty value labels are editable (detail)" | Active |
 | 013  | CNV-94368 | "User-added labels remain deletable"             | Active |
+| 014  | CNV-96233 | "New label key stays editable (wizard)"          | Active |
+| 015  | CNV-96233 | "New label key stays editable (detail)"          | Active |

--- a/playwright/src/components/shared/labels-modal-component.ts
+++ b/playwright/src/components/shared/labels-modal-component.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared helpers for the Edit labels modal used in the wizard and VM detail.
+ */
+
+import BaseComponent from '@/components/shared/base-component';
+import { TestTimeouts } from '@/utils/test-config';
+import { expect, type Locator, type Page } from '@playwright/test';
+
+export default class LabelsModalComponent extends BaseComponent {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  private dialog(): Locator {
+    return this.page.getByRole('dialog', { name: /Edit labels/i });
+  }
+
+  private newKeyInput(): Locator {
+    return this.dialog().getByTestId('label-key-input').last().locator('input');
+  }
+
+  async waitForOpen(): Promise<void> {
+    await this.dialog().waitFor({
+      state: 'visible',
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+  }
+
+  async addLabelRow(): Promise<void> {
+    await this.robustClick(this.dialog().getByRole('button', { exact: true, name: 'Add label' }));
+  }
+
+  async fillNewLabelKey(key: string): Promise<void> {
+    const input = this.newKeyInput();
+    await input.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    await input.fill(key);
+  }
+
+  async isNewLabelKeyEnabled(): Promise<boolean> {
+    const input = this.newKeyInput();
+    const isVisible = await input
+      .isVisible({ timeout: TestTimeouts.UI_ELEMENT_VISIBILITY })
+      .catch(() => false);
+    if (!isVisible) return false;
+    return input.isEnabled();
+  }
+
+  async isSaveDisabled(): Promise<boolean> {
+    const saveButton = this.dialog().getByTestId('save-button');
+    await saveButton.waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+    return saveButton.isDisabled();
+  }
+
+  async waitForValidationError(): Promise<void> {
+    await this.dialog()
+      .getByTestId('label-row-error')
+      .last()
+      .waitFor({ state: 'visible', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+  }
+
+  async waitForValidationErrorHidden(): Promise<void> {
+    await expect(this.dialog().getByTestId('label-row-error')).toHaveCount(0, {
+      timeout: TestTimeouts.UI_ELEMENT_VISIBILITY,
+    });
+  }
+
+  async close(): Promise<void> {
+    const dialog = this.dialog();
+    await this.page.keyboard.press('Escape');
+    if (await dialog.isVisible().catch(() => false)) {
+      const cancelButton = dialog.getByTestId('cancel-button');
+      if (await cancelButton.isVisible().catch(() => false)) {
+        await this.robustClick(cancelButton);
+      } else {
+        await this.page.keyboard.press('Escape');
+      }
+    }
+    await dialog.waitFor({ state: 'hidden', timeout: TestTimeouts.UI_ELEMENT_VISIBILITY });
+  }
+}

--- a/playwright/src/components/vm-wizard/wizard-labels-component.ts
+++ b/playwright/src/components/vm-wizard/wizard-labels-component.ts
@@ -4,6 +4,7 @@
  */
 
 import BaseComponent from '@/components/shared/base-component';
+import LabelsModalComponent from '@/components/shared/labels-modal-component';
 import { TestTimeouts } from '@/utils/test-config';
 import type { Page } from '@playwright/test';
 
@@ -15,9 +16,11 @@ export default class WizardLabelsComponent extends BaseComponent {
   private readonly _labelsTable = this.locator('[data-test="labels-card-table"]');
   private readonly _saveAsDefaultsCheckbox = this.locator('#save-as-defaults');
   private readonly _tabPanel = this.locator('[role="tabpanel"]');
+  readonly labelsModal: LabelsModalComponent;
 
   constructor(page: Page) {
     super(page);
+    this.labelsModal = new LabelsModalComponent(page);
   }
 
   async closeRequiredLabelsDrawer(): Promise<void> {
@@ -115,5 +118,11 @@ export default class WizardLabelsComponent extends BaseComponent {
     if (isChecked !== checked) {
       await this._saveAsDefaultsCheckbox.click();
     }
+  }
+
+  async openAddLabelsModal(): Promise<void> {
+    const addButton = this._tabPanel.getByTestId('labels-card-add-btn');
+    await this.robustClick(addButton);
+    await this.labelsModal.waitForOpen();
   }
 }

--- a/playwright/src/components/vm/vm-detail-metadata-component.ts
+++ b/playwright/src/components/vm/vm-detail-metadata-component.ts
@@ -3,6 +3,7 @@
  */
 
 import BaseComponent from '@/components/shared/base-component';
+import LabelsModalComponent from '@/components/shared/labels-modal-component';
 import { TestTimeouts } from '@/utils/test-config';
 import type { Page } from '@playwright/test';
 
@@ -12,9 +13,11 @@ export default class VmDetailMetadataComponent extends BaseComponent {
   private readonly _advancedViewToggle = this.testId('advanced-view-toggle');
   private readonly _labelsCard = this.testId('labels-card');
   private readonly _labelsTable = this.locator('[data-test="labels-card-table"]');
+  readonly labelsModal: LabelsModalComponent;
 
   constructor(page: Page) {
     super(page);
+    this.labelsModal = new LabelsModalComponent(page);
   }
 
   async clickDeleteLabel(key: string): Promise<void> {
@@ -86,5 +89,11 @@ export default class VmDetailMetadataComponent extends BaseComponent {
   async toggleAdvancedView(): Promise<void> {
     await this.robustClick(this._advancedViewToggle);
     await this.page.waitForTimeout(TestTimeouts.UI_DELAY_MEDIUM);
+  }
+
+  async openAddLabelsModal(): Promise<void> {
+    const addButton = this._labelsCard.getByTestId('labels-card-add-btn');
+    await this.robustClick(addButton);
+    await this.labelsModal.waitForOpen();
   }
 }

--- a/playwright/src/fixtures/auto-labels-fixture.ts
+++ b/playwright/src/fixtures/auto-labels-fixture.ts
@@ -10,7 +10,6 @@ import SettingsPage from '@/page-objects/settings/settings-page';
 import VirtualMachineDetailPage from '@/page-objects/vm/virtual-machine-detail-page';
 import VirtualMachinesPage from '@/page-objects/vm/virtual-machines-page';
 import VmCreationWizardPage from '@/page-objects/vm-wizard/vm-creation-wizard-page';
-import VmTreePage from '@/page-objects/vm/vm-tree-page';
 
 import { baseTest, expect } from './scenario-test-fixture';
 
@@ -19,7 +18,6 @@ interface AutoLabelsFixtures {
   settingsPage: SettingsPage;
   vmDetailPage: VirtualMachineDetailPage;
   vmListPage: VirtualMachinesPage;
-  vmTreePage: VmTreePage;
   vmWizardPage: VmCreationWizardPage;
 }
 
@@ -35,9 +33,6 @@ const test = baseTest.extend<AutoLabelsFixtures>({
   },
   vmListPage: async ({ page }, use) => {
     await use(new VirtualMachinesPage(page));
-  },
-  vmTreePage: async ({ page }, use) => {
-    await use(new VmTreePage(page));
   },
   vmWizardPage: async ({ page }, use) => {
     await use(new VmCreationWizardPage(page));

--- a/playwright/src/utils/auto-labels-test-helpers.ts
+++ b/playwright/src/utils/auto-labels-test-helpers.ts
@@ -9,8 +9,8 @@
 import type RequestContextClient from '@/clients/request-context-client';
 import type { TestUtilsType } from '@/fixtures/test-utils';
 import type SettingsPage from '@/page-objects/settings/settings-page';
+import type VirtualMachinesPage from '@/page-objects/vm/virtual-machines-page';
 import type VmCreationWizardPage from '@/page-objects/vm-wizard/vm-creation-wizard-page';
-import type VmTreePage from '@/page-objects/vm/vm-tree-page';
 
 export const FEATURES_CONFIG_MAP = 'kubevirt-ui-features';
 export const USER_SETTINGS_CONFIG_MAP = 'kubevirt-user-settings';
@@ -94,12 +94,12 @@ export async function navigateToUserLabelsSection(settingsPage: SettingsPage): P
 
 /** Navigates through the VM creation wizard to the Customization step. Returns the VM name. */
 export async function navigateToWizardCustomizationStep(
-  vmTreePage: VmTreePage,
+  vmListPage: VirtualMachinesPage,
   vmWizardPage: VmCreationWizardPage,
   namespace: string,
 ): Promise<string> {
-  await vmTreePage.switchToVirtualizationPerspective();
-  await vmTreePage.navigateToProjectVmListViaUI(namespace);
+  await vmListPage.switchToVirtualizationPerspective();
+  await vmListPage.navigateToProjectVmListViaUI(namespace);
   await vmWizardPage.openWizardFromCreateDropdown();
   await vmWizardPage.ensureVmNameFilled();
   const vmName = await vmWizardPage.page.locator('.vm-creation-wizard #vm-name').inputValue();

--- a/playwright/tests/tier2/auto-applied-labels/wizard-vm-detail-auto-labels.spec.ts
+++ b/playwright/tests/tier2/auto-applied-labels/wizard-vm-detail-auto-labels.spec.ts
@@ -10,6 +10,7 @@
  * test.step() provides granular reporting within each test.
  */
 
+import type LabelsModalComponent from '@/components/shared/labels-modal-component';
 import {
   ADMIN_ONLY_TAG,
   AUTO_LABELS_FEATURE,
@@ -36,6 +37,35 @@ const TEST_LABELS = [
 
 const USER_ADDED_LABEL_KEY = 'user-custom-label';
 
+const assertNewLabelKeyStaysEditable = async (
+  labelsModal: LabelsModalComponent,
+): Promise<void> => {
+  await labelsModal.addLabelRow();
+  await labelsModal.fillNewLabelKey('team');
+  expect
+    .soft(
+      await labelsModal.isNewLabelKeyEnabled(),
+      'Key input should stay enabled for a reserved key',
+    )
+    .toBe(true);
+  await labelsModal.waitForValidationError();
+  expect
+    .soft(await labelsModal.isSaveDisabled(), 'Save should be disabled for a reserved key')
+    .toBe(true);
+  await labelsModal.fillNewLabelKey('team-custom');
+  expect
+    .soft(
+      await labelsModal.isNewLabelKeyEnabled(),
+      'Key input should stay enabled after correcting the key',
+    )
+    .toBe(true);
+  await labelsModal.waitForValidationErrorHidden();
+  expect
+    .soft(await labelsModal.isSaveDisabled(), 'Save should be enabled after correcting the key')
+    .toBe(false);
+  await labelsModal.close();
+};
+
 test.describe(
   'Auto-applied labels — wizard & VM detail',
   { tag: [T2_TAG, ADMIN_ONLY_TAG, AUTO_LABELS_TAG] },
@@ -61,13 +91,13 @@ test.describe(
     // Single wizard session: drawer behavior + label protection assertions
     test('Wizard drawer and label protection', async ({
       apiClient,
-      vmTreePage,
+      vmListPage,
       vmWizardPage,
       utils,
     }) => {
       test.setTimeout(utils.TestTimeouts.TEST_EXTENDED);
       const ns = await setupTestNamespace(apiClient, 'al-wizard');
-      await navigateToWizardCustomizationStep(vmTreePage, vmWizardPage, ns);
+      await navigateToWizardCustomizationStep(vmListPage, vmWizardPage, ns);
 
       // Wait for useApplyAutoLabels hook to process — drawer signals labels are merged
       await vmWizardPage.labels.waitForDrawerVisible();
@@ -117,19 +147,24 @@ test.describe(
           .toBe(true);
       });
 
+      await test.step('New label key stays editable when it matches an auto-applied key', async () => {
+        await vmWizardPage.labels.openAddLabelsModal();
+        await assertNewLabelKeyStaysEditable(vmWizardPage.labels.labelsModal);
+      });
+
       await vmWizardPage.cancelWizard().catch(() => {});
     });
 
     // Single VM creation: verifies required + admin-set labels are applied, optional excluded
     test('VM creation applies correct labels', async ({
       apiClient,
-      vmTreePage,
+      vmListPage,
       vmWizardPage,
       utils,
     }) => {
       test.setTimeout(utils.TestTimeouts.TEST_EXTENDED);
       const ns = await setupTestNamespace(apiClient, 'al-create');
-      const vmName = await navigateToWizardCustomizationStep(vmTreePage, vmWizardPage, ns);
+      const vmName = await navigateToWizardCustomizationStep(vmListPage, vmWizardPage, ns);
       await vmWizardPage.labels.waitForDrawerVisible();
       await vmWizardPage.labels.fillDrawerLabelValue('env', 'test');
       await vmWizardPage.labels.fillDrawerLabelValue('department', 'engineering');
@@ -158,7 +193,7 @@ test.describe(
       metadataComponent,
       utils,
       vmDetailPage,
-      vmTreePage,
+      vmListPage,
     }) => {
       const ns = await setupTestNamespace(apiClient, 'al-detail');
       const vmName = utils.generateRandomVmName('al-detail');
@@ -188,7 +223,7 @@ test.describe(
         ns,
       );
 
-      await vmTreePage.switchToVirtualizationPerspective();
+      await vmListPage.switchToVirtualizationPerspective();
       await vmDetailPage.navigateToVirtualMachineDetail(vmName, ns);
       await vmDetailPage.navigateToConfigurationMetadata();
 
@@ -215,6 +250,11 @@ test.describe(
             'User label deletable',
           )
           .toBe(true);
+      });
+
+      await test.step('New label key stays editable when it matches an auto-applied key', async () => {
+        await metadataComponent.openAddLabelsModal();
+        await assertNewLabelKeyStaysEditable(metadataComponent.labelsModal);
       });
     });
   },

--- a/src/utils/components/LabelsModal/NewLabelsModal.tsx
+++ b/src/utils/components/LabelsModal/NewLabelsModal.tsx
@@ -1,9 +1,8 @@
-import React, { type FC, useMemo } from 'react';
+import React, { type FC } from 'react';
 
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import useAutoAppliedLabels from '@kubevirt-utils/hooks/useAutoAppliedLabels/useAutoAppliedLabels';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { isSystemKey } from '@kubevirt-utils/utils/labelValidation/labelValidation';
 import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, ButtonVariant, Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
@@ -29,22 +28,20 @@ const NewLabelsModal: FC<NewLabelsModalProps> = ({
   const { t } = useKubevirtTranslation();
   const { labels: autoAppliedLabels } = useAutoAppliedLabels();
 
-  const protectedKeys = useMemo(
-    () => new Map(autoAppliedLabels.map((label) => [label.key, Boolean(label.value)])),
-    [autoAppliedLabels],
-  );
-
   const {
+    autoAppliedKeys,
     existingKeys,
     handleSubmit,
     hasEmptyKeys,
     hasValidationErrors,
     initialKeys,
+    keyProtectedIds,
     labels,
     onLabelAdd,
     onLabelChange,
     onLabelDelete,
-  } = useLabelsModalState({ initialLabels, obj, onLabelsSubmit });
+    valueProtectedIds,
+  } = useLabelsModalState({ autoAppliedLabels, initialLabels, obj, onLabelsSubmit });
 
   return (
     <TabModal
@@ -67,13 +64,11 @@ const NewLabelsModal: FC<NewLabelsModalProps> = ({
             <GridItem span={2} />
             {labels.map((entry) => (
               <LabelRow
+                autoAppliedKeys={autoAppliedKeys}
                 existingKeys={existingKeys}
                 initialKeys={initialKeys}
-                isKeyProtected={
-                  protectedKeys.has(entry.key) ||
-                  (initialKeys.has(entry.key) && isSystemKey(entry.key))
-                }
-                isValueProtected={protectedKeys.get(entry.key) === true}
+                isKeyProtected={keyProtectedIds.has(entry.id)}
+                isValueProtected={valueProtectedIds.has(entry.id)}
                 key={entry.id}
                 label={entry}
                 onChange={(updated) => onLabelChange(entry.id, updated)}

--- a/src/utils/components/LabelsModal/components/LabelKeyInput.tsx
+++ b/src/utils/components/LabelsModal/components/LabelKeyInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useMemo, useRef, useState } from 'react';
+import React, { type FC, useCallback, useMemo, useRef, useState } from 'react';
 
 import { useClickOutside } from '@kubevirt-utils/hooks/useClickOutside/useClickOutside';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -92,7 +92,7 @@ const LabelKeyInput: FC<LabelKeyInputProps> = ({ existingKeys, onChange, value }
         isVisible={isOpen && filteredSuggestions.length > 0}
         popper={menu}
         trigger={
-          <TextInputGroup>
+          <TextInputGroup data-test="label-key-input">
             <TextInputGroupMain
               aria-label={t('Label key')}
               onChange={onInputChange}

--- a/src/utils/components/LabelsModal/components/LabelRow.tsx
+++ b/src/utils/components/LabelsModal/components/LabelRow.tsx
@@ -15,6 +15,7 @@ import { MinusCircleIcon } from '@patternfly/react-icons';
 import LabelKeyInput from './LabelKeyInput';
 
 type LabelRowProps = {
+  autoAppliedKeys?: Set<string>;
   existingKeys: string[];
   initialKeys?: Set<string>;
   isKeyProtected?: boolean;
@@ -25,6 +26,7 @@ type LabelRowProps = {
 };
 
 const LabelRow: FC<LabelRowProps> = ({
+  autoAppliedKeys,
   existingKeys,
   initialKeys,
   isKeyProtected,
@@ -36,15 +38,20 @@ const LabelRow: FC<LabelRowProps> = ({
   const { t } = useKubevirtTranslation();
 
   const error = useMemo(
-    () => validateLabelEntry(label.key, label.value, t, initialKeys, existingKeys),
-    [label.key, label.value, t, initialKeys, existingKeys],
+    () => validateLabelEntry(label.key, label.value, t, initialKeys, existingKeys, autoAppliedKeys),
+    [label.key, label.value, t, initialKeys, existingKeys, autoAppliedKeys],
   );
 
   return (
     <>
       <GridItem span={5}>
         {isKeyProtected ? (
-          <TextInput aria-label={t('Label key')} isDisabled value={label.key} />
+          <TextInput
+            aria-label={t('Label key')}
+            data-test="label-key-input-protected"
+            isDisabled
+            value={label.key}
+          />
         ) : (
           <LabelKeyInput
             existingKeys={existingKeys}
@@ -76,7 +83,7 @@ const LabelRow: FC<LabelRowProps> = ({
       </GridItem>
       {error && (
         <GridItem span={12}>
-          <HelperText>
+          <HelperText data-test="label-row-error">
             <HelperTextItem variant="error">{error}</HelperTextItem>
           </HelperText>
         </GridItem>

--- a/src/utils/components/LabelsModal/hooks/useLabelsModalState.ts
+++ b/src/utils/components/LabelsModal/hooks/useLabelsModalState.ts
@@ -1,37 +1,43 @@
 import { useMemo, useState } from 'react';
 
 import { logVMLabelsCollectedIfVirtualMachine } from '@kubevirt-utils/extensions/telemetry/labels';
+import { type AutoAppliedLabel } from '@kubevirt-utils/hooks/useAutoAppliedLabels/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getLabels } from '@kubevirt-utils/resources/shared';
 import {
   hasDuplicateKeys,
   validateLabelEntry,
 } from '@kubevirt-utils/utils/labelValidation/labelValidation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
-import { LabelEntry } from '../constants';
-import { entriesToLabels, labelsToEntries } from '../utils';
-import { getLabels } from '@kubevirt-utils/resources/shared';
+import { type LabelEntry } from '../constants';
+import { entriesToLabels, getProtectedEntryIds, labelsToEntries } from '../utils';
 
 type UseLabelsModalStateParams = {
+  autoAppliedLabels?: AutoAppliedLabel[];
   initialLabels?: Record<string, string>;
   obj: K8sResourceCommon;
   onLabelsSubmit: (labels: Record<string, string>) => Promise<unknown>;
 };
 
 type UseLabelsModalStateReturn = {
+  autoAppliedKeys: Set<string>;
   existingKeys: string[];
   handleSubmit: () => Promise<unknown>;
   hasEmptyKeys: boolean;
   hasValidationErrors: boolean;
   initialKeys: Set<string>;
+  keyProtectedIds: Set<number>;
   labels: LabelEntry[];
   onLabelAdd: () => void;
   onLabelChange: (entryId: number, updated: { key: string; value: string }) => void;
   onLabelDelete: (entryId: number) => void;
+  valueProtectedIds: Set<number>;
 };
 
 const useLabelsModalState = ({
+  autoAppliedLabels = [],
   initialLabels,
   obj,
   onLabelsSubmit,
@@ -50,6 +56,21 @@ const useLabelsModalState = ({
 
   const initialKeys = useMemo(() => new Set(Object.keys(initLabels)), [initLabels]);
 
+  const autoAppliedKeys = useMemo(
+    () => new Set(autoAppliedLabels.map((label) => label.key)),
+    [autoAppliedLabels],
+  );
+
+  const protectedKeys = useMemo(
+    () => new Map(autoAppliedLabels.map((label) => [label.key, Boolean(label.value)])),
+    [autoAppliedLabels],
+  );
+
+  const { keyProtectedIds, valueProtectedIds } = useMemo(
+    () => getProtectedEntryIds(labelsToEntries(initLabels), protectedKeys),
+    [initLabels, protectedKeys],
+  );
+
   const [labels, setLabels] = useState<LabelEntry[]>(initialEntries);
 
   const existingKeys = useMemo(() => labels.map(({ key }) => key), [labels]);
@@ -58,8 +79,10 @@ const useLabelsModalState = ({
 
   const hasValidationErrors = useMemo(
     () =>
-      labels.some(({ key, value }) => validateLabelEntry(key, value, t, initialKeys, existingKeys)),
-    [labels, t, initialKeys, existingKeys],
+      labels.some(({ key, value }) =>
+        validateLabelEntry(key, value, t, initialKeys, existingKeys, autoAppliedKeys),
+      ),
+    [labels, t, initialKeys, existingKeys, autoAppliedKeys],
   );
 
   const onLabelAdd = (): void => {
@@ -86,15 +109,18 @@ const useLabelsModalState = ({
   };
 
   return {
+    autoAppliedKeys,
     existingKeys,
     handleSubmit,
     hasEmptyKeys,
     hasValidationErrors,
     initialKeys,
+    keyProtectedIds,
     labels,
     onLabelAdd,
     onLabelChange,
     onLabelDelete,
+    valueProtectedIds,
   };
 };
 

--- a/src/utils/components/LabelsModal/utils.ts
+++ b/src/utils/components/LabelsModal/utils.ts
@@ -1,3 +1,5 @@
+import { isSystemKey } from '@kubevirt-utils/utils/labelValidation/labelValidation';
+
 import { type LabelEntry } from './constants';
 
 type ProcessLabelChangeResult =
@@ -60,3 +62,25 @@ export const labelsToEntries = (labels: Record<string, string>): LabelEntry[] =>
 
 export const entriesToLabels = (entries: LabelEntry[]): Record<string, string> =>
   Object.fromEntries(entries.map(({ key, value }) => [key, value]));
+
+export const getProtectedEntryIds = (
+  entries: LabelEntry[],
+  protectedKeys: Map<string, boolean>,
+): { keyProtectedIds: Set<number>; valueProtectedIds: Set<number> } => {
+  const keyProtectedIds = new Set<number>();
+  const valueProtectedIds = new Set<number>();
+
+  for (const { id, key } of entries) {
+    if (!key) continue;
+
+    if (protectedKeys.has(key) || isSystemKey(key)) {
+      keyProtectedIds.add(id);
+    }
+
+    if (protectedKeys.get(key) === true) {
+      valueProtectedIds.add(id);
+    }
+  }
+
+  return { keyProtectedIds, valueProtectedIds };
+};

--- a/src/utils/utils/labelValidation/labelValidation.ts
+++ b/src/utils/utils/labelValidation/labelValidation.ts
@@ -1,4 +1,4 @@
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
 import {
   K8S_LABEL_NAME_REGEX,
@@ -19,6 +19,7 @@ export const validateLabelEntry = (
   t: TFunction,
   initialKeys?: Set<string>,
   allKeys?: string[],
+  autoAppliedKeys?: Set<string>,
 ): string | undefined => {
   if (!key.trim()) return undefined;
 
@@ -30,6 +31,9 @@ export const validateLabelEntry = (
   if (isInitialKey && isSystemKey(key)) return undefined;
 
   if (!isInitialKey && isSystemKey(key)) return t('Cannot use system-managed key prefix');
+
+  if (!isInitialKey && autoAppliedKeys?.has(key))
+    return t('This key is reserved for an auto-applied label');
 
   const keyError = validateK8sLabelKey(key, t);
   if (keyError) return keyError;


### PR DESCRIPTION

## 📝 Description

If a user types a key that matches an auto-applied label, the Edit labels modal used to disable the key (and delete) immediately, so they could not fix a typo or continue typing. Protection is now tied to the original auto-applied rows only. New rows stay editable, show a validation error, and Save stays disabled until the key is unique.

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-96233

## 🎥 Demo

Before:

https://github.com/user-attachments/assets/d2ebead9-d2db-47ca-8318-d16efc70725b

After:

https://github.com/user-attachments/assets/8073dc62-f8f5-41f5-8aca-b5f707c8a681



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Label editing now identifies keys reserved for automatic application.
  - New label keys matching auto-applied keys remain editable, but saving is blocked until the key is corrected.
  - Protected label keys and values receive appropriate validation and protection indicators.

- **Tests**
  - Added coverage for reserved-key validation in both the VM creation wizard and VM details label dialogs.
  - Added shared test interactions for opening label dialogs, editing keys, checking validation messages, and verifying save availability.

- **Documentation**
  - Added traceability entries for the new wizard and VM details coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->