### PR TITLE
CNV-96788: hide Windows OS filter on s390x clusters

### DIFF
--- a/src/views/templates/list/filters/useOSFilter.ts
+++ b/src/views/templates/list/filters/useOSFilter.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
-import { KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
+import useIsWindowsSupportedArchitecture from '@kubevirt-utils/hooks/useIsWindowsSupportedArchitecture';
+import { type KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   getTemplateOS,
@@ -22,15 +23,18 @@ const getRowOS = (obj: TemplateOrRequest): string => {
 
 const useOSFilter = (): KubevirtFilter<TemplateOrRequest> => {
   const { t } = useKubevirtTranslation();
+  const isWindowsSupported = useIsWindowsSupportedArchitecture();
 
   return useMemo(
     () => ({
       categoryLabel: t('Operating system'),
       id: TemplateFilterType.OSName,
       match: (obj, selected) => selected.includes(getRowOS(obj)),
-      options: OS_NAMES.map(({ id, title }) => ({ label: title, value: id })),
+      options: OS_NAMES.filter(({ id }) => isWindowsSupported || id !== OS_NAME_TYPES.windows).map(
+        ({ id, title }) => ({ label: title, value: id }),
+      ),
     }),
-    [t],
+    [isWindowsSupported, t],
   );
 };
 

--- a/src/views/virtualmachines/list/filters/getOSFilter.ts
+++ b/src/views/virtualmachines/list/filters/getOSFilter.ts
@@ -24,15 +24,20 @@ export const getOSName = (obj: V1VirtualMachine) => {
   return matchOSName(osAnnotation, osLabel, osPreference);
 };
 
-export const getOSFilter = (t: TFunction): KubevirtFilter<V1VirtualMachine> => ({
+export const getOSFilter = (
+  t: TFunction,
+  isWindowsSupported = true,
+): KubevirtFilter<V1VirtualMachine> => ({
   categoryLabel: t('Operating system'),
   categoryLabelShort: t('OS'),
   filterLayout: KubevirtFilterLayout.SELECT,
   id: VirtualMachineRowFilterType.OS,
   match: (obj, selected) => selected.includes(getOSName(obj)),
-  options: Object.values(OS_NAME_LABELS).map((osName) => ({
-    label: osName,
-    value: osName,
-  })),
+  options: Object.values(OS_NAME_LABELS)
+    .filter((osName) => isWindowsSupported || osName !== OS_NAME_LABELS.windows)
+    .map((osName) => ({
+      label: osName,
+      value: osName,
+    })),
   showAllBadge: true,
 });

--- a/src/views/virtualmachines/list/filters/tests/getOSFilter.test.ts
+++ b/src/views/virtualmachines/list/filters/tests/getOSFilter.test.ts
@@ -281,6 +281,14 @@ describe('VM OS Filter', () => {
         expect(optionValues).toContain(os);
       }
     });
+
+    it('should exclude Windows when Windows is not supported', () => {
+      const optionValues = getOSFilter(t as TFunction, false).options?.map(
+        (option) => option.value,
+      );
+
+      expect(optionValues).not.toContain(OS_NAME_LABELS.windows);
+    });
   });
 
   describe('priority of OS detection methods', () => {

--- a/src/views/virtualmachines/list/hooks/useVMListFilters.ts
+++ b/src/views/virtualmachines/list/hooks/useVMListFilters.ts
@@ -1,16 +1,18 @@
 import { useMemo } from 'react';
 
 import { VirtualMachineModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
+import useIsWindowsSupportedArchitecture from '@kubevirt-utils/hooks/useIsWindowsSupportedArchitecture';
 import useClusterFilter from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/filters/useClusterFilter';
 import useProjectFilter from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/filters/useProjectFilter';
-import { KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
+import { type KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useIsACMPage from '@multicluster/useIsACMPage';
+import useProjectsWithVMs from '@search/components/AdvancedSearchModal/hooks/useProjectsWithVMs';
 import { useAccessibleResources } from '@virtualmachines/search/hooks/useAccessibleResources';
-import { PVCMapper, VMIMapper } from '@virtualmachines/utils/mappers';
+import { type PVCMapper, type VMIMapper } from '@virtualmachines/utils/mappers';
 
 import { getCPUFilter } from '../filters/getCPUFilter';
 import { getDateCreatedFilter, getDateFromFilter, getDateToFilter } from '../filters/getDateFilter';
@@ -27,8 +29,6 @@ import { getStatusFilter } from '../filters/getStatusFilter';
 import useArchitectureFilter from '../filters/useArchitectureFilter';
 import useNodeFilter from '../filters/useNodeFilter';
 import useStorageClassFilter from '../filters/useStorageClassFilter';
-
-import useProjectsWithVMs from '@search/components/AdvancedSearchModal/hooks/useProjectsWithVMs';
 import { useInstanceTypeMapper } from './useInstanceTypeMapper';
 
 const useVMListFilters = (
@@ -37,6 +37,7 @@ const useVMListFilters = (
 ): KubevirtFilter<V1VirtualMachine>[] => {
   const { t } = useKubevirtTranslation();
   const isACMPage = useIsACMPage();
+  const isWindowsSupported = useIsWindowsSupportedArchitecture();
   const { featureEnabled: treeViewFoldersEnabled } = useFeatures(TREE_VIEW_FOLDERS);
 
   const { resources: vms } = useAccessibleResources<V1VirtualMachine>({
@@ -72,7 +73,7 @@ const useVMListFilters = (
         showAllBadge: true,
       },
       getStatusFilter(t),
-      getOSFilter(t),
+      getOSFilter(t, isWindowsSupported),
       storageClassFilter,
       getHWDevicesFilter(t),
       getSchedulingFilter(t),
@@ -93,6 +94,7 @@ const useVMListFilters = (
   }, [
     t,
     isACMPage,
+    isWindowsSupported,
     treeViewFoldersEnabled,
     clusterFilter,
     projectFilter,

--- a/src/views/virtualmachines/wizard/steps/CloneSourceStep/components/VirtualMachinesList/hooks/useCloneSourceVMFilters.ts
+++ b/src/views/virtualmachines/wizard/steps/CloneSourceStep/components/VirtualMachinesList/hooks/useCloneSourceVMFilters.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 
 import type { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import useIsWindowsSupportedArchitecture from '@kubevirt-utils/hooks/useIsWindowsSupportedArchitecture';
 import { type KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { toGrouped } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/utils';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -20,6 +21,7 @@ export const useCloneSourceVMFilters = (
   pvcMapper: PVCMapper,
 ): KubevirtFilter<V1VirtualMachine>[] => {
   const { t } = useKubevirtTranslation();
+  const isWindowsSupported = useIsWindowsSupportedArchitecture();
 
   const storageClassFilter = useStorageClassFilter(vms, pvcMapper);
   const nodeFilter = useNodeFilter(vmiMapper);
@@ -29,7 +31,7 @@ export const useCloneSourceVMFilters = (
     () =>
       [
         getStatusFilter(t),
-        getOSFilter(t),
+        getOSFilter(t, isWindowsSupported),
         storageClassFilter,
         getHWDevicesFilter(t),
         getSchedulingFilter(t),
@@ -37,6 +39,6 @@ export const useCloneSourceVMFilters = (
         getGuestAgentFilter(t),
         architectureFilter,
       ].map(toGrouped),
-    [t, storageClassFilter, nodeFilter, architectureFilter],
+    [t, isWindowsSupported, storageClassFilter, nodeFilter, architectureFilter],
   );
 };


### PR DESCRIPTION
## Summary
- Exclude Windows from the template operating system filter on clusters that do not support Windows workloads (e.g. s390x)
- Uses existing `useIsWindowsSupportedArchitecture()` hook, consistent with other Windows UI hiding on unsupported architectures

## Links

Jira: https://issues.redhat.com/browse/CNV-96788

## Test plan
- [ ] On an **s390x** cluster: open VM wizard → Create from template → Windows is not shown in the OS filter
- [ ] On **amd64/arm64** cluster: Windows still appears in the OS filter
- [ ] Templates list page OS filter behaves the same on both architectures



**BEFORE**

<img width="1397" height="904" alt="Screenshot 2026-09-08 at 23 55 23" src="https://github.com/user-attachments/assets/1b82f9c2-b9e3-4c08-92f4-efe493785f21" />


<img width="1218" height="799" alt="Screenshot 2026-09-09 at 09 22 14" src="https://github.com/user-attachments/assets/b0562fd4-327c-48cc-9536-550e09038014" />

**AFTER**

<img width="1385" height="881" alt="Screenshot 2026-09-08 at 23 56 05" src="https://github.com/user-attachments/assets/c24f0e2b-1773-496d-b1d3-7de94cb745fb" />

<img width="310" height="278" alt="Screenshot 2026-09-09 at 09 23 02" src="https://github.com/user-attachments/assets/e9216a92-91e2-4285-84ad-019d740eafc9" />


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Windows is now hidden from operating system filter options when it isn’t supported by the current system architecture.
  - This behavior is applied consistently to VM lists, VM templates, and clone-source selections.
  - Operating system filter options now refresh correctly when architecture support changes, helping prevent unsupported Windows options from appearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->