### PR TITLE
CNV-96923: disable auto hiding the sidebar

### DIFF
--- a/playwright/project-dependencies/rule-engine/setup-rules.ts
+++ b/playwright/project-dependencies/rule-engine/setup-rules.ts
@@ -457,7 +457,7 @@ export function getSetupRules(): SetupRule[] {
           const patchData: Record<string, string> = {};
           for (const key of keysToUpdate) {
             patchData[key] = JSON.stringify({
-              navigation: { autoHideNav: true },
+              navigation: { autoHideNav: false },
               quickStart: { dontShowWelcomeModal: true, activeQuickStartID: '' },
               guidedTour: false,
               onboardingPopoversHidden: {


### PR DESCRIPTION
## 📝 Description

Playwright E2E tests were flaky when relying on sidebar clicks for navigation. This PR switches the default navigation path across page objects to direct URLs, which is faster and more reliable.

set autohiding sidebar setting to false 

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-96923


## Test plan

- [x] `npm run check-types` passes
- [ ] Run affected Playwright scenario/gating tests locally or in CI
- [ ] Verify sidebar-specific navigation tests still pass (`recommended-capabilities-navigation`, `welcome-modal`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Virtualization user settings now keep navigation visible instead of automatically hiding it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->