### PR TITLE
CNV-96423: allow SSH service config when VM is stopped

### DIFF
--- a/src/utils/components/SSHAccess/components/SSHCommand.tsx
+++ b/src/utils/components/SSHAccess/components/SSHCommand.tsx
@@ -20,6 +20,7 @@ import {
   Stack,
   StackItem,
 } from '@patternfly/react-core';
+import { isRunning } from '@virtualmachines/utils';
 
 import { SERVICE_TYPES } from '../constants';
 import useSSHCommand, { isLoadBalancerBonded } from '../useSSHCommand';
@@ -52,7 +53,7 @@ const SSHCommand: FC<SSHCommandProps> = ({
     loaded: vmiAndPodsLoaded,
     pod,
     vmi,
-  } = useVMIAndPodForVM(getName(vm), getNamespace(vm), getCluster(vm));
+  } = useVMIAndPodForVM(getName(vm), getNamespace(vm), getCluster(vm), isRunning(vm));
   const loadError = sshServiceError ?? vmiAndPodsError;
 
   const onSSHChange = async (newServiceType: SERVICE_TYPES): Promise<void> => {

--- a/src/utils/components/SSHAccess/useSSHService.tsx
+++ b/src/utils/components/SSHAccess/useSSHService.tsx
@@ -6,6 +6,7 @@ import { useVMIAndPodForVM } from '@kubevirt-utils/resources/vm';
 import { getServicesForVmi } from '@kubevirt-utils/resources/vmi';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import { isRunning } from '@virtualmachines/utils';
 
 import { SSH_PORT } from './constants';
 
@@ -28,9 +29,10 @@ const useSSHService = (vm: V1VirtualMachine): UseSSHServiceReturnType => {
   );
 
   const { pod, vmi } = useVMIAndPodForVM(
-    vm ? getName(vm) : '',
-    vm ? getNamespace(vm) : '',
-    vm ? getCluster(vm) : undefined,
+    getName(vm),
+    getNamespace(vm),
+    getCluster(vm),
+    isRunning(vm),
   );
 
   if (!vm) return [undefined, false, undefined];

--- a/src/utils/resources/vm/hooks/useVMIAndPodForVM.ts
+++ b/src/utils/resources/vm/hooks/useVMIAndPodForVM.ts
@@ -17,8 +17,9 @@ export const useVMIAndPodForVM = (
   vmName: string,
   vmNamespace: string,
   vmCluster?: string,
+  fetchVMI = true,
 ): UseVMIAndPodForVMValues => {
-  const { vmi, vmiLoaded, vmiLoadError } = useVMI(vmName, vmNamespace, vmCluster);
+  const { vmi, vmiLoaded, vmiLoadError } = useVMI(vmName, vmNamespace, vmCluster, fetchVMI);
 
   const [pods, podsLoaded, podsLoadError] = useK8sWatchData<K8sResourceCommon[]>({
     cluster: vmCluster,


### PR DESCRIPTION
## Summary
- Skip the VMI watch in SSH settings when the VM is not running, avoiding a spurious 404 on stopped VMs
- Running VMs still fetch the VMI and show an error if it is missing
- Matches the existing Configuration tab pattern (`useVMI(..., isRunning(vm))`)

## Links

Jira: https://issues.redhat.com/browse/CNV-96423

**BEFORE**

<img width="1151" height="763" alt="Screenshot 2026-09-08 at 23 48 28" src="https://github.com/user-attachments/assets/7777865b-359b-433e-a0f3-36f19fe4b8bd" />


**AFTER**

<img width="1168" height="687" alt="Screenshot 2026-09-08 at 23 48 54" src="https://github.com/user-attachments/assets/cd268e77-d8b0-4f2f-921c-8317e02e9219" />


## Test plan
- [ ] Open a **stopped** VM → Configuration → SSH → SSH service type selector loads without "404: Not Found"
- [ ] Configure SSH service type on a stopped VM (None / LoadBalancer / NodePort)
- [ ] Open a **running** VM → Configuration → SSH → SSH service type works as before
- [ ] Start/stop VM and verify SSH tab updates correctly


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SSH access handling for virtual machines based on their current running state.
  - Prevented unnecessary virtual machine instance retrieval when a virtual machine is not running.
  - Preserved connection details consistently while resolving SSH access information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->