### PR TITLE
CNV-96400: show snapshot load errors instead of infinite loading

### DIFF
--- a/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceSnapshotVolumeSelect/DiskSourceSnapshotVolumeSelectName.tsx
+++ b/src/utils/components/DiskModal/components/DiskSourceSelect/components/DiskSourceSnapshotVolumeSelect/DiskSourceSnapshotVolumeSelectName.tsx
@@ -1,11 +1,12 @@
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import {
   modelToGroupVersionKind,
   VolumeSnapshotModel,
 } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1DiskFormState } from '@kubevirt-utils/components/DiskModal/utils/types';
+import { type V1DiskFormState } from '@kubevirt-utils/components/DiskModal/utils/types';
+import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
@@ -37,9 +38,11 @@ const DiskSourceSnapshotVolumeSelectName: FC = () => {
   const vmCluster = watch(VM_CLUSTER_FIELD);
   const namespace = watch(DATAVOLUME_SNAPSHOT_NAMESPACE);
 
-  const { snapshots, snapshotsLoaded } = useSnapshots(namespace, vmCluster);
+  const { error: loadError, snapshots, snapshotsLoaded } = useSnapshots(namespace, vmCluster);
 
   const snapshotNames = useMemo(() => snapshots?.map(getName), [snapshots]);
+
+  if (loadError) return <ErrorAlert error={loadError} />;
 
   if (!snapshotsLoaded) return <Loading />;
 

--- a/src/utils/components/SelectSnapshot/SelectSnapshot.tsx
+++ b/src/utils/components/SelectSnapshot/SelectSnapshot.tsx
@@ -11,6 +11,7 @@ import { getName } from '@kubevirt-utils/resources/shared';
 import { Content, FormGroup } from '@patternfly/react-core';
 
 import { initialBootableVolumeState } from '../AddBootableVolumeModal/consts';
+import ErrorAlert from '../ErrorAlert/ErrorAlert';
 import InlineFilterSelect from '../FilterSelect/InlineFilterSelect';
 import Loading from '../Loading/Loading';
 
@@ -36,10 +37,8 @@ const SelectSnapshot: FC<SelectSnapshotProps> = ({
   snapshotNamespaceSelected,
 }) => {
   const { t } = useKubevirtTranslation();
-  const { projectsLoaded, projectsWithSnapshots, snapshots, snapshotsLoaded } = useSnapshots(
-    snapshotNamespaceSelected,
-    cluster,
-  );
+  const { error, projectsLoaded, projectsWithSnapshots, snapshots, snapshotsLoaded } =
+    useSnapshots(snapshotNamespaceSelected, cluster);
 
   const onSelectProject = useCallback(
     (newProject) => {
@@ -66,6 +65,14 @@ const SelectSnapshot: FC<SelectSnapshotProps> = ({
     () => snapshots?.map((snapshot) => getName(snapshot))?.sort((a, b) => a?.localeCompare(b)),
     [snapshots],
   );
+
+  if (error) {
+    return (
+      <div>
+        <ErrorAlert error={error} />
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/src/utils/components/SelectSnapshot/useSnapshots.ts
+++ b/src/utils/components/SelectSnapshot/useSnapshots.ts
@@ -16,7 +16,7 @@ type ProjectSnapshotCount = {
 };
 
 type UseSnapshotsReturnType = {
-  error: Error;
+  error?: Error;
   projectsLoaded: boolean;
   projectsWithSnapshots: ProjectSnapshotCount[];
   snapshots: VolumeSnapshotKind[];
@@ -59,12 +59,14 @@ const useSnapshots = (projectSelected: string, cluster?: string): UseSnapshotsRe
     [allSnapshots, projectSelected],
   );
 
+  const loaded = allSnapshotsLoaded || !!allSnapshotsErrors;
+
   return {
     error: allSnapshotsErrors,
-    projectsLoaded: allSnapshotsLoaded,
+    projectsLoaded: loaded,
     projectsWithSnapshots,
     snapshots,
-    snapshotsLoaded: allSnapshotsLoaded,
+    snapshotsLoaded: loaded,
   };
 };
 


### PR DESCRIPTION
## 📝 Description

When VolumeSnapshot listing fails (e.g. missing RBAC for non-privileged users), the Add volume and Add disk snapshot pickers stayed on a loading spinner indefinitely.

This PR treats failed snapshot watches as loaded and shows an inline `ErrorAlert` with the API error message instead.

## 🔗 Links

Jira: https://redhat.atlassian.net/browse/CNV-96400

## 🎥 Demo

Before: Infinite loading when the user cannot list VolumeSnapshots.

<img width="665" height="945" alt="Screenshot at Sep 02 13-18-14 (1)" src="https://github.com/user-attachments/assets/355c94f5-b824-41e2-aa8e-0c548732b52c" />

After: Inline error alert with the API failure message.

<img width="722" height="988" alt="Screenshot 2026-09-08 at 22 57 29" src="https://github.com/user-attachments/assets/1fc04741-3bf1-4713-9117-6dd489de97af" />

## Test plan

- [x] `npm run check-types` passes
- [ ] Open **Add volume** → **Snapshot** as a user without `volumesnapshots` list permission — verify error alert appears
- [ ] Open **Add disk** → **Snapshot** source — verify same error handling
- [ ] As a user with snapshot access — verify project/name dropdowns still load normally

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added clear error alerts when snapshot data cannot be loaded.
  - Prevented snapshot selection interfaces from remaining in a loading state after an error occurs.
  - Improved error handling across snapshot selection workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->