### PR TITLE
CNV-81017: Align Dockerfile base images to UBI10 for v5.99

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest AS policy
+FROM registry.access.redhat.com/ubi10/ubi:latest AS policy
 
 RUN update-crypto-policies --set DEFAULT:PQ
 # NOTE: Since the `:latest` tag can have npm version changes, we are using
 #       a specific version tag. Container build errors have come up when
 #       the `:latest` is updated.
 #
-# Image info: https://catalog.redhat.com/en/software/containers/ubi9/nodejs-22/66431d1785c5c3a31edd24f1
-FROM registry.access.redhat.com/ubi9/nodejs-22:1788246555 AS builder
+# Image info: https://catalog.redhat.com/en/software/containers/ubi10/nodejs-22/677d3d3e5fdd0fab2f7ad136
+FROM registry.access.redhat.com/ubi10/nodejs-22:10.2-1788329676 AS builder
 USER root
 
 COPY . /opt/app-root/src
@@ -17,8 +17,8 @@ RUN npm config set fetch-timeout 1200000 && \
     npm ci --ignore-scripts --no-audit && \
     npm run build
 
-# Image info: https://catalog.redhat.com/en/software/containers/ubi9/nginx-124/657b066b6c1bc124a1d7ff39
-FROM registry.access.redhat.com/ubi9/nginx-124:1788334099
+# Image info: https://catalog.redhat.com/en/software/containers/ubi10/nginx-126/677d3735607921b4d7503cf3
+FROM registry.access.redhat.com/ubi10/nginx-126:10.2-1787734528
 
 COPY --from=policy /etc/crypto-policies /etc/crypto-policies
 COPY --from=builder /opt/app-root/src/dist /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
+# RHEL 10 enables post-quantum algorithms in the DEFAULT policy; copy them into nginx.
 FROM registry.access.redhat.com/ubi10/ubi:latest AS policy
-
-RUN update-crypto-policies --set DEFAULT:PQ
 # NOTE: Since the `:latest` tag can have npm version changes, we are using
 #       a specific version tag. Container build errors have come up when
 #       the `:latest` is updated.


### PR DESCRIPTION
## Summary
- Rebase the production `Dockerfile` from UBI9 to UBI10 for the v5.99 Konflux builds
- Update builder image to `ubi10/nodejs-22:10.2-1788329676`
- Update runtime image to `ubi10/nginx-126:10.2-1787734528` (RHEL 10 App Stream equivalent of nginx-124)

## Jira
https://issues.redhat.com/browse/CNV-81017

## Test plan
- [ ] Konflux build passes with the updated base images
- [ ] Container starts and serves the plugin over HTTPS (port 9443)
- [ ] PQ crypto policies are applied from the policy stage


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the application’s container base images to UBI 10, Node.js 22, and NGINX 1.26.
  * Post-quantum cryptographic algorithms are now provided by default through the updated base image configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->