### PR TITLE
CNV-90382: add typescript-linters-part-2

### DIFF
--- a/src/multicluster/components/ACMExtentionsTableData.tsx
+++ b/src/multicluster/components/ACMExtentionsTableData.tsx
@@ -1,8 +1,6 @@
-/* eslint-disable */
-import { ComponentType, FC } from 'react';
-import React from 'react';
+import React, { type ComponentType, type FC, type ReactElement } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import useACMExtensionColumns from '@multicluster/hooks/useACMExtensionColumns/useACMExtensionColumns';
 import { TableData } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -11,15 +9,16 @@ type ACMExtentionsTableDataProps = {
   vm: V1VirtualMachine;
 };
 
-const ACMExtentionsTableData: FC<ACMExtentionsTableDataProps> = ({ activeColumnIDs, vm }) => {
+const ACMExtentionsTableData: FC<ACMExtentionsTableDataProps> = ({
+  activeColumnIDs,
+  vm,
+}): ReactElement => {
   const columnProperties = useACMExtensionColumns();
 
   return (
     <>
       {columnProperties.map((column) => {
-        const CellColumn = column.cell as ComponentType<{
-          resource?: any;
-        }>;
+        const CellColumn = column.cell as ComponentType<{ resource?: unknown }>;
 
         return (
           <TableData

--- a/src/multicluster/components/CrossClusterMigration/components/VersionCompatibility.tsx
+++ b/src/multicluster/components/CrossClusterMigration/components/VersionCompatibility.tsx
@@ -1,21 +1,22 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Divider, Split, SplitItem, Title } from '@patternfly/react-core';
 
 import './VersionCompatibility.scss';
 
-const VersionCompatibility = ({
-  sourceClusterVersion,
-  sourceKubevirtVersion,
-  targetClusterVersion,
-  targetKubevirtVersion,
-}: {
+type VersionCompatibilityProps = {
   sourceClusterVersion: string;
   sourceKubevirtVersion: string;
   targetClusterVersion: string;
   targetKubevirtVersion: string;
+};
+
+const VersionCompatibility: FC<VersionCompatibilityProps> = ({
+  sourceClusterVersion,
+  sourceKubevirtVersion,
+  targetClusterVersion,
+  targetKubevirtVersion,
 }) => {
   const { t } = useKubevirtTranslation();
   return (

--- a/src/multicluster/components/CrossClusterMigration/components/utils.ts
+++ b/src/multicluster/components/CrossClusterMigration/components/utils.ts
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
-import { LabelProps } from '@patternfly/react-core';
+import { type LabelProps } from '@patternfly/react-core';
 
 export const getScoreColor = (score: number): LabelProps['color'] => {
   if (score >= 70) return 'green';
@@ -9,8 +8,12 @@ export const getScoreColor = (score: number): LabelProps['color'] => {
   return 'red';
 };
 
-export const getSubtitleChecks = (t: TFunction, checks: boolean[], checksLoaded: boolean[]) => {
-  const subtitle = [];
+export const getSubtitleChecks = (
+  t: TFunction,
+  checks: boolean[],
+  checksLoaded: boolean[],
+): string => {
+  const subtitle: string[] = [];
 
   const errorChecksCount = checks.filter((check, index) => !check && checksLoaded[index]).length;
   const successChecksCount = checks.filter((check, index) => check && checksLoaded[index]).length;

--- a/src/multicluster/components/CrossClusterMigration/hooks/useAdvisorRouteURL.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useAdvisorRouteURL.ts
@@ -1,5 +1,21 @@
-/* eslint-disable */
-import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+
+type ConsolePluginResource = K8sResourceCommon & {
+  spec?: {
+    backend?: {
+      service?: {
+        namespace?: string;
+      };
+    };
+  };
+};
+
+type RouteResource = K8sResourceCommon & {
+  spec?: {
+    host?: string;
+  };
+};
 
 const ACM_CONSOLE_PLUGIN_NAME = 'acm';
 const MTV_ADVISOR_ROUTE_NAME = 'mtv-advisor-route';
@@ -18,15 +34,15 @@ const RouteGroupVersionKind = {
   version: 'v1',
 };
 
-const useAdvisorRouteURL = (): [null | string, boolean, Error] => {
-  const [acmPlugin, acmLoaded, acmError] = useK8sWatchResource({
+const useAdvisorRouteURL = (): [null | string, boolean, Error | undefined] => {
+  const [acmPlugin, acmLoaded, acmError] = useK8sWatchData<ConsolePluginResource>({
     groupVersionKind: ConsolePluginGroupVersionKind,
     name: ACM_CONSOLE_PLUGIN_NAME,
   });
 
-  const acmNamespace = (acmPlugin as any)?.spec?.backend?.service?.namespace;
+  const acmNamespace = acmPlugin?.spec?.backend?.service?.namespace;
 
-  const [route, routeLoaded, routeError] = useK8sWatchResource(
+  const [route, routeLoaded, routeError] = useK8sWatchData<RouteResource>(
     acmNamespace
       ? {
           groupVersionKind: RouteGroupVersionKind,
@@ -37,8 +53,8 @@ const useAdvisorRouteURL = (): [null | string, boolean, Error] => {
   );
 
   const loaded = acmLoaded && routeLoaded;
-  const error = acmError || routeError;
-  const isAvailable = loaded && !error && !!(route as any)?.spec?.host;
+  const error = acmError ?? routeError;
+  const isAvailable = loaded && !error && !!route?.spec?.host;
 
   return [isAvailable ? PROXY_KUBEVIRT_MTV_ADVISOR : null, loaded, error];
 };

--- a/src/multicluster/components/CrossClusterMigration/hooks/useClusterRecommendation.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useClusterRecommendation.ts
@@ -1,9 +1,8 @@
-/* eslint-disable */
 import { useMemo, useState } from 'react';
 
 import useConsoleFetch from '@kubevirt-utils/hooks/useConsoleFetch';
 
-import { MigrationTargetResponse } from './useClusterRecommendationTypes';
+import { type MigrationTargetResponse } from './useClusterRecommendationTypes';
 
 type VMQueryParams = {
   cluster: string;
@@ -41,7 +40,7 @@ const useClusterRecommendation = (
 
   const { data, error, loaded } = useConsoleFetch<MigrationTargetResponse>(triggered ? url : null);
 
-  const fetchRecommendation = () => setTriggered(true);
+  const fetchRecommendation = (): void => setTriggered(true);
 
   return { data: data ?? null, error, fetchRecommendation, loaded, loading: triggered && !loaded };
 };

--- a/src/multicluster/components/CrossClusterMigration/hooks/useClustersAndProjects.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useClustersAndProjects.ts
@@ -1,8 +1,7 @@
-/* eslint-disable */
 import { useCallback, useMemo } from 'react';
 
-import { V1beta1Provider } from '@forklift-ui/types';
-import { EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
+import { type V1beta1Provider } from '@forklift-ui/types';
+import { type EnhancedSelectOptionProps } from '@kubevirt-utils/components/FilterSelect/utils/types';
 import useProjects from '@kubevirt-utils/hooks/useProjects';
 import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-utils/models';
 import { getName } from '@kubevirt-utils/resources/shared';
@@ -18,27 +17,37 @@ type UseClustersAndProjects = (
   sourceCluster: string,
   selectedClusterTarget: string,
 ) => {
-  clustersError: any;
+  clustersError: Error | undefined;
   clustersLoaded: boolean;
   clustersOptions: EnhancedSelectOptionProps[];
-  getProviderFromClusterName: (clusterName: string) => V1beta1Provider;
+  getProviderFromClusterName: (clusterName: string) => V1beta1Provider | undefined;
   projectOptions: EnhancedSelectOptionProps[];
-  projectsError: any;
+  projectsError: Error | undefined;
   projectsLoaded: boolean;
   providers: V1beta1Provider[];
 };
 
 const useClustersAndProjects: UseClustersAndProjects = (sourceCluster, selectedClusterTarget) => {
-  const [clusterNames, clustersLoaded, clustersError] = useFleetClusterNames();
+  const [clusterNames, clustersLoaded, clustersError] = useFleetClusterNames() as [
+    string[],
+    boolean,
+    Error | undefined,
+  ];
   const [providers, providersLoaded, providersError] = useProviders();
 
-  const selectableClusters = useMemo(() => {
-    return clusterNames?.filter((clusterName) => clusterName !== sourceCluster);
-  }, [clusterNames, sourceCluster]);
+  const selectableClusters = useMemo(
+    () => clusterNames?.filter((clusterName) => clusterName !== sourceCluster),
+    [clusterNames, sourceCluster],
+  );
 
-  const enabledClusters = useMemo(() => {
-    return providers?.map((provider) => getClusterFromProvider(getName(provider)));
-  }, [providers]);
+  const enabledClusters = useMemo(
+    () =>
+      providers
+        ?.map((provider) => getName(provider))
+        .filter((name): name is string => !!name)
+        .map((name) => getClusterFromProvider(name)),
+    [providers],
+  );
 
   const clustersOptions = getSelectableOptions(
     selectableClusters,
@@ -50,14 +59,13 @@ const useClustersAndProjects: UseClustersAndProjects = (sourceCluster, selectedC
   const projectOptions = getSelectableOptions(projects, modelToGroupVersionKind(ProjectModel));
 
   const getProviderFromClusterName = useCallback(
-    (clusterName: string) => {
-      return getProviderByClusterName(clusterName, providers);
-    },
+    (clusterName: string): V1beta1Provider | undefined =>
+      getProviderByClusterName(clusterName, providers),
     [providers],
   );
 
   return {
-    clustersError: clustersError || providersError,
+    clustersError: (clustersError ?? providersError) as Error | undefined,
     clustersLoaded: clustersLoaded && providersLoaded,
     clustersOptions,
     getProviderFromClusterName,

--- a/src/multicluster/components/CrossClusterMigration/hooks/useComputeReadiness.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useComputeReadiness.ts
@@ -1,13 +1,23 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
-import { IoK8sApiCoreV1Node } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type IoK8sApiCoreV1Node } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { modelToGroupVersionKind, NodeModel } from '@kubevirt-utils/models';
 import { getArchitecture } from '@kubevirt-utils/resources/vm/utils/selectors';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
-const useComputeReadiness = (vms: V1VirtualMachine[], targetCluster: string) => {
+type UseComputeReadinessResult = {
+  error: Error;
+  isReady: boolean;
+  loaded: boolean;
+  nodesArchs: string[];
+  vmsArchs: string[];
+};
+
+const useComputeReadiness = (
+  vms: V1VirtualMachine[],
+  targetCluster: string,
+): UseComputeReadinessResult => {
   const vmsArchs = useMemo(() => Array.from(new Set(vms.map((vm) => getArchitecture(vm)))), [vms]);
 
   const [nodes, nodesLoaded, nodesError] = useK8sWatchData<IoK8sApiCoreV1Node[]>({
@@ -17,13 +27,21 @@ const useComputeReadiness = (vms: V1VirtualMachine[], targetCluster: string) => 
   });
 
   const nodesArchs = useMemo(
-    () => Array.from(new Set(nodes.map((node) => node.status?.nodeInfo?.architecture))),
+    () =>
+      Array.from(
+        new Set(
+          nodes
+            .map((node) => node.status?.nodeInfo?.architecture)
+            .filter((arch): arch is string => !!arch),
+        ),
+      ),
     [nodes],
   );
 
-  const isReady = useMemo(() => {
-    return vmsArchs.every((vmArch) => nodesArchs.includes(vmArch));
-  }, [vmsArchs, nodesArchs]);
+  const isReady = useMemo(
+    () => vmsArchs.every((vmArch) => nodesArchs.includes(vmArch)),
+    [vmsArchs, nodesArchs],
+  );
 
   return {
     error: nodesError,

--- a/src/multicluster/components/CrossClusterMigration/hooks/useCrossClusterMigrationSubmit.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useCrossClusterMigrationSubmit.ts
@@ -1,15 +1,14 @@
-/* eslint-disable */
 import { useCallback, useRef, useState } from 'react';
-import { Updater } from 'use-immer';
+import { type Updater } from 'use-immer';
 
 import {
   MigrationModel,
   NetworkMapModel,
   PlanModel,
   StorageMapModel,
-  V1beta1NetworkMap,
-  V1beta1Plan,
-  V1beta1StorageMap,
+  type V1beta1NetworkMap,
+  type V1beta1Plan,
+  type V1beta1StorageMap,
 } from '@forklift-ui/types';
 import { logMigrationPlanCreated } from '@kubevirt-utils/extensions/telemetry/mtv';
 import { getMtvSourceTelemetry } from '@kubevirt-utils/extensions/telemetry/utils/mtv-provider';
@@ -28,7 +27,12 @@ const useCrossClusterMigrationSubmit = (
   setMigrationPlan: Updater<V1beta1Plan>,
   storageMap: V1beta1StorageMap,
   networkMap: V1beta1NetworkMap,
-) => {
+): {
+  error: Error | null;
+  isSubmitting: boolean;
+  onSubmit: () => Promise<void>;
+  success: boolean;
+} => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -38,7 +42,7 @@ const useCrossClusterMigrationSubmit = (
   const isSubmittingRef = useRef(false);
   const [providers] = useProviders();
 
-  const onSubmit = useCallback(async () => {
+  const onSubmit = useCallback(async (): Promise<void> => {
     if (isSubmittingRef.current) return;
     isSubmittingRef.current = true;
 
@@ -136,9 +140,9 @@ const useCrossClusterMigrationSubmit = (
         vmCount: migrationPlan?.spec?.vms?.length,
       });
       setSuccess(true);
-    } catch (apiError) {
+    } catch (apiError: unknown) {
       cleanupPartialResources({ createdMigrationPlan, createdNetworkMap, createdStorageMap });
-      setError(apiError);
+      setError(apiError instanceof Error ? apiError : new Error(String(apiError)));
     } finally {
       setIsSubmitting(false);
       isSubmittingRef.current = false;

--- a/src/multicluster/components/CrossClusterMigration/hooks/useNetworkReadiness.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useNetworkReadiness.ts
@@ -1,11 +1,12 @@
-/* eslint-disable */
 import { useCallback, useEffect, useMemo } from 'react';
-import { Updater } from 'use-immer';
+import { type Updater } from 'use-immer';
 
-import { V1beta1NetworkMap, V1beta1NetworkMapSpecMapDestination } from '@forklift-ui/types';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
-import { getNamespace } from '@kubevirt-utils/resources/shared';
+import {
+  type V1beta1NetworkMap,
+  type V1beta1NetworkMapSpecMapDestination,
+} from '@forklift-ui/types';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
 import { POD_NETWORK_TYPE } from '../constants';
@@ -18,7 +19,7 @@ export type UseNetworkReadinessReturnType = {
     vmNetworkName: string,
     destinationNetwork: V1beta1NetworkMapSpecMapDestination,
   ) => void;
-  error: any;
+  error: Error | undefined;
   isReady: boolean;
   loaded: boolean;
   networkMap: V1beta1NetworkMap;
@@ -28,10 +29,11 @@ export type UseNetworkReadinessReturnType = {
 const useNetworkReadiness = (
   vms: V1VirtualMachine[],
   targetCluster: string,
-  networkMap: V1beta1NetworkMap,
-  setNetworkMap: Updater<V1beta1NetworkMap>,
+  networkMap: V1beta1NetworkMap | null,
+  setNetworkMap: Updater<V1beta1NetworkMap | null>,
 ): UseNetworkReadinessReturnType => {
-  const { data, error, loaded } = useProviderNADs(targetCluster, getNamespace(vms?.[0]));
+  const namespace = vms?.[0]?.metadata?.namespace ?? '';
+  const { data, error, loaded } = useProviderNADs(targetCluster, namespace);
 
   useEffect(() => {
     if (loaded && networkMap === null) {
@@ -45,16 +47,20 @@ const useNetworkReadiness = (
         (map) =>
           map.source.type === POD_NETWORK_TYPE ||
           (!isEmpty(map?.destination?.namespace) && !isEmpty(map?.destination?.name)),
-      ),
+      ) ?? false,
     [networkMap?.spec?.map],
   );
 
   const changeNetworkMap = useCallback(
-    (vmNetworkName: string, destinationNetwork: V1beta1NetworkMapSpecMapDestination) => {
+    (vmNetworkName: string, destinationNetwork: V1beta1NetworkMapSpecMapDestination): void => {
       setNetworkMap((draftNetworkMap) => {
-        const mappedNAD = draftNetworkMap.spec.map.find((map) => map.source.name === vmNetworkName);
+        const mappedNAD = draftNetworkMap.spec?.map?.find(
+          (map) => map.source.name === vmNetworkName,
+        );
 
-        mappedNAD.destination = destinationNetwork;
+        if (mappedNAD) {
+          mappedNAD.destination = destinationNetwork;
+        }
       });
     },
     [setNetworkMap],

--- a/src/multicluster/components/CrossClusterMigration/hooks/useProviderByClusterName.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useProviderByClusterName.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { type V1beta1Provider } from '@forklift-ui/types';
 
 import { getProviderByClusterName } from '../utils';
@@ -10,7 +9,11 @@ const useProviderByClusterName = (
 ): [undefined | V1beta1Provider, boolean, Error | undefined] => {
   const [providers, providersLoaded, providersError] = useProviders();
 
-  return [getProviderByClusterName(cluster, providers), providersLoaded, providersError];
+  return [
+    cluster ? getProviderByClusterName(cluster, providers) : undefined,
+    providersLoaded,
+    providersError,
+  ];
 };
 
 export default useProviderByClusterName;

--- a/src/multicluster/components/CrossClusterMigration/hooks/useProviderNADs.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useProviderNADs.ts
@@ -1,15 +1,17 @@
-/* eslint-disable */
 import { NetworkAttachmentDefinitionModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import {
   DEFAULT_NAMESPACE,
   OPENSHIFT_MULTUS_NS,
   OPENSHIFT_SRIOV_NETWORK_OPERATOR_NS,
 } from '@kubevirt-utils/constants/constants';
 import { modelToGroupVersionKind } from '@kubevirt-utils/models';
+import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
-const useProviderNADs = (targetCluster: string, namespace: string) => {
+const useProviderNADs = (
+  targetCluster: string,
+  namespace: string,
+): { data: NetworkAttachmentDefinitionKind[]; error: Error; loaded: boolean } => {
   const [namespaceNADs, namespaceNADsLoaded, namespaceNADsError] = useK8sWatchData<
     NetworkAttachmentDefinitionKind[]
   >({

--- a/src/multicluster/components/CrossClusterMigration/hooks/useProviderStorageClasses.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useProviderStorageClasses.ts
@@ -1,9 +1,10 @@
-/* eslint-disable */
-import { IoK8sApiStorageV1StorageClass } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiStorageV1StorageClass } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { modelToGroupVersionKind, StorageClassModel } from '@kubevirt-utils/models';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
-const useProviderStorageClasses = (cluster: string) => {
+const useProviderStorageClasses = (
+  cluster: string,
+): { data: IoK8sApiStorageV1StorageClass[]; error: Error; loaded: boolean } => {
   const [data, loaded, error] = useK8sWatchData<IoK8sApiStorageV1StorageClass[]>({
     cluster,
     groupVersionKind: modelToGroupVersionKind(StorageClassModel),

--- a/src/multicluster/components/CrossClusterMigration/hooks/useProviders.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useProviders.ts
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import { ProviderModel, V1beta1Provider } from '@forklift-ui/types';
+import { ProviderModel, type V1beta1Provider } from '@forklift-ui/types';
 import { modelToGroupVersionKind } from '@kubevirt-utils/models';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
-const useProviders = () => {
+const useProviders = (): [V1beta1Provider[], boolean, Error] => {
   return useK8sWatchData<V1beta1Provider[]>({
     groupVersionKind: modelToGroupVersionKind(ProviderModel),
     isList: true,

--- a/src/multicluster/components/CrossClusterMigration/hooks/useStorageReadiness.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useStorageReadiness.ts
@@ -1,10 +1,12 @@
-/* eslint-disable */
 import { useCallback, useEffect } from 'react';
-import { Updater } from 'use-immer';
+import { type Updater } from 'use-immer';
 
-import { IoK8sApiCoreV1PersistentVolumeClaim, V1beta1StorageMap } from '@forklift-ui/types';
-import { IoK8sApiStorageV1StorageClass } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  type IoK8sApiCoreV1PersistentVolumeClaim,
+  type V1beta1StorageMap,
+} from '@forklift-ui/types';
+import { type IoK8sApiStorageV1StorageClass } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { modelToGroupVersionKind, PersistentVolumeClaimModel } from '@kubevirt-utils/models';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -17,7 +19,7 @@ import useProviderStorageClasses from './useProviderStorageClasses';
 
 export type UseStorageReadinessReturnType = {
   changeStorageMap: (storageClassName: string, destinationStorageClassName: string) => void;
-  error: any;
+  error: Error | undefined;
   isReady: boolean;
   loaded: boolean;
   storageMap: V1beta1StorageMap;
@@ -27,9 +29,9 @@ export type UseStorageReadinessReturnType = {
 const useStorageReadiness = (
   vms: V1VirtualMachine[],
   targetCluster: string,
-  storageMap: V1beta1StorageMap,
-  setStorageMap: Updater<V1beta1StorageMap>,
-) => {
+  storageMap: V1beta1StorageMap | null,
+  setStorageMap: Updater<V1beta1StorageMap | null>,
+): UseStorageReadinessReturnType => {
   const sourceCluster = getCluster(vms?.[0]);
   const sourceNamespace = getNamespace(vms?.[0]);
 
@@ -61,9 +63,9 @@ const useStorageReadiness = (
   ]);
 
   const changeStorageMap = useCallback(
-    (storageClassName: string, destinationStorageClassName: string) => {
+    (storageClassName: string, destinationStorageClassName: string): void => {
       setStorageMap((draft) => {
-        const storageMapItem = draft.spec.map.find((map) => map.source.name === storageClassName);
+        const storageMapItem = draft.spec?.map?.find((map) => map.source.name === storageClassName);
         if (storageMapItem) {
           storageMapItem.destination.storageClass = destinationStorageClassName;
         }
@@ -72,13 +74,13 @@ const useStorageReadiness = (
     [setStorageMap],
   );
 
-  const error = targetStorageClassesError || pvcsError;
+  const error = targetStorageClassesError ?? pvcsError;
   const loaded = (pvcsLoaded && targetStorageClassesLoaded) || !isEmpty(error);
 
   return {
     changeStorageMap,
     error,
-    isReady: storageMap?.spec?.map?.every((map) => map.destination.storageClass),
+    isReady: !!storageMap?.spec?.map?.every((map) => map.destination.storageClass),
     loaded,
     storageMap,
     targetStorageClasses,

--- a/src/multicluster/components/CrossClusterMigration/hooks/useVersionReadiness.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useVersionReadiness.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import useClusterVersion from '@kubevirt-utils/hooks/useClusterVersion/useClusterVersion';
@@ -10,13 +9,13 @@ type UseVersionReadinessReturnType = (
   sourceCluster: string,
   targetCluster: string,
 ) => {
-  error: any;
+  error: Error | undefined;
   isReady: boolean;
   loaded: boolean;
-  sourceClusterVersion: string;
-  sourceKubevirtVersion: string;
-  targetClusterVersion: string;
-  targetKubevirtVersion: string;
+  sourceClusterVersion: string | null;
+  sourceKubevirtVersion: string | null;
+  targetClusterVersion: string | null;
+  targetKubevirtVersion: string | null;
 };
 
 const useVersionReadiness: UseVersionReadinessReturnType = (sourceCluster, targetCluster) => {
@@ -37,13 +36,13 @@ const useVersionReadiness: UseVersionReadinessReturnType = (sourceCluster, targe
   const [sourceClusterVersion, sourceClusterVersionLoaded, sourceClusterVersionError] =
     useClusterVersion(sourceCluster);
 
-  const targetClusterMajorMinorVersion = getClusterMajorMinorVersion(targetClusterVersion);
-  const sourceClusterMajorMinorVersion = getClusterMajorMinorVersion(sourceClusterVersion);
+  const targetClusterMajorMinorVersion = getClusterMajorMinorVersion(targetClusterVersion ?? '');
+  const sourceClusterMajorMinorVersion = getClusterMajorMinorVersion(sourceClusterVersion ?? '');
   const targetInstalledCSVMajorMinorVersion = getClusterMajorMinorVersion(
-    targetInstalledCSV?.spec?.version,
+    targetInstalledCSV?.spec?.version ?? '',
   );
   const sourceInstalledCSVMajorMinorVersion = getClusterMajorMinorVersion(
-    sourceInstalledCSV?.spec?.version,
+    sourceInstalledCSV?.spec?.version ?? '',
   );
 
   const isReady = useMemo(() => {
@@ -60,9 +59,9 @@ const useVersionReadiness: UseVersionReadinessReturnType = (sourceCluster, targe
 
   return {
     error:
-      targetClusterVersionError ||
-      sourceClusterVersionError ||
-      sourceLoadErrors ||
+      targetClusterVersionError ??
+      sourceClusterVersionError ??
+      sourceLoadErrors ??
       targetLoadErrors,
     isReady,
     loaded:

--- a/src/multicluster/components/MulticlusterYAMLCreation/MulticlusterYAMLCreation.tsx
+++ b/src/multicluster/components/MulticlusterYAMLCreation/MulticlusterYAMLCreation.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useState } from 'react';
+import React, { type FC, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { load } from 'js-yaml';
 
@@ -24,7 +23,7 @@ import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { kubevirtK8sCreate } from '@multicluster/k8sRequests';
 import { getFleetResourceRoute, getMulticlusterSearchURL } from '@multicluster/urls';
 import useIsACMPage from '@multicluster/useIsACMPage';
-import { ResourceYAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon, ResourceYAMLEditor } from '@openshift-console/dynamic-plugin-sdk';
 
 import useModelFromParam from './hooks/useModelFromParam';
 import useYAMLTemplateExtension from './hooks/useYAMLTemplateExtension';
@@ -38,18 +37,18 @@ const MulticlusterYAMLCreation: FC = () => {
 
   const cluster = useClusterParam();
   const namespace = useNamespaceParam();
-  const [error, setError] = useState<Error>(null);
+  const [error, setError] = useState<Error | null>(null);
   const isVirtualMachineModel = model?.kind === VirtualMachineModel.kind;
   const isTemplateModel = model?.kind === TemplateModel.kind;
 
-  const onSave = async (yaml: string) => {
+  const onSave = async (yaml: string): Promise<void> => {
     setError(null);
 
     if (!model) return;
     try {
       const createdResource = await kubevirtK8sCreate({
         cluster,
-        data: load(yaml),
+        data: load(yaml) as K8sResourceCommon,
         model,
         ns: namespace,
       });
@@ -72,14 +71,14 @@ const MulticlusterYAMLCreation: FC = () => {
       });
 
       navigate(
-        kubevirtURL ||
+        kubevirtURL ??
           getMulticlusterSearchURL(model, getName(createdResource), namespace, cluster),
       );
     } catch (apiError) {
       if (isVirtualMachineModel) {
         logVMCreationFailed(TELEMETRY_VM_CREATION_METHOD.SCRATCH, apiError);
       }
-      setError(apiError);
+      setError(apiError instanceof Error ? apiError : new Error(String(apiError)));
     }
   };
 

--- a/src/multicluster/components/MulticlusterYAMLCreation/hooks/useModelFromParam.ts
+++ b/src/multicluster/components/MulticlusterYAMLCreation/hooks/useModelFromParam.ts
@@ -1,19 +1,19 @@
-/* eslint-disable */
 import { useMatch } from 'react-router';
 
 import { FLEET_BASE_PATH } from '@multicluster/constants';
-import { K8sModel, useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sModel, useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
 import { customModels } from './constants';
 
 const useModelFromParam = (): [model: K8sModel | null, loading: boolean] => {
   const pageMatch = useMatch(`${FLEET_BASE_PATH}/:page/*`);
-  const modelRef = pageMatch?.params?.page || '';
+  const modelRef = pageMatch?.params?.page ?? '';
 
   const [group, version, kind] = modelRef.split('~');
 
   const [model, inFlight] = useK8sModel({ group, kind, version });
-  const customModel = customModels[modelRef];
+  const customModel =
+    modelRef in customModels ? customModels[modelRef as keyof typeof customModels] : undefined;
 
   if (customModel) {
     return [customModel, false];

--- a/src/multicluster/components/MulticlusterYAMLCreation/hooks/useYAMLTemplateExtension.ts
+++ b/src/multicluster/components/MulticlusterYAMLCreation/hooks/useYAMLTemplateExtension.ts
@@ -1,18 +1,20 @@
-/* eslint-disable */
 import {
   isYAMLTemplate,
-  K8sModel,
+  type K8sModel,
   useResolvedExtensions,
-  YAMLTemplate,
+  type YAMLTemplate,
 } from '@openshift-console/dynamic-plugin-sdk';
 
-import { ResourceYAMLTemplate } from '../types';
+import { type ResourceYAMLTemplate } from '../types';
 import { convertResourceYAMLTemplate } from '../utils';
 
-const useYAMLTemplateExtension = (model: K8sModel) => {
+const useYAMLTemplateExtension = (
+  model: K8sModel | null,
+): { resourceYAMLTemplate: object | undefined; yamlExtensionsResolved: boolean } => {
   const [yamlExtensions, yamlExtensionsResolved] =
     useResolvedExtensions<YAMLTemplate>(isYAMLTemplate);
 
+  // SDK extension template type doesn't align with ResourceYAMLTemplate; cast is required
   const resourceYAMLTemplate = yamlExtensions?.find(
     (ext) => ext.properties.model.kind === model?.kind,
   )?.properties?.template as ResourceYAMLTemplate;

--- a/src/multicluster/flags.ts
+++ b/src/multicluster/flags.ts
@@ -1,15 +1,18 @@
-/* eslint-disable */
 import { useEffect, useRef } from 'react';
 
 import { logMultiClusterManagementDetected } from '@kubevirt-utils/extensions/telemetry/multicluster';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { SetFeatureFlag } from '@openshift-console/dynamic-plugin-sdk';
+import { type SetFeatureFlag } from '@openshift-console/dynamic-plugin-sdk';
 import { useFleetClusterNames, useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import { FLAG_DISALLOWED_KUBEVIRT_DYNAMIC_ACM, FLAG_KUBEVIRT_DYNAMIC_ACM } from './constants';
 
-export const useKubevirtDynamicACMFlag = (setFeatureFlag: SetFeatureFlag) => {
-  const [hubClusterName, hubClusterNameLoaded, hubClusterError] = useHubClusterName();
+export const useKubevirtDynamicACMFlag = (setFeatureFlag: SetFeatureFlag): void => {
+  const [hubClusterName, hubClusterNameLoaded, hubClusterError] = useHubClusterName() as [
+    string | undefined,
+    boolean,
+    Error | undefined,
+  ];
   const [clusterNames, clustersLoaded] = useFleetClusterNames();
   const hasLoggedMultiClusterRef = useRef(false);
 

--- a/src/multicluster/helpers/selectors.ts
+++ b/src/multicluster/helpers/selectors.ts
@@ -1,8 +1,8 @@
-/* eslint-disable */
 /**
  *
  * @param resource k8s resource with optional cluster
  * @returns resource's cluster
  */
-export const getCluster = <A extends K8sResourceCommon = K8sResourceCommon>(resource?: A) =>
-  resource?.cluster;
+export const getCluster = <A extends K8sResourceCommon = K8sResourceCommon>(
+  resource?: A,
+): string | undefined => resource?.cluster;

--- a/src/multicluster/hooks/useACMExtensionActions/utils.tsx
+++ b/src/multicluster/hooks/useACMExtensionActions/utils.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, { type ComponentType } from 'react';
 
 import { PlanModel } from '@forklift-ui/types';
@@ -59,7 +58,6 @@ export function buildACMVirtualMachineActionsFromExtensions(
       description: action.properties.description,
       disabled: resolveActionDisabled(action.properties.isDisabled, virtualMachine),
       id: action.properties.id,
-
       label: action.properties.title as ACMVirtualMachineAction['properties']['title'],
     };
   });

--- a/src/multicluster/hooks/useACMExtensionColumns/useACMExtensionColumns.tsx
+++ b/src/multicluster/hooks/useACMExtensionColumns/useACMExtensionColumns.tsx
@@ -1,22 +1,25 @@
-/* eslint-disable */
 import {
-  ACMVirtualMachineListColumn,
+  type ACMVirtualMachineListColumn,
   isACMVirtualMachineListColumn,
 } from '@kubevirt-extensions/acm.virtualmachine';
 import useIsACMPage from '@multicluster/useIsACMPage';
-import { useResolvedExtensions } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  type ResolvedExtension,
+  useResolvedExtensions,
+} from '@openshift-console/dynamic-plugin-sdk';
 
-const useACMExtensionColumns = () => {
-  const [virtualMachineListColumnExtensions, virtualMachineListColumnExtensionsResolved] =
-    useResolvedExtensions<ACMVirtualMachineListColumn>(isACMVirtualMachineListColumn);
+const useACMExtensionColumns =
+  (): ResolvedExtension<ACMVirtualMachineListColumn>['properties'][] => {
+    const [virtualMachineListColumnExtensions, virtualMachineListColumnExtensionsResolved] =
+      useResolvedExtensions<ACMVirtualMachineListColumn>(isACMVirtualMachineListColumn);
 
-  const isACMPage = useIsACMPage();
+    const isACMPage = useIsACMPage();
 
-  if (!isACMPage) return [];
+    if (!isACMPage) return [];
 
-  return virtualMachineListColumnExtensionsResolved
-    ? virtualMachineListColumnExtensions.map((extension) => extension.properties)
-    : [];
-};
+    return virtualMachineListColumnExtensionsResolved
+      ? virtualMachineListColumnExtensions.map((extension) => extension.properties)
+      : [];
+  };
 
 export default useACMExtensionColumns;

--- a/src/multicluster/hooks/useActiveClusterParam.ts
+++ b/src/multicluster/hooks/useActiveClusterParam.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useMatch } from 'react-router';
 
 import { ALL_CLUSTERS_KEY } from '@kubevirt-utils/hooks/constants';
@@ -11,10 +10,9 @@ const useActiveClusterParam = (): null | string => {
   const pathMatch = useMatch(`${FLEET_BASE_PATH}/:page/cluster/:cluster/*`);
 
   if (!isACMPage) return null;
-
   if (allClustersMatch) return ALL_CLUSTERS_KEY;
 
-  return pathMatch?.params?.cluster || null;
+  return pathMatch?.params?.cluster ?? null;
 };
 
 export default useActiveClusterParam;

--- a/src/multicluster/hooks/useCluster.ts
+++ b/src/multicluster/hooks/useCluster.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import useClusterParam from './useClusterParam';
@@ -7,7 +6,7 @@ const useCluster = (): string | undefined => {
   const clusterParam = useClusterParam();
   const [hubClusterName] = useHubClusterName();
 
-  return clusterParam || hubClusterName;
+  return clusterParam ?? hubClusterName;
 };
 
 export default useCluster;

--- a/src/multicluster/hooks/useClusterParam.ts
+++ b/src/multicluster/hooks/useClusterParam.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useMatch } from 'react-router';
 
 import { FLEET_BASE_PATH } from '@multicluster/constants';

--- a/src/multicluster/hooks/useIsAllClustersPage.ts
+++ b/src/multicluster/hooks/useIsAllClustersPage.ts
@@ -1,10 +1,9 @@
-/* eslint-disable */
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useIsACMPage from '@multicluster/useIsACMPage';
 
 import useClusterParam from './useClusterParam';
 
-const useIsAllClustersPage = () => {
+const useIsAllClustersPage = (): boolean => {
   const cluster = useClusterParam();
   const isACMPage = useIsACMPage();
 

--- a/src/multicluster/hooks/useKubevirtSearchPoll.ts
+++ b/src/multicluster/hooks/useKubevirtSearchPoll.ts
@@ -1,14 +1,17 @@
-/* eslint-disable */
+import { useMemo } from 'react';
+
 import useIsACMPage from '@multicluster/useIsACMPage';
-import { K8sResourceCommon, WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
 import {
-  AdvancedSearchFilter,
-  FleetWatchK8sResource,
-  SearchResult,
+  type K8sResourceCommon,
+  type WatchK8sResource,
+} from '@openshift-console/dynamic-plugin-sdk';
+import {
+  type AdvancedSearchFilter,
+  type FleetWatchK8sResource,
+  type SearchResult,
   useFleetSearchPoll,
   useHubClusterName,
 } from '@stolostron/multicluster-sdk';
-import { useMemo } from 'react';
 
 const useKubevirtSearchPoll = <T extends K8sResourceCommon | K8sResourceCommon[]>(
   watchOptions: WatchK8sResource,
@@ -16,7 +19,9 @@ const useKubevirtSearchPoll = <T extends K8sResourceCommon | K8sResourceCommon[]
   pollInterval?: false | number,
 ): [SearchResult<T>, boolean, Error, () => void] => {
   const isACMPage = useIsACMPage();
-  const [, hubClusterNameLoaded, hubClusterError] = useHubClusterName();
+  const hubClusterResult = useHubClusterName();
+  const hubClusterNameLoaded = hubClusterResult[1];
+  const hubClusterError: unknown = hubClusterResult[2];
   const isHubClusterLoaded = isACMPage && (hubClusterNameLoaded || !!hubClusterError);
 
   const requestAllAPIVersionsWithNoLimit: FleetWatchK8sResource = useMemo(() => {
@@ -24,7 +29,7 @@ const useKubevirtSearchPoll = <T extends K8sResourceCommon | K8sResourceCommon[]
     const groupVersionKind = { group, kind, version: '' };
 
     if (watchOptions && isHubClusterLoaded) {
-      return { ...watchOptions, limit: undefined, groupVersionKind };
+      return { ...watchOptions, groupVersionKind, limit: undefined };
     }
 
     return { groupVersionKind, isList: watchOptions?.isList };

--- a/src/multicluster/hooks/useManagedClusterConsoleURLs.ts
+++ b/src/multicluster/hooks/useManagedClusterConsoleURLs.ts
@@ -1,11 +1,12 @@
-/* eslint-disable */
 import { useCallback, useMemo } from 'react';
 
 import { modelToGroupVersionKind } from '@kubevirt-utils/models';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-import { useFleetK8sWatchResource, useHubClusterName } from '@stolostron/multicluster-sdk';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import { CONSOLE_URL_CLAIM, ManagedClusterModel } from '../constants';
+
+import useK8sWatchData from './useK8sWatchData';
 
 type ManagedCluster = K8sResourceCommon & {
   status?: {
@@ -18,7 +19,7 @@ type ManagedCluster = K8sResourceCommon & {
 
 type UseManagedClusterConsoleURLs = (cluster?: string) => {
   consoleURLs: Record<string, string>;
-  error: unknown;
+  error: Error | undefined;
   getConsoleURL: (clusterName: string) => string | undefined;
   isSpokeCluster: boolean;
   loaded: boolean;
@@ -35,7 +36,7 @@ type UseManagedClusterConsoleURLs = (cluster?: string) => {
 const useManagedClusterConsoleURLs: UseManagedClusterConsoleURLs = (cluster) => {
   const [hubClusterName] = useHubClusterName();
 
-  const [managedClusters, loaded, error] = useFleetK8sWatchResource<ManagedCluster[]>({
+  const [managedClusters, loaded, error] = useK8sWatchData<ManagedCluster[]>({
     groupVersionKind: modelToGroupVersionKind(ManagedClusterModel),
     isList: true,
   });
@@ -61,7 +62,6 @@ const useManagedClusterConsoleURLs: UseManagedClusterConsoleURLs = (cluster) => 
 
   const getConsoleURL = useCallback(
     (clusterName: string): string | undefined => {
-      // Hub cluster doesn't need external URL - use current console
       if (!clusterName || clusterName === hubClusterName) {
         return undefined;
       }

--- a/src/multicluster/hooks/useMulticlusterAvailableSources.ts
+++ b/src/multicluster/hooks/useMulticlusterAvailableSources.ts
@@ -1,10 +1,9 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 import { isDataSourceReady } from 'src/views/datasources/utils';
 
 import { DataSourceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
-import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import useListMulticlusterFilters from '@kubevirt-utils/hooks/useListMulticlusterFilters';
 import { modelToGroupVersionKind, PersistentVolumeClaimModel } from '@kubevirt-utils/models';
 import { convertResourceArrayToMapWithCluster } from '@kubevirt-utils/resources/shared';
@@ -12,7 +11,15 @@ import { isDataSourceCloning } from '@kubevirt-utils/resources/template/hooks/us
 import useIsACMPage from '@multicluster/useIsACMPage';
 import { useFleetSearchPoll } from '@stolostron/multicluster-sdk';
 
-const useMulticlusterAvailableSources = () => {
+type UseMulticlusterAvailableSourcesReturn = {
+  availableDataSources: ReturnType<typeof convertResourceArrayToMapWithCluster>;
+  availablePVCs: ReturnType<typeof convertResourceArrayToMapWithCluster>;
+  cloneInProgressDataSources: ReturnType<typeof convertResourceArrayToMapWithCluster>;
+  error: Error | undefined;
+  loaded: boolean;
+};
+
+const useMulticlusterAvailableSources = (): UseMulticlusterAvailableSourcesReturn => {
   const multiclusterSearch = useListMulticlusterFilters();
   const isACMPage = useIsACMPage();
 
@@ -55,7 +62,7 @@ const useMulticlusterAvailableSources = () => {
       availableDataSources,
       availablePVCs: pvcsMap,
       cloneInProgressDataSources,
-      error: dataSourcesError || pvcsError,
+      error: (dataSourcesError ?? pvcsError) as Error | undefined,
       loaded: pvcsLoaded && dataSourcesLoaded,
     }),
     [

--- a/src/multicluster/hooks/useMulticlusterNamespaces.ts
+++ b/src/multicluster/hooks/useMulticlusterNamespaces.ts
@@ -1,15 +1,15 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import { modelToGroupVersionKind, NamespaceModel } from '@kubevirt-utils/models';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useIsACMPage from '@multicluster/useIsACMPage';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 import useKubevirtSearchPoll from './useKubevirtSearchPoll';
 
 export type UseMulticlusterNamespacesReturn = {
   allNamespaces: K8sResourceCommon[];
-  error: any;
+  error: Error | undefined;
   loaded: boolean;
   namespacesByCluster: Record<string, K8sResourceCommon[]>;
 };
@@ -33,18 +33,17 @@ const useMulticlusterNamespaces = (
 
   const namespacesByCluster = useMemo(
     () =>
-      namespaces?.reduce(
-        (acc, project) => {
-          const cluster = getCluster(project);
+      namespaces?.reduce<Record<string, K8sResourceCommon[]>>((acc, project) => {
+        const cluster = getCluster(project);
 
-          if (!(cluster in acc)) acc[cluster] = [];
+        if (!cluster) return acc;
 
-          acc[cluster].push(project);
+        if (!(cluster in acc)) acc[cluster] = [];
 
-          return acc;
-        },
-        {} as Record<string, K8sResourceCommon[]>,
-      ),
+        acc[cluster].push(project);
+
+        return acc;
+      }, {}),
     [namespaces],
   );
 

--- a/src/multicluster/hooks/useVMListQueries.ts
+++ b/src/multicluster/hooks/useVMListQueries.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import useListClusters from '@kubevirt-utils/hooks/useListClusters';
@@ -6,7 +5,7 @@ import useListNamespaces from '@kubevirt-utils/hooks/useListNamespaces';
 import { useHubClusterName } from '@stolostron/multicluster-sdk';
 import { getVMListQueries } from '@virtualmachines/list/hooks/utils';
 
-const useVMListQueries = () => {
+const useVMListQueries = (): ReturnType<typeof getVMListQueries> => {
   const clusters = useListClusters();
   const namespaces = useListNamespaces();
 

--- a/src/multicluster/k8sRequests.ts
+++ b/src/multicluster/k8sRequests.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import {
   k8sCreate,
   k8sDelete,
@@ -8,36 +7,38 @@ import {
   k8sUpdate,
 } from '@openshift-console/dynamic-plugin-sdk';
 import {
-  Fleet,
+  type Fleet,
   fleetK8sCreate,
-  FleetK8sCreateUpdateOptions,
+  type FleetK8sCreateUpdateOptions,
   fleetK8sDelete,
-  FleetK8sDeleteOptions,
+  type FleetK8sDeleteOptions,
   fleetK8sGet,
-  FleetK8sGetOptions,
+  type FleetK8sGetOptions,
   fleetK8sListItems,
-  FleetK8sListOptions,
+  type FleetK8sListOptions,
   fleetK8sPatch,
-  FleetK8sPatchOptions,
+  type FleetK8sPatchOptions,
   fleetK8sUpdate,
   getFleetK8sAPIPath,
 } from '@stolostron/multicluster-sdk';
 
 import { BASE_K8S_API_PATH } from './constants';
+import { getCluster } from './helpers/selectors';
 
-export const getKubevirtBaseAPIPath = async (cluster?: string) => {
+export const getKubevirtBaseAPIPath = async (cluster?: string): Promise<string> => {
   if (!cluster) return BASE_K8S_API_PATH;
 
-  return await getFleetK8sAPIPath(cluster);
+  return getFleetK8sAPIPath(cluster);
 };
 
 export const kubevirtK8sPatch = async <R extends K8sResourceCommon>(
   options: FleetK8sPatchOptions<R>,
 ): Promise<R> => {
-  if (options?.cluster || options?.resource?.cluster) {
+  const cluster = options?.cluster ?? getCluster(options?.resource);
+  if (cluster) {
     const object = await fleetK8sPatch<R>(options);
 
-    if (object) object.cluster = options?.cluster || options?.resource?.cluster;
+    if (object) object.cluster = cluster;
     return object;
   }
 
@@ -47,10 +48,11 @@ export const kubevirtK8sPatch = async <R extends K8sResourceCommon>(
 export const kubevirtK8sUpdate = async <R extends K8sResourceCommon>(
   options: FleetK8sCreateUpdateOptions<R>,
 ): Promise<R> => {
-  if (options?.cluster || options?.data?.cluster) {
+  const cluster = options?.cluster ?? getCluster(options?.data);
+  if (cluster) {
     const object = await fleetK8sUpdate<R>(options);
 
-    if (object) object.cluster = options?.cluster || options?.data?.cluster;
+    if (object) object.cluster = cluster;
     return object;
   }
 
@@ -64,7 +66,7 @@ export const kubevirtK8sGet = async <R extends K8sResourceCommon>(
     const object = await fleetK8sGet<R>(options);
 
     if (object) {
-      object.cluster = options?.cluster;
+      object.cluster = options.cluster;
     }
     return object;
   }
@@ -75,10 +77,11 @@ export const kubevirtK8sGet = async <R extends K8sResourceCommon>(
 export const kubevirtK8sDelete = async <R extends K8sResourceCommon>(
   options: FleetK8sDeleteOptions<R>,
 ): Promise<R> => {
-  if (options?.cluster || options?.resource?.cluster) {
+  const cluster = options?.cluster ?? getCluster(options?.resource);
+  if (cluster) {
     const object = await fleetK8sDelete<R>(options);
 
-    if (object) object.cluster = options?.cluster || options?.resource?.cluster;
+    if (object) object.cluster = cluster;
     return object;
   }
 
@@ -88,10 +91,11 @@ export const kubevirtK8sDelete = async <R extends K8sResourceCommon>(
 export const kubevirtK8sCreate = async <R extends K8sResourceCommon>(
   options: FleetK8sCreateUpdateOptions<R>,
 ): Promise<R> => {
-  if (options?.cluster || options?.data?.cluster) {
+  const cluster = options?.cluster ?? getCluster(options?.data);
+  if (cluster) {
     const object = await fleetK8sCreate<R>(options);
 
-    if (object) object.cluster = options?.cluster || options?.data?.cluster;
+    if (object) object.cluster = cluster;
     return object;
   }
 

--- a/src/multicluster/useIsACMPage.ts
+++ b/src/multicluster/useIsACMPage.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useEffect, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
@@ -13,7 +12,7 @@ type UseIsACMPageOptions = {
   activePerspectiveSync?: boolean;
 };
 
-const useIsACMPage = ({ activePerspectiveSync = true }: UseIsACMPageOptions = {}) => {
+const useIsACMPage = ({ activePerspectiveSync = true }: UseIsACMPageOptions = {}): boolean => {
   const { pathname, search } = useLocation();
   const navigate = useNavigate();
   const [activePerspective] = useActivePerspective();

--- a/src/multicluster/utils.ts
+++ b/src/multicluster/utils.ts
@@ -1,22 +1,26 @@
-/* eslint-disable */
-import { K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sGroupVersionKind } from '@openshift-console/dynamic-plugin-sdk';
 
 /**
  * useFleetK8sWatchResource does not inject apiVersion/kind into list items
  * (unlike fleetK8sList which does). This normalizes fleet data so that
  * getGroupVersionKindForResource and kind-based type guards work correctly.
  */
-export const enrichFleetData = <T>(data: T, gvk: K8sGroupVersionKind): T => {
+export const enrichFleetData = <T extends K8sResourceCommon | K8sResourceCommon[]>(
+  data: T,
+  gvk: K8sGroupVersionKind,
+): T => {
   if (!data || !gvk?.kind || !gvk?.version) return data;
 
   const apiVersion = gvk.group ? `${gvk.group}/${gvk.version}` : gvk.version;
 
-  const enrichResource = (resource: K8sResourceCommon) =>
-    resource.apiVersion && resource.kind ? resource : { apiVersion, kind: gvk.kind, ...resource };
+  const enrichResource = <R extends K8sResourceCommon>(resource: R): R =>
+    resource.apiVersion && resource.kind
+      ? resource
+      : ({ apiVersion, kind: gvk.kind, ...resource } as R);
 
   if (Array.isArray(data)) {
-    return data.map((item: K8sResourceCommon) => enrichResource(item)) as T;
+    return data.map((item) => enrichResource(item)) as T;
   }
 
-  return enrichResource(data) as T;
+  return enrichResource(data as K8sResourceCommon & T) as T;
 };

--- a/src/utils/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/src/utils/components/ActionsDropdown/ActionsDropdown.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, memo, ReactNode, useRef, useState } from 'react';
+import React, { type FC, memo, type ReactElement, type ReactNode, useRef, useState } from 'react';
 import classNames from 'classnames';
 
 import DropdownToggle from '@kubevirt-utils/components/toggles/DropdownToggle';
@@ -9,8 +8,7 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { Menu, MenuContent, MenuList, Popper, Tooltip } from '@patternfly/react-core';
 
 import ActionDropdownItem from '../ActionDropdownItem/ActionDropdownItem';
-
-import { ActionDropdownItemType } from './constants';
+import { type ActionDropdownItemType } from './constants';
 
 type ActionsDropdownProps = {
   actions: ActionDropdownItemType[];
@@ -31,7 +29,7 @@ const ActionsDropdown: FC<ActionsDropdownProps> = ({
   isKebabToggle,
   onLazyClick,
   variant,
-}) => {
+}): ReactElement => {
   const { t } = useKubevirtTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -40,7 +38,7 @@ const ActionsDropdown: FC<ActionsDropdownProps> = ({
 
   useClickOutside([menuRef, toggleRef], () => setIsOpen(false));
 
-  const onToggle = () => {
+  const onToggle = (): void => {
     setIsOpen((prevIsOpen) => {
       if (onLazyClick && !prevIsOpen) onLazyClick();
 

--- a/src/utils/components/AddBootableVolumeModal/components/AddBootableVolumeBody.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/AddBootableVolumeBody.tsx
@@ -1,5 +1,10 @@
-/* eslint-disable */
-import React, { Dispatch, FC, SetStateAction, useCallback } from 'react';
+import React, {
+  type Dispatch,
+  type FC,
+  type ReactElement,
+  type SetStateAction,
+  useCallback,
+} from 'react';
 
 import {
   DROPDOWN_FORM_SELECTION,
@@ -7,15 +12,15 @@ import {
   SOURCE_DETAILS_SECTION_ID,
 } from '@kubevirt-utils/components/AddBootableVolumeModal/consts';
 import {
-  AddBootableVolumeState,
-  SetBootableVolumeFieldType,
+  type AddBootableVolumeState,
+  type SetBootableVolumeFieldType,
 } from '@kubevirt-utils/components/AddBootableVolumeModal/types';
 import {
   deleteBootableVolumeLabel,
   updateBootableVolumeField,
 } from '@kubevirt-utils/components/AddBootableVolumeModal/utils';
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
-import { DataUpload } from '@kubevirt-utils/hooks/useCDIUpload/types';
+import { type DataUpload } from '@kubevirt-utils/hooks/useCDIUpload/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getValidNamespace } from '@kubevirt-utils/utils/utils';
 import PopoverContentWithLightspeedButton from '@lightspeed/components/PopoverContentWithLightspeedButton/PopoverContentWithLightspeedButton';
@@ -24,12 +29,12 @@ import useIsACMPage from '@multicluster/useIsACMPage';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { Form, PopoverPosition, Title } from '@patternfly/react-core';
 
+import SchedulingSettings from './SchedulingSettings';
 import SourceTypeSelection from './SourceTypeSelection/SourceTypeSelection';
 import VolumeDestination from './VolumeDestination/VolumeDestination';
 import ClusterSelect from './VolumeMetadata/components/ClusterSelect';
 import VolumeMetadata from './VolumeMetadata/VolumeMetadata';
 import VolumeSource from './VolumeSource/VolumeSource';
-import SchedulingSettings from './SchedulingSettings';
 
 type AddBootableVolumeBodyProps = {
   bootableVolume: AddBootableVolumeState;
@@ -47,7 +52,7 @@ const AddBootableVolumeBody: FC<AddBootableVolumeBodyProps> = ({
   setSourceType,
   sourceType,
   upload,
-}) => {
+}): ReactElement => {
   const { t } = useKubevirtTranslation();
   const isACMPage = useIsACMPage();
   const [activeNamespace] = useActiveNamespace();
@@ -60,11 +65,12 @@ const AddBootableVolumeBody: FC<AddBootableVolumeBodyProps> = ({
   );
 
   const deleteLabel = useCallback(
-    (labelKey: string) => setBootableVolume((prev) => deleteBootableVolumeLabel(prev, labelKey)),
+    (labelKey: string): void =>
+      setBootableVolume((prev) => deleteBootableVolumeLabel(prev, labelKey)),
     [setBootableVolume],
   );
 
-  const resetDiskSize = () => setBootableVolumeField('size')(initialBootableVolumeState.size);
+  const resetDiskSize = (): void => setBootableVolumeField('size')(initialBootableVolumeState.size);
 
   return (
     <Form className="pf-v6-u-mt-md">

--- a/src/utils/components/AddBootableVolumeModal/components/SourceTypeSelection/SourceTypeSelection.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/SourceTypeSelection/SourceTypeSelection.tsx
@@ -1,13 +1,11 @@
-/* eslint-disable */
-import React, { FC, useCallback, useEffect, useState } from 'react';
+import React, { type FC, type ReactElement, useCallback, useEffect, useState } from 'react';
 
 import SelectToggle from '@kubevirt-utils/components/toggles/SelectToggle';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import usePermissions from '@kubevirt-utils/hooks/usePermissions/usePermissions';
 import useCanCreateBootableVolume from '@kubevirt-utils/resources/bootableresources/hooks/useCanCreateBootableVolume';
 import { getNoPermissionTooltipContent } from '@kubevirt-utils/utils/utils';
-import { Divider, FormGroup, SelectGroup } from '@patternfly/react-core';
-import { Select, SelectOption } from '@patternfly/react-core';
+import { Divider, FormGroup, Select, SelectGroup, SelectOption } from '@patternfly/react-core';
 
 import { DROPDOWN_FORM_SELECTION, optionsValueLabelMapper } from '../../consts';
 
@@ -25,7 +23,7 @@ const SourceTypeSelection: FC<SourceTypeSelectionProps> = ({
   namespace,
   resetDiskSize,
   setFormSelection,
-}) => {
+}): ReactElement => {
   const { t } = useKubevirtTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const { canCreateDS, canCreatePVC, canCreateSnapshots, loading } =
@@ -34,9 +32,9 @@ const SourceTypeSelection: FC<SourceTypeSelectionProps> = ({
   const canUploadImage = capabilitiesData.uploadImage.allowed && canCreatePVC;
 
   const onSelect = useCallback(
-    (event, value) => {
-      event.preventDefault();
-      setFormSelection(value);
+    (_event, value): void => {
+      _event?.preventDefault();
+      setFormSelection(value as DROPDOWN_FORM_SELECTION);
       setIsOpen(false);
 
       if (
@@ -59,7 +57,7 @@ const SourceTypeSelection: FC<SourceTypeSelectionProps> = ({
     }
   }, [canUploadImage, permissionsLoading, loading, setFormSelection]);
 
-  const onToggle = () => setIsOpen((prevIsOpen) => !prevIsOpen);
+  const onToggle = (): void => setIsOpen((prevIsOpen) => !prevIsOpen);
 
   return (
     <FormGroup fieldId="source-type" label={t('Source type')}>

--- a/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/ArchitectureSelect/ArchitectureSelect.tsx
+++ b/src/utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/ArchitectureSelect/ArchitectureSelect.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC, type ReactElement } from 'react';
 
 import {
-  AddBootableVolumeState,
-  SetBootableVolumeFieldType,
+  type AddBootableVolumeState,
+  type SetBootableVolumeFieldType,
 } from '@kubevirt-utils/components/AddBootableVolumeModal/types';
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
@@ -25,7 +24,7 @@ const ArchitectureSelect: FC<ArchitectureSelectProps> = ({
   bootableVolumeState,
   isDisabled,
   setBootableVolumeField,
-}) => {
+}): ReactElement | null => {
   const { t } = useKubevirtTranslation();
   const [workloadArchitectures] = useHcoWorkloadArchitectures(
     bootableVolumeState?.bootableVolumeCluster,
@@ -69,7 +68,7 @@ const ArchitectureSelect: FC<ArchitectureSelectProps> = ({
                 setBootableVolumeField('architectures')(
                   architectures?.includes(arch)
                     ? architectures.filter((a) => a !== arch)
-                    : [...(architectures || []), arch],
+                    : [...(architectures ?? []), arch],
                 )
               }
               hasCheckbox


### PR DESCRIPTION
## 📝 Description

Adds eslint typescript rules to the code base part- 2

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-90382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cluster resolution for Kubernetes resource operations, prioritizing explicitly selected clusters.
  - Improved handling of missing cluster, network, storage, version, and provider data during migration readiness checks.
  - Improved error normalization and reporting across multicluster workflows.
  - Prevented projects without an associated cluster from appearing in grouped namespace results.
  - Improved handling of empty or missing routing and model parameters.

- **Refactor**
  - Strengthened type safety and validation across multicluster migration, YAML creation, VM listing, and action workflows.
  - Re-enabled linting checks across affected components without changing core functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->