### PR TITLE
CNV-96509: disable cross-cluster migration for unsupported clusters and non-priv users

### DIFF
--- a/src/multicluster/components/CrossClusterMigration/hooks/useProviderByClusterName.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useProviderByClusterName.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { V1beta1Provider } from '@forklift-ui/types';
+import { type V1beta1Provider } from '@forklift-ui/types';
 
 import { getProviderByClusterName } from '../utils';
 
@@ -7,7 +7,7 @@ import useProviders from './useProviders';
 
 const useProviderByClusterName = (
   cluster?: string,
-): [undefined | V1beta1Provider, boolean, any] => {
+): [undefined | V1beta1Provider, boolean, Error | undefined] => {
   const [providers, providersLoaded, providersError] = useProviders();
 
   return [getProviderByClusterName(cluster, providers), providersLoaded, providersError];

--- a/src/multicluster/hooks/useACMExtensionActions/useACMExtensionActions.ts
+++ b/src/multicluster/hooks/useACMExtensionActions/useACMExtensionActions.ts
@@ -2,10 +2,10 @@ import { useMemo } from 'react';
 import produce from 'immer';
 
 import {
-  ACMVirtualMachineAction,
+  type ACMVirtualMachineAction,
   isACMVirtualMachineAction,
 } from '@kubevirt-extensions/acm.virtualmachine';
-import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
+import { type ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -24,7 +24,9 @@ const useACMExtensionActions = (vm): ActionDropdownItemType[] => {
   const { t } = useKubevirtTranslation();
   const isACMPage = useIsACMPage();
   const [hubClusterName] = useHubClusterName();
-  const [provider, providerLoaded] = useProviderByClusterName(getCluster(vm) ?? hubClusterName);
+  const [provider, providerLoaded, providerError] = useProviderByClusterName(
+    getCluster(vm) ?? hubClusterName,
+  );
 
   const [virtualMachineActionExtensions, virtualMachineActionExtensionsResolved] =
     useResolvedExtensions<ACMVirtualMachineAction>(isACMVirtualMachineAction);
@@ -36,7 +38,7 @@ const useACMExtensionActions = (vm): ActionDropdownItemType[] => {
       const crossClusterMigration = draft.find(
         (action) => action.properties.id === CROSS_CLUSTER_MIGRATION_ACTION_ID,
       );
-      if (providerLoaded && isEmpty(provider)) {
+      if (!providerLoaded || !isEmpty(providerError) || isEmpty(provider)) {
         crossClusterMigration.properties.isDisabled = true;
         crossClusterMigration.properties.description = t(
           'Cross-cluster migration is not supported on this cluster.',
@@ -58,6 +60,7 @@ const useACMExtensionActions = (vm): ActionDropdownItemType[] => {
     hubClusterName,
     providerLoaded,
     provider,
+    providerError,
     t,
   ]);
 };

--- a/src/multicluster/hooks/useACMExtensionActions/utils.tsx
+++ b/src/multicluster/hooks/useACMExtensionActions/utils.tsx
@@ -1,11 +1,25 @@
 /* eslint-disable */
-import React, { ComponentType } from 'react';
+import React, { type ComponentType } from 'react';
 
-import { ACMVirtualMachineAction } from '@kubevirt-extensions/acm.virtualmachine';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
-import { ModalComponent } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
-import { ResolvedExtension } from '@openshift-console/dynamic-plugin-sdk/lib/types';
+import { PlanModel } from '@forklift-ui/types';
+import { type ACMVirtualMachineAction } from '@kubevirt-extensions/acm.virtualmachine';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
+import { type ModalComponent } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import { MTV_MIGRATION_NAMESPACE } from '@multicluster/components/CrossClusterMigration/constants';
+import { CROSS_CLUSTER_MIGRATION_ACTION_ID } from '@multicluster/constants';
+import { type ResolvedExtension } from '@openshift-console/dynamic-plugin-sdk/lib/types';
+
+const resolveActionDisabled = (
+  isDisabled: ResolvedExtension<ACMVirtualMachineAction>['properties']['isDisabled'],
+  resource: V1VirtualMachine,
+): boolean => {
+  if (typeof isDisabled === 'function') {
+    return isDisabled(resource);
+  }
+
+  return Boolean(isDisabled);
+};
 
 export function buildACMVirtualMachineActionsFromExtensions(
   virtualMachine: V1VirtualMachine,
@@ -16,24 +30,36 @@ export function buildACMVirtualMachineActionsFromExtensions(
   if (!actionExtensions?.length) return [];
 
   return actionExtensions.map<ActionDropdownItemType>((action) => {
-    const ModalComp = action.properties.component as ComponentType<any>;
+    const ModalComp = action.properties.component as ComponentType<{
+      close: () => void;
+      cluster: string;
+      isOpen: boolean;
+      resource: V1VirtualMachine;
+    }>;
 
     return {
+      ...(action.properties.id === CROSS_CLUSTER_MIGRATION_ACTION_ID && {
+        accessReview: {
+          cluster: virtualMachine?.cluster ?? hubClusterName,
+          group: PlanModel.apiGroup,
+          namespace: MTV_MIGRATION_NAMESPACE,
+          resource: PlanModel.plural,
+          verb: 'create',
+        },
+      }),
       cta: () =>
         createModal(({ isOpen, onClose }) => (
           <ModalComp
             close={onClose}
-            cluster={virtualMachine?.cluster || hubClusterName}
+            cluster={virtualMachine?.cluster ?? hubClusterName}
             isOpen={isOpen}
             resource={virtualMachine}
           />
         )),
       description: action.properties.description,
-      disabled:
-        typeof action.properties.isDisabled === 'function'
-          ? action.properties.isDisabled(virtualMachine)
-          : action.properties.isDisabled,
+      disabled: resolveActionDisabled(action.properties.isDisabled, virtualMachine),
       id: action.properties.id,
+
       label: action.properties.title as ACMVirtualMachineAction['properties']['title'],
     };
   });

--- a/src/views/virtualmachines/actions/bulkMigrationActionConfigs.tsx
+++ b/src/views/virtualmachines/actions/bulkMigrationActionConfigs.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { type TFunction } from 'i18next';
 
+import { PlanModel } from '@forklift-ui/types';
 import { VirtualMachineInstanceMigrationModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { type ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
@@ -13,6 +14,7 @@ import {
 } from '@kubevirt-utils/resources/migrations/constants';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getNoPermissionTooltipContent, isEmpty } from '@kubevirt-utils/utils/utils';
+import { MTV_MIGRATION_NAMESPACE } from '@multicluster/components/CrossClusterMigration/constants';
 import CrossClusterMigration from '@multicluster/components/CrossClusterMigration/CrossClusterMigration';
 import { CROSS_CLUSTER_MIGRATION_ACTION_ID } from '@multicluster/constants';
 import { getCluster } from '@multicluster/helpers/selectors';
@@ -29,19 +31,34 @@ export const createCrossClusterMigrationConfig =
   (
     vms: V1VirtualMachine[],
     createModal: (modal: ModalComponent) => void,
-    isDisabled: boolean,
+    isClusterUnsupported: boolean,
   ): ActionDropdownItemType => {
     const allRunning = vms?.every(isRunning);
 
+    const getDisabledTooltip = (): string | undefined => {
+      if (!allRunning) {
+        return t('All VirtualMachines must be running');
+      }
+      if (isClusterUnsupported) {
+        return t('Cross-cluster migration is not supported on this cluster.');
+      }
+      return undefined;
+    };
+
     return {
+      accessReview: {
+        cluster: getCluster(vms?.[0]),
+        group: PlanModel.apiGroup,
+        namespace: MTV_MIGRATION_NAMESPACE,
+        resource: PlanModel.plural,
+        verb: 'create',
+      },
       cta: () =>
         createModal(({ isOpen, onClose }) => (
           <CrossClusterMigration close={onClose} isOpen={isOpen} resources={vms} />
         )),
-      disabled: isEmpty(vms) || isDisabled || !allRunning,
-      disabledTooltip: !allRunning
-        ? t('All VirtualMachines must be running')
-        : t('Cross-cluster migration is not supported on this cluster.'),
+      disabled: isEmpty(vms) || isClusterUnsupported || !allRunning,
+      disabledTooltip: getDisabledTooltip(),
       id: CROSS_CLUSTER_MIGRATION_ACTION_ID,
       label: t('Cross-cluster migration'),
     };

--- a/src/views/virtualmachines/actions/hooks/useMultipleVirtualMachineActions.tsx
+++ b/src/views/virtualmachines/actions/hooks/useMultipleVirtualMachineActions.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { CONFIRM_VM_ACTIONS, TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
@@ -13,12 +13,12 @@ import { getCluster } from '@multicluster/helpers/selectors';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { useHubClusterName } from '@stolostron/multicluster-sdk';
 import { isPaused, isRunning, isStopped } from '@virtualmachines/utils';
-import { getVMIMFromMapper, VMIMMapper } from '@virtualmachines/utils/mappers';
+import { getVMIMFromMapper, type VMIMMapper } from '@virtualmachines/utils/mappers';
 
 import { createBulkVirtualMachineActionFactory } from '../BulkVirtualMachineActionFactory';
 
-import useClusterStorageMigrationAPI from './storageMigrationApi/useClusterStorageMigrationAPI';
 import { BULK_ACTIONS_ID } from './constants';
+import useClusterStorageMigrationAPI from './storageMigrationApi/useClusterStorageMigrationAPI';
 import useIsMTVInstalled from './useIsMTVInstalled';
 import useVirtualMachineActionsProvider from './useVirtualMachineActionsProvider';
 import { someVMIsMigrating } from './utils';
@@ -43,7 +43,9 @@ const useMultipleVirtualMachineActions: UseMultipleVirtualMachineActions = (
   const clusterParam = useClusterParam();
   const effectiveCluster = getCluster(vms?.[0]) ?? clusterParam ?? undefined;
 
-  const [provider, providerLoaded] = useProviderByClusterName(effectiveCluster ?? hubClusterName);
+  const [provider, providerLoaded, providerError] = useProviderByClusterName(
+    effectiveCluster ?? hubClusterName,
+  );
 
   const storageMigAPI = useClusterStorageMigrationAPI(effectiveCluster);
 
@@ -86,7 +88,7 @@ const useMultipleVirtualMachineActions: UseMultipleVirtualMachineActions = (
         BulkVirtualMachineActionFactory.crossClusterMigration(
           vms,
           createModal,
-          providerLoaded && isEmpty(provider),
+          !providerLoaded || !isEmpty(providerError) || isEmpty(provider),
         ),
       );
     }
@@ -132,6 +134,7 @@ const useMultipleVirtualMachineActions: UseMultipleVirtualMachineActions = (
     isTreeViewMenu,
     mtvInstalled,
     provider,
+    providerError,
     providerLoaded,
     storageMigAPI,
     t,

--- a/src/views/virtualmachines/actions/types.ts
+++ b/src/views/virtualmachines/actions/types.ts
@@ -1,6 +1,6 @@
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
-import { ModalComponent } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
+import { type ModalComponent } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import type { StorageMigrationAPI } from '@kubevirt-utils/resources/migrations/constants';
 
 export type BulkVirtualMachineActionFactory = {
@@ -8,7 +8,7 @@ export type BulkVirtualMachineActionFactory = {
   crossClusterMigration: (
     vms: V1VirtualMachine[],
     createModal: (modal: ModalComponent) => void,
-    isDisabled: boolean,
+    isClusterUnsupported: boolean,
   ) => ActionDropdownItemType;
   delete: (
     vms: V1VirtualMachine[],


### PR DESCRIPTION
## 📝 Description

Fixes cross-cluster migration staying enabled for non-privileged users on non-ACM clusters when opening the action from the VM tree project context menu.

The bulk/tree-view menu previously only disabled the action when `providerLoaded && isEmpty(provider)`. When the MTV provider watch fails or never loads (e.g. Forbidden), the action stayed enabled and opened a modal that errors.

This PR:
- Disables cross-cluster migration when provider data is unavailable, errored, or empty
- Adds MTV `Plan` create `accessReview` so non-privileged users get the standard permission tooltip
- Shows context-specific disabled tooltips (not running, unsupported cluster, no permission)

## 🔗 Links

Jira: https://issues.redhat.com/browse/CNV-96509

## 🎥 Demo

Before:
- Non-privileged user on non-ACM cluster: Cross-cluster migration enabled, modal errors on click
- Admin on same cluster: action disabled with "not supported" tooltip

https://github.com/user-attachments/assets/0839c6ec-99f2-4fe6-afa6-02e7175e1f55



After:
- Non-privileged user matches admin behavior: action disabled with appropriate tooltip

<img width="967" height="886" alt="Screenshot 2026-09-08 at 18 17 01" src="https://github.com/user-attachments/assets/23211673-a23e-4b28-93a7-b742cacce0a3" />


## Test plan

- [ ] On a non-ACM cluster, log in as a non-privileged user without MTV provider list permissions
- [ ] Open VirtualMachines list tree view, right-click a project with running VMs
- [ ] Verify Migration → Cross-cluster migration is disabled with tooltip
- [ ] Repeat as admin and confirm same disabled state/tooltip
- [ ] On a supported ACM cluster with MTV provider, verify cross-cluster migration remains enabled for users with Plan create permission

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cross-cluster migration availability handling while provider information is loading, unavailable, or fails to load.
  - Migration actions are now correctly disabled for unsupported clusters, insufficient permissions, and virtual machines that are not running.
  - Added clearer guidance explaining why migration cannot be started.
  - Improved provider-error handling so migration options remain consistent and predictable.
  - Added access checks for migration namespaces, plans, clusters, and plan creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->