### PR TITLE
CNV-96419: keep YAML create page when switching project

### DIFF
--- a/src/views/templates/extensions.ts
+++ b/src/views/templates/extensions.ts
@@ -1,4 +1,8 @@
-import type { ResourceDetailsPage, ResourceListPage } from '@openshift-console/dynamic-plugin-sdk';
+import type {
+  ResourceDetailsPage,
+  ResourceListPage,
+  RoutePage,
+} from '@openshift-console/dynamic-plugin-sdk';
 import type {
   ConsolePluginBuildMetadata,
   EncodedExtension,
@@ -6,10 +10,18 @@ import type {
 
 export const exposedModules: ConsolePluginBuildMetadata['exposedModules'] = {
   TemplateNavPage: './views/templates/details/TemplateNavPage.tsx',
+  TemplateYAMLCreatePage: './views/templates/list/components/TemplateYAMLCreatePage.tsx',
   VirtualMachineTemplatesList: './views/templates/list/VirtualMachineTemplatesList.tsx',
 };
 
 export const extensions: EncodedExtension[] = [
+  {
+    properties: {
+      component: { $codeRef: 'TemplateYAMLCreatePage' },
+      path: ['/k8s/ns/:ns/templates/~new'],
+    },
+    type: 'console.page/route',
+  } as EncodedExtension<RoutePage>,
   {
     properties: {
       component: { $codeRef: 'VirtualMachineTemplatesList' },

--- a/src/views/templates/list/components/TemplateYAMLCreatePage.tsx
+++ b/src/views/templates/list/components/TemplateYAMLCreatePage.tsx
@@ -1,0 +1,62 @@
+/* eslint-disable */
+import React, { FC, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { load } from 'js-yaml';
+
+import { TemplateModel, type V1Template } from '@kubevirt-ui-ext/kubevirt-api/console';
+import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
+import {
+  TELEMETRY_RESOURCE_CREATION_METHOD,
+  TELEMETRY_RESOURCE_TYPE,
+} from '@kubevirt-utils/extensions/telemetry/utils/property-constants';
+import { logResourceCreated } from '@kubevirt-utils/extensions/telemetry/yaml-vs-ui';
+import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { getName } from '@kubevirt-utils/resources/shared';
+import { getTemplateURL } from '@kubevirt-utils/resources/template';
+import { getCluster } from '@multicluster/helpers/selectors';
+import { kubevirtK8sCreate } from '@multicluster/k8sRequests';
+import { ResourceYAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
+
+import { defaultVMTemplateYamlTemplate } from '../../../../templates';
+
+const TemplateYAMLCreatePage: FC = () => {
+  const { t } = useKubevirtTranslation();
+  const navigate = useNavigate();
+  const { cluster, ns: namespace } = useParams<{ cluster?: string; ns: string }>();
+  const [error, setError] = useState<Error | null>(null);
+  const initialResource = useMemo(() => load(defaultVMTemplateYamlTemplate) as V1Template, []);
+
+  const onSave = async (yaml: string) => {
+    setError(null);
+    try {
+      const template = load(yaml) as V1Template;
+      const createdTemplate = await kubevirtK8sCreate({
+        cluster,
+        data: template,
+        model: TemplateModel,
+        ns: namespace,
+      });
+
+      logResourceCreated(TELEMETRY_RESOURCE_TYPE.TEMPLATE, TELEMETRY_RESOURCE_CREATION_METHOD.YAML);
+
+      const templateCluster = getCluster(createdTemplate) || cluster;
+      navigate(getTemplateURL(getName(createdTemplate), namespace, templateCluster));
+    } catch (apiError) {
+      setError(apiError as Error);
+    }
+  };
+
+  return (
+    <>
+      <ResourceYAMLEditor
+        create
+        header={t('Create Template')}
+        initialResource={initialResource}
+        onSave={onSave}
+      />
+      {error && <ErrorAlert error={error} />}
+    </>
+  );
+};
+
+export default TemplateYAMLCreatePage;

--- a/src/views/virtualmachines/extensions.ts
+++ b/src/views/virtualmachines/extensions.ts
@@ -15,6 +15,8 @@ export const exposedModules: ConsolePluginBuildMetadata['exposedModules'] = {
   NodeInventoryItem: './views/virtualmachines/node/inventoryitem/NodeInventoryItem.tsx',
   NodeVirtualMachineList: './views/virtualmachines/node/list/NodeVirtualMachinesList.tsx',
   useServiceActionsProvider: './utils/components/ServicesList/useServiceActionsProvider.ts',
+  VirtualMachineYAMLCreatePage:
+    './views/virtualmachines/navigator/VirtualMachineYAMLCreatePage.tsx',
 };
 
 export const extensions: EncodedExtension[] = [
@@ -43,6 +45,14 @@ export const extensions: EncodedExtension[] = [
     },
     type: 'console.action/resource-provider',
   } as EncodedExtension<ResourceActionProvider>,
+
+  {
+    properties: {
+      component: { $codeRef: 'VirtualMachineYAMLCreatePage' },
+      path: ['/k8s/ns/:ns/kubevirt.io~v1~VirtualMachine/~new'],
+    },
+    type: 'console.page/route',
+  } as EncodedExtension<RoutePage>,
 
   {
     properties: {

--- a/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
+++ b/src/views/virtualmachines/navigator/VirtualMachineNavigator.tsx
@@ -24,7 +24,6 @@ import useAutoHideNavigation from '../hooks/useAutoHideNavigation/useAutoHideNav
 import OverviewTab from '../list/components/OverviewTab/OverviewTab';
 import { OVERVIEW_TAB_INDEX, VM_LIST_TAB_INDEX } from './constants';
 import useNavigatorTabs from './useNavigatorTabs';
-import VirtualMachineYAMLCreatePage from './VirtualMachineYAMLCreatePage';
 
 import './VirtualMachineNavigator.scss';
 
@@ -55,10 +54,6 @@ const VirtualMachineNavigator: FC = () => {
   const isNavCollapsed = useAutoHideNavigation();
 
   const treeProps = useTreeViewData();
-
-  if (location.pathname.endsWith(`${VirtualMachineModelRef}/~new`)) {
-    return <VirtualMachineYAMLCreatePage />;
-  }
 
   return (
     <>


### PR DESCRIPTION
## Summary
- Register dedicated `~new` routes for VM and template YAML creation on single-cluster
- Prevents the console project dropdown from dropping `~new` and landing on the VM list Overview tab
- Fleet/multicluster was already covered via existing `MulticlusterYAMLCreation` routes

## Test plan
- [ ] Create VM with YAML → switch project via console dropdown → stays on YAML create page
- [ ] Create template with YAML → switch project → stays on YAML create page
- [ ] Save still creates resource in the selected project
- [ ] Fleet VM/template YAML create unchanged

Jira: https://issues.redhat.com/browse/CNV-96419

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a YAML-based workflow for creating namespace-scoped Kubernetes templates.
  - Added a dedicated route for creating new virtual machines through the YAML creation page.
  - Creation workflows now validate submitted YAML, display errors, and navigate to the newly created resource when successful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->