### PR TITLE
CNV-90382: add typescript-linters-part-4

### DIFF
--- a/src/utils/components/ErrorIcon/ErrorIcon.tsx
+++ b/src/utils/components/ErrorIcon/ErrorIcon.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type JSX } from 'react';
 
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
-export const ErrorIcon = () => (
+export const ErrorIcon = (): JSX.Element => (
   <ExclamationCircleIcon color="var(--pf-t--global--icon--color--status--danger--default)" />
 );

--- a/src/utils/components/EvictionStrategy/useHCOEvictionStrategy.ts
+++ b/src/utils/components/EvictionStrategy/useHCOEvictionStrategy.ts
@@ -1,11 +1,10 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 
 import { EVICTION_STRATEGY_DEFAULT } from './constants';
 
-const useHCOEvictionStrategy = (cluster?: string) => {
+const useHCOEvictionStrategy = (cluster?: string): string | undefined => {
   const [hyperConverge, hyperLoaded, hyperLoadingError] = useHyperConvergeConfiguration(cluster);
 
   return useMemo(() => {

--- a/src/utils/components/ExportTableButton/ExportTableButton.tsx
+++ b/src/utils/components/ExportTableButton/ExportTableButton.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { useCallback, useMemo } from 'react';
+import React, { type JSX, useCallback, useMemo } from 'react';
 
 import { type ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -29,7 +28,7 @@ const ExportTableButton = <TData, TCallbacks = undefined>({
   filename,
   isDisabled,
   loaded = true,
-}: ExportTableButtonProps<TData, TCallbacks>) => {
+}: ExportTableButtonProps<TData, TCallbacks>): JSX.Element => {
   const { t } = useKubevirtTranslation();
 
   const disabled = isDisabled ?? (!loaded || isEmpty(data));

--- a/src/utils/components/FilterSelect/components/InlineFilterSelectOptionContent.tsx
+++ b/src/utils/components/FilterSelect/components/InlineFilterSelectOptionContent.tsx
@@ -1,24 +1,24 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC, type JSX } from 'react';
 
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 
-import { EnhancedSelectOptionProps } from '../utils/types';
+import { type EnhancedSelectOptionProps } from '../utils/types';
 
 type InlineFilterSelectOptionContentProps = {
   option: EnhancedSelectOptionProps;
 };
 
-const InlineFilterSelectOptionContent: FC<InlineFilterSelectOptionContentProps> = ({ option }) =>
-  !isEmpty(option?.groupVersionKind) ? (
-    <ResourceLink
-      groupVersionKind={option.groupVersionKind}
-      linkTo={false}
-      name={option?.label || option.value}
-    />
+const InlineFilterSelectOptionContent: FC<InlineFilterSelectOptionContentProps> = ({
+  option,
+}): JSX.Element => {
+  const name = String(option.label ?? option.value);
+
+  return !isEmpty(option?.groupVersionKind) ? (
+    <ResourceLink groupVersionKind={option.groupVersionKind} linkTo={false} name={name} />
   ) : (
     <>{option?.children}</>
   );
+};
 
 export default InlineFilterSelectOptionContent;

--- a/src/utils/components/FilterSelect/utils/utils.ts
+++ b/src/utils/components/FilterSelect/utils/utils.ts
@@ -1,17 +1,14 @@
-/* eslint-disable */
-import { EnhancedSelectOptionProps } from './types';
+import { type EnhancedSelectOptionProps } from './types';
 
 export const getGroupedOptions = (
   filterOptions: EnhancedSelectOptionProps[],
   options: EnhancedSelectOptionProps[],
-) => {
+): Record<string, EnhancedSelectOptionProps[]> | null => {
   if (options.some((option) => option.group)) {
     return filterOptions.reduce(
       (groups, option) => {
-        const group = option.group || 'Ungrouped';
-        if (!groups[group]) {
-          groups[group] = [];
-        }
+        const group = option.group ?? 'Ungrouped';
+        groups[group] ??= [];
         groups[group].push(option);
         return groups;
       },

--- a/src/utils/components/FirmwareBootloaderModal/utils/constants.ts
+++ b/src/utils/components/FirmwareBootloaderModal/utils/constants.ts
@@ -1,43 +1,42 @@
-/* eslint-disable */
-import { BootloaderOption } from './types';
+import { type BootloaderOption } from './types';
 
 export enum BootMode {
-  bios = 'bios',
-  ipl = 'ipl',
-  uefi = 'uefi',
-  uefiSecure = 'uefiSecure',
+  BIOS = 'bios',
+  IPL = 'ipl',
+  UEFI = 'uefi',
+  UefiSecure = 'uefiSecure',
 }
 
 export const BootModeTitles = {
-  [BootMode.bios]: 'BIOS',
-  [BootMode.ipl]: 'IPL',
-  [BootMode.uefi]: 'UEFI',
-  [BootMode.uefiSecure]: 'UEFI (secure)',
+  [BootMode.BIOS]: 'BIOS',
+  [BootMode.IPL]: 'IPL',
+  [BootMode.UEFI]: 'UEFI',
+  [BootMode.UefiSecure]: 'UEFI (secure)',
 };
 
 export const defaultBootloaderOptions: BootloaderOption[] = [
   {
     description: 'Use BIOS when bootloading the guest OS',
-    title: BootModeTitles[BootMode.bios],
-    value: BootMode.bios,
+    title: BootModeTitles[BootMode.BIOS],
+    value: BootMode.BIOS,
   },
   {
     description: 'Use UEFI when bootloading the guest OS.',
-    title: BootModeTitles[BootMode.uefi],
-    value: BootMode.uefi,
+    title: BootModeTitles[BootMode.UEFI],
+    value: BootMode.UEFI,
   },
   {
     description:
       'Use UEFI when bootloading the guest OS. Requires SMM feature, if the SMM feature is not set, choosing this method will set it to true',
-    title: BootModeTitles[BootMode.uefiSecure],
-    value: BootMode.uefiSecure,
+    title: BootModeTitles[BootMode.UefiSecure],
+    value: BootMode.UefiSecure,
   },
 ];
 
 export const s390xBootloaderOptions: BootloaderOption[] = [
   {
     description: 'Use IPL (Initial Program Load) when bootloading the guest OS',
-    title: BootModeTitles[BootMode.ipl],
-    value: BootMode.ipl,
+    title: BootModeTitles[BootMode.IPL],
+    value: BootMode.IPL,
   },
 ];

--- a/src/utils/components/FirmwareBootloaderModal/utils/types.ts
+++ b/src/utils/components/FirmwareBootloaderModal/utils/types.ts
@@ -1,9 +1,9 @@
-import { BootMode } from './constants';
+import { type BootMode } from './constants';
 
 export type BootloaderOption = { description: string; title: string; value: string };
 
 export type BootloaderOptionValue =
-  | BootMode.bios
-  | BootMode.ipl
-  | BootMode.uefi
-  | BootMode.uefiSecure;
+  | BootMode.BIOS
+  | BootMode.IPL
+  | BootMode.UEFI
+  | BootMode.UefiSecure;

--- a/src/utils/components/FirmwareBootloaderModal/utils/utils.ts
+++ b/src/utils/components/FirmwareBootloaderModal/utils/utils.ts
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 import { produce } from 'immer';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { ARCHITECTURES } from '@kubevirt-utils/constants/constants';
 import {
   getArchitecture,
@@ -17,7 +16,7 @@ import {
   defaultBootloaderOptions,
   s390xBootloaderOptions,
 } from './constants';
-import { BootloaderOption, BootloaderOptionValue } from './types';
+import { type BootloaderOption, type BootloaderOptionValue } from './types';
 
 export const isObjectEmpty = (obj: object): boolean => obj && isEmpty(obj);
 
@@ -29,24 +28,24 @@ export const getClusterOnlyArchitecture = (
 
 export const getBootloaderFromVM = (
   vm: V1VirtualMachine,
-  defaultBootmode = BootMode.bios,
+  defaultBootmode = BootMode.BIOS,
   clusterOnlyArchitecture?: string,
 ): BootloaderOptionValue => {
   const architecture = getArchitecture(vm) || clusterOnlyArchitecture;
   if (architecture === ARCHITECTURES.S390X) {
-    return BootMode.ipl;
+    return BootMode.IPL;
   }
 
   const uefiBoot = getBootloader(vm)?.efi;
 
   if (uefiBoot?.secureBoot === true || isObjectEmpty(uefiBoot)) {
-    return BootMode.uefiSecure;
+    return BootMode.UefiSecure;
   }
   if (uefiBoot?.secureBoot === false) {
-    return BootMode.uefi;
+    return BootMode.UEFI;
   }
 
-  if (getBootloader(vm)?.bios) return BootMode.bios;
+  if (getBootloader(vm)?.bios) return BootMode.BIOS;
 
   return defaultBootmode;
 };
@@ -85,10 +84,10 @@ export const updatedVMBootMode = (
   vm: V1VirtualMachine,
   firmwareBootloader: BootloaderOptionValue,
   clusterOnlyArchitecture?: string,
-) =>
+): V1VirtualMachine =>
   produce<V1VirtualMachine>(vm as V1VirtualMachine, (vmDraft: V1VirtualMachine) => {
     const architecture = getArchitecture(vm) || clusterOnlyArchitecture;
-    if (architecture === ARCHITECTURES.S390X && firmwareBootloader === BootMode.ipl) {
+    if (architecture === ARCHITECTURES.S390X && firmwareBootloader === BootMode.IPL) {
       if (getBootloader(vmDraft)) {
         delete vmDraft.spec.template.spec.domain.firmware.bootloader;
       }
@@ -104,12 +103,12 @@ export const updatedVMBootMode = (
     vmDraft.spec.template.spec.domain.features.smm = { enabled: true };
 
     switch (firmwareBootloader) {
-      case BootMode.uefi:
+      case BootMode.UEFI:
         vmDraft.spec.template.spec.domain.firmware.bootloader = {
           efi: { secureBoot: false },
         };
         break;
-      case BootMode.uefiSecure:
+      case BootMode.UefiSecure:
         vmDraft.spec.template.spec.domain.firmware.bootloader = {
           efi: { secureBoot: true },
         };

--- a/src/utils/components/FolderSelect/utils/getFolderSelectOptions.ts
+++ b/src/utils/components/FolderSelect/utils/getFolderSelectOptions.ts
@@ -1,6 +1,5 @@
-/* eslint-disable */
-import { SelectTypeaheadOptionProps } from '@kubevirt-utils/components/SelectTypeahead/SelectTypeahead';
-import { SelectOptionProps } from '@patternfly/react-core';
+import { type SelectTypeaheadOptionProps } from '@kubevirt-utils/components/SelectTypeahead/SelectTypeahead';
+import { type SelectOptionProps } from '@patternfly/react-core';
 
 import { createNewFolderOption } from './options';
 
@@ -16,7 +15,10 @@ export const getFolderSelectOptions = (
   selectedFolder: string,
 ): SelectTypeaheadOptionProps[] => {
   const mappedOptions =
-    folderOptions?.map((option) => ({ optionProps: option, value: option.value })) ?? [];
+    folderOptions?.map((option) => ({
+      optionProps: option,
+      value: String(option.value),
+    })) ?? [];
 
   if (selectedFolder && !mappedOptions.some((option) => option.value === selectedFolder)) {
     return [

--- a/src/utils/components/FolderSelect/utils/validation.tsx
+++ b/src/utils/components/FolderSelect/utils/validation.tsx
@@ -1,17 +1,16 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type JSX } from 'react';
 
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { MenuToggleProps } from '@patternfly/react-core';
+import { type MenuToggleProps } from '@patternfly/react-core';
 
 const isValidFolderNameRegex = /^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$/;
 const startsCorrectlyRegex = /(^$)|(^[A-Za-z0-9])/;
 
-const findInvalidCharacter = (input: string) => {
+const findInvalidCharacter = (input: string): string | undefined => {
   return input.split('').find((char) => /[^-A-Za-z0-9_.]/.test(char));
 };
 
-export const getCreationNotAllowedMessage = (filterValue: string) => {
+export const getCreationNotAllowedMessage = (filterValue: string): JSX.Element | null => {
   const invalidCharacter = findInvalidCharacter(filterValue);
 
   if (invalidCharacter) {

--- a/src/utils/components/FormPFSelect/FormPFSelect.tsx
+++ b/src/utils/components/FormPFSelect/FormPFSelect.tsx
@@ -1,18 +1,18 @@
-/* eslint-disable */
-import React, { FC, ReactNode, useState } from 'react';
+import React, { type FC, type JSX, type ReactNode, useState } from 'react';
 
-import { Select, SelectList, SelectProps } from '@patternfly/react-core';
+import { Select, SelectList, type SelectProps } from '@patternfly/react-core';
 
-import SelectToggle, { MenuTogglePropsWithTestId } from '../toggles/SelectToggle';
+import SelectToggle, { type MenuTogglePropsWithTestId } from '../toggles/SelectToggle';
 
 import './FormPFSelect.scss';
 
-type FormPFSelectProps = Omit<SelectProps, 'isOpen' | 'toggle'> & {
+type FormPFSelectProps = Omit<SelectProps, 'isOpen' | 'selected' | 'toggle'> & {
   children?: ReactNode;
   closeOnSelect?: boolean;
   isDisabled?: boolean;
   placeholder?: string;
-  selectedLabel?: any;
+  selected?: string | readonly string[] | number | undefined;
+  selectedLabel?: ReactNode;
   toggleProps?: MenuTogglePropsWithTestId;
 };
 
@@ -40,22 +40,22 @@ const FormPFSelect: FC<FormPFSelectProps> = ({
   selectedLabel,
   toggleProps,
   ...props
-}) => {
+}): JSX.Element => {
   const [isOpen, setIsOpen] = useState(false);
 
-  const onToggle = () => setIsOpen((prevIsOpen) => !prevIsOpen);
+  const onToggle = (): void => setIsOpen((prevIsOpen) => !prevIsOpen);
 
   return (
     <Select
       onSelect={(event, value) => {
-        onSelect && onSelect(event, value);
+        onSelect?.(event, value);
         closeOnSelect && setIsOpen(false);
       }}
       toggle={SelectToggle({
         isDisabled,
         isExpanded: isOpen,
         onClick: onToggle,
-        selected: selectedLabel || selected || placeholder,
+        selected: selectedLabel ?? selected ?? placeholder,
         ...toggleProps,
       })}
       className={className}

--- a/src/utils/components/GuidedTour/GuidedTour.tsx
+++ b/src/utils/components/GuidedTour/GuidedTour.tsx
@@ -1,6 +1,10 @@
-/* eslint-disable */
-import React, { ComponentType, FC, useMemo } from 'react';
-import Joyride, { ACTIONS, CallBackProps, EVENTS, TooltipRenderProps } from 'react-joyride';
+import React, { type ComponentType, type FC, useMemo } from 'react';
+import Joyride, {
+  ACTIONS,
+  type CallBackProps,
+  EVENTS,
+  type TooltipRenderProps,
+} from 'react-joyride';
 import { useLocation, useNavigate } from 'react-router';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -14,6 +18,10 @@ import useTour from './hooks/useTour';
 import { getTourSteps } from './utils/constants';
 import { runningTourSignal, stepIndexSignal, tourStepsSeenSignal } from './utils/guidedTourSignals';
 import { handleClose, handleNext, handlePrev } from './utils/utils';
+
+type TourStepData = {
+  route?: string;
+};
 
 const GuidedTour: FC = () => {
   useSignals();
@@ -31,22 +39,22 @@ const GuidedTour: FC = () => {
     <Joyride
       callback={(callbackProps: CallBackProps) => {
         const { action, index, size, step, type } = callbackProps;
-        const route = step?.data?.route;
+        const route = (step?.data as TourStepData | undefined)?.route;
 
         if (typeof step?.target === 'string') {
           document.querySelector(step.target)?.scrollIntoView({ block: 'nearest' });
         }
 
-        const markStepSeen = (stepIndex: number) => {
+        const markStepSeen = (stepIndex: number): void => {
           const mergedSeen = Array.from(
             new Set([
-              ...(quickStarts?.tourStepsSeen || []),
+              ...(quickStarts?.tourStepsSeen ?? []),
               ...tourStepsSeenSignal.value,
               stepIndex,
             ]),
           );
-          if (mergedSeen.length !== (quickStarts?.tourStepsSeen || []).length) {
-            setQuickStarts?.({ ...quickStarts, tourStepsSeen: mergedSeen });
+          if (mergedSeen.length !== (quickStarts?.tourStepsSeen ?? []).length) {
+            void setQuickStarts?.({ ...quickStarts, tourStepsSeen: mergedSeen });
           }
           if (mergedSeen.length !== tourStepsSeenSignal.value.length) {
             tourStepsSeenSignal.value = mergedSeen;

--- a/src/utils/components/GuidedTour/hooks/useTour.ts
+++ b/src/utils/components/GuidedTour/hooks/useTour.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useLocation, useNavigate } from 'react-router';
 
 import { ALL_NAMESPACES } from '@kubevirt-utils/hooks/constants';
@@ -7,18 +6,24 @@ import useNamespaceParam from '@kubevirt-utils/hooks/useNamespaceParam';
 import { TOUR_STEPS_COUNT } from '../utils/constants';
 import { namespaceSignal, runningTourSignal, stepIndexSignal } from '../utils/guidedTourSignals';
 
-const useTour = () => {
+type UseTourReturn = {
+  resetTour: () => void;
+  startTour: () => void;
+  stopTour: () => void;
+};
+
+const useTour = (): UseTourReturn => {
   const location = useLocation();
   const navigate = useNavigate();
   const namespace = useNamespaceParam();
 
-  const startTour = () => {
+  const startTour = (): void => {
     if (stepIndexSignal.value >= TOUR_STEPS_COUNT) stepIndexSignal.value = 0;
     namespaceSignal.value = namespace;
     runningTourSignal.value = true;
   };
 
-  const stopTour = () => {
+  const stopTour = (): void => {
     runningTourSignal.value = false;
     // Navigate back to the user's namespace URL if the tour moved them to all-namespaces
     if (location.pathname.includes(ALL_NAMESPACES) && namespaceSignal.value) {
@@ -28,7 +33,7 @@ const useTour = () => {
     }
   };
 
-  const resetTour = () => {
+  const resetTour = (): void => {
     stopTour();
     stepIndexSignal.value = 0;
   };

--- a/src/utils/components/GuidedTour/utils/guidedTourSignals.ts
+++ b/src/utils/components/GuidedTour/utils/guidedTourSignals.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { signal } from '@preact/signals-react';
 
 export const runningTourSignal = signal(false);
@@ -8,11 +7,11 @@ export const tourContextMenuTriggerSignal = signal<HTMLElement | null>(null);
 export const dismissOnboardingPopoverByWelcomeModalSignal = signal(false);
 export const tourStepsSeenSignal = signal<number[]>([]);
 
-export const nextStep = () => {
+export const nextStep = (): void => {
   stepIndexSignal.value++;
 };
 
-export const prevStep = () => {
+export const prevStep = (): void => {
   if (stepIndexSignal.value > 0) {
     --stepIndexSignal.value;
   }

--- a/src/utils/components/GuidedTour/utils/utils.ts
+++ b/src/utils/components/GuidedTour/utils/utils.ts
@@ -1,23 +1,22 @@
-/* eslint-disable */
 import { TOUR_GUIDE_VM_TREE_ID } from './constants';
 import { nextStep, prevStep, tourContextMenuTriggerSignal } from './guidedTourSignals';
 
 export const CONTEXT_MENU_STEP_INDEX = 1;
 
-export const openContextMenu = () => {
+export const openContextMenu = (): void => {
   tourContextMenuTriggerSignal.value = document.getElementById(TOUR_GUIDE_VM_TREE_ID);
 };
 
-export const closeContextMenu = () => {
+export const closeContextMenu = (): void => {
   tourContextMenuTriggerSignal.value = null;
 };
 
-export const handleClose = (resetTour: () => void) => {
+export const handleClose = (resetTour: () => void): void => {
   closeContextMenu();
   resetTour();
 };
 
-export const handlePrev = (currentIndex: number) => {
+export const handlePrev = (currentIndex: number): void => {
   if (currentIndex === CONTEXT_MENU_STEP_INDEX) {
     closeContextMenu();
     prevStep();
@@ -31,7 +30,7 @@ export const handlePrev = (currentIndex: number) => {
   prevStep();
 };
 
-export const handleNext = (currentIndex: number, size: number, resetTour: () => void) => {
+export const handleNext = (currentIndex: number, size: number, resetTour: () => void): void => {
   if (currentIndex === CONTEXT_MENU_STEP_INDEX - 1) {
     openContextMenu();
     nextStep();

--- a/src/utils/components/HardwareDevices/HardwareDevices.tsx
+++ b/src/utils/components/HardwareDevices/HardwareDevices.tsx
@@ -1,7 +1,9 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getGPUDevices, getHostDevices } from '@kubevirt-utils/resources/vm';
 import { hasS390xArchitecture } from '@kubevirt-utils/resources/vm/utils/architecture';
@@ -12,12 +14,11 @@ import {
 } from '@patternfly/react-core';
 
 import { useModal } from '../ModalProvider/ModalProvider';
-
-import HardwareDevicesModal from './modal/HardwareDevicesModal';
-import { HARDWARE_DEVICE_TYPE } from './utils/constants';
 import HardwareDevicesHeadlessMode from './HardwareDevicesHeadlessMode';
 import HardwareDevicesTable from './HardwareDevicesTable';
 import HardwareDeviceTitle from './HardwareDeviceTitle';
+import HardwareDevicesModal from './modal/HardwareDevicesModal';
+import { HARDWARE_DEVICE_TYPE } from './utils/constants';
 
 type HardwareDevicesProps = {
   canEdit?: boolean;
@@ -41,7 +42,7 @@ const HardwareDevices: FC<HardwareDevicesProps> = ({
   const gpus = getGPUDevices(vm);
   const vmHasS390xArchitecture = hasS390xArchitecture(vm);
 
-  const onEditGPU = () => {
+  const onEditGPU = (): void => {
     createModal(({ isOpen, onClose }) => (
       <HardwareDevicesModal
         btnText={t('Add GPU device')}
@@ -57,7 +58,7 @@ const HardwareDevices: FC<HardwareDevicesProps> = ({
     ));
   };
 
-  const onEditHostDevices = () => {
+  const onEditHostDevices = (): void => {
     createModal(({ isOpen, onClose }) => (
       <HardwareDevicesModal
         btnText={t('Add host device')}

--- a/src/utils/components/HardwareDevices/HardwareDevicesPage.tsx
+++ b/src/utils/components/HardwareDevices/HardwareDevicesPage.tsx
@@ -1,22 +1,37 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC, type JSX } from 'react';
 
-import { V1PciHostDevice } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1PciHostDevice } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { HorizontalNav } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  HorizontalNav,
+  type HorizontalNavProps,
+  type NavPage,
+} from '@openshift-console/dynamic-plugin-sdk';
 import { Bullseye, Flex, PageSection, PopoverPosition, Title } from '@patternfly/react-core';
 
-import useHCPermittedHostDevices from './hooks/useHCPermittedHostDevices';
 import HardwareDevicesPageTable from './HardwareDevicesPageTable';
+import useHCPermittedHostDevices from './hooks/useHCPermittedHostDevices';
+import { type HardwareDevicePageRow } from './utils/constants';
 
-const HardwareDevicesPage: FC<any> = (props) => {
+type HardwareDevicesPageTableProps = {
+  devices: HardwareDevicePageRow[];
+  error?: Error;
+  loaded: boolean;
+};
+
+type HardwareDevicesNavPage = Omit<NavPage, 'component'> & {
+  component: (pageProps: HardwareDevicesPageTableProps) => JSX.Element;
+  pageData: HardwareDevicesPageTableProps;
+};
+
+const HardwareDevicesPage: FC<HorizontalNavProps> = (props) => {
   const { t } = useKubevirtTranslation();
   const { hcError, hcLoaded, permittedHostDevices } = useHCPermittedHostDevices();
 
-  const pages = [
+  const pages: HardwareDevicesNavPage[] = [
     {
-      component: (pageProps) => (
+      component: (pageProps: HardwareDevicesPageTableProps) => (
         <PageSection hasBodyWrapper={false}>
           <Bullseye>
             <HardwareDevicesPageTable {...pageProps} />
@@ -29,7 +44,7 @@ const HardwareDevicesPage: FC<any> = (props) => {
         devices: permittedHostDevices?.pciHostDevices?.map(
           (device: V1PciHostDevice & { pciDeviceSelector: string }) => ({
             ...device,
-            selector: device?.pciVendorSelector || device?.pciDeviceSelector,
+            selector: device?.pciVendorSelector ?? device?.pciDeviceSelector,
           }),
         ),
         error: hcError,
@@ -37,7 +52,7 @@ const HardwareDevicesPage: FC<any> = (props) => {
       },
     },
     {
-      component: (pageProps) => (
+      component: (pageProps: HardwareDevicesPageTableProps) => (
         <PageSection hasBodyWrapper={false}>
           <Bullseye>
             <HardwareDevicesPageTable {...pageProps} />
@@ -71,7 +86,7 @@ const HardwareDevicesPage: FC<any> = (props) => {
           />
         </Flex>
       </PageSection>
-      <HorizontalNav {...props} match={props.match} pages={pages} />
+      <HorizontalNav {...props} pages={pages} />
     </div>
   );
 };

--- a/src/utils/components/HardwareDevices/form/DeviceNameSelect.tsx
+++ b/src/utils/components/HardwareDevices/form/DeviceNameSelect.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC, MouseEvent, useState } from 'react';
+import React, { type FC, type MouseEvent, useState } from 'react';
 
-import { V1PermittedHostDevices } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1PermittedHostDevices } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import SelectToggle from '@kubevirt-utils/components/toggles/SelectToggle';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -24,8 +23,8 @@ const DeviceNameSelect: FC<DeviceNameSelectProps> = ({
   const { t } = useKubevirtTranslation();
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
-  const onToggle = () => setIsOpen((prevIsOpen) => !prevIsOpen);
-  const onSelect = (_event: MouseEvent<HTMLSelectElement>, value: string) => {
+  const onToggle = (): void => setIsOpen((prevIsOpen) => !prevIsOpen);
+  const onSelect = (_event: MouseEvent<HTMLSelectElement>, value: string): void => {
     setDeviceName(value);
     setIsOpen(false);
   };

--- a/src/utils/components/HardwareDevices/hooks/useHCPermittedHostDevices.ts
+++ b/src/utils/components/HardwareDevices/hooks/useHCPermittedHostDevices.ts
@@ -1,24 +1,24 @@
-/* eslint-disable */
-import {
-  V1KubeVirtConfiguration,
-  V1PermittedHostDevices,
-} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1PermittedHostDevices } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import useKubevirtHyperconvergeConfiguration from '@kubevirt-utils/hooks/useKubevirtHyperconvergeConfiguration';
 import { getHyperconvergedConfiguration } from '@kubevirt-utils/resources/hyperconverged/selectors';
 
-type UseHCPermittedHostDevicesType = () => {
-  hcError: Error;
+type UseHCPermittedHostDevicesReturn = {
+  hcError: Error | undefined;
   hcLoaded: boolean;
-  permittedHostDevices: V1PermittedHostDevices;
+  permittedHostDevices: V1PermittedHostDevices | undefined;
 };
 
-const useHCPermittedHostDevices: UseHCPermittedHostDevicesType = () => {
-  const { hcConfig, hcError, hcLoaded } = useKubevirtHyperconvergeConfiguration();
+const useHCPermittedHostDevices = (): UseHCPermittedHostDevicesReturn => {
+  const configurationResult = useKubevirtHyperconvergeConfiguration();
+  const permittedHostDevices = getHyperconvergedConfiguration(
+    configurationResult.hcConfig,
+  )?.permittedHostDevices;
 
-  const { permittedHostDevices }: V1KubeVirtConfiguration =
-    getHyperconvergedConfiguration(hcConfig) || {};
-
-  return { hcError, hcLoaded, permittedHostDevices };
+  return {
+    hcError: configurationResult.hcError as Error | undefined,
+    hcLoaded: configurationResult.hcLoaded,
+    permittedHostDevices,
+  };
 };
 
 export default useHCPermittedHostDevices;

--- a/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
+++ b/src/utils/components/HorizontalNavbar/HorizontalNavbar.tsx
@@ -1,27 +1,25 @@
-/* eslint-disable */
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { type FC, useEffect, useMemo, useState } from 'react';
 import { NavLink, Route, Routes, useLocation, useParams } from 'react-router';
 import classNames from 'classnames';
 import { VirtualMachineModel } from 'src/views/dashboard-extensions/utils';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { logVMDetailTabViewed } from '@kubevirt-utils/extensions/telemetry/dashboard';
-import { VMDetailTabTelemetry } from '@kubevirt-utils/extensions/telemetry/utils/types';
+import { type VMDetailTabTelemetry } from '@kubevirt-utils/extensions/telemetry/utils/types';
 import { getName } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { isVMWizardURL } from '@multicluster/urls';
 import { Badge } from '@patternfly/react-core';
 
 import StateHandler from '../StateHandler/StateHandler';
-
 import useDynamicPages from './utils/useDynamicPages';
-import { NavPageKubevirt, trimLastHistoryPath } from './utils/utils';
+import { type NavPageKubevirt, trimLastHistoryPath } from './utils/utils';
 
 import './HorizontalNavbar.scss';
 
 type HorizontalNavbarProps = {
   basePath?: string;
-  error?: any;
+  error?: unknown;
   instanceTypeExpandedSpec?: V1VirtualMachine;
   loaded: boolean;
   pages: NavPageKubevirt[];
@@ -49,6 +47,8 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
 
   const paths = useMemo(() => allPages.map((page) => page.href), [allPages]);
 
+  const [activeItem, setActiveItem] = useState<number | string>();
+
   useEffect(() => {
     const defaultPage = allPages.find(({ href }) => isEmpty(href));
 
@@ -56,12 +56,10 @@ const HorizontalNavbar: FC<HorizontalNavbarProps> = ({
       allPages.find(
         ({ href }) =>
           !isEmpty(href) && location?.pathname?.replace(basePath, '').includes('/' + href),
-      ) || defaultPage;
+      ) ?? defaultPage;
 
     setActiveItem(initialActiveTab?.name?.toLowerCase());
   }, [allPages, location?.pathname, basePath]);
-
-  const [activeItem, setActiveItem] = useState<number | string>();
 
   const RoutesComponents = allPages.map((page) => {
     const Component = page.component;

--- a/src/utils/components/KubevirtFilterToolbar/components/SearchFilter.tsx
+++ b/src/utils/components/KubevirtFilterToolbar/components/SearchFilter.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import React, { forwardRef, useEffect, useMemo, useRef } from 'react';
+import React, { forwardRef, useEffect, useRef } from 'react';
 import classNames from 'classnames';
 
-import { TextInput, TextInputProps } from '@patternfly/react-core';
+import { TextInput, type TextInputProps } from '@patternfly/react-core';
 
 type SearchFilterProps = {
   className?: string;
@@ -12,26 +11,26 @@ type SearchFilterProps = {
 const SearchFilter = forwardRef<HTMLInputElement, SearchFilterProps>((props, ref) => {
   const { className, placeholder, ...otherInputProps } = props;
 
-  const defaultRef = useRef<HTMLInputElement>();
+  const defaultRef = useRef<HTMLInputElement>(null);
 
-  const inputRef = useMemo(() => ref ?? defaultRef, [ref]);
+  const inputRef = ref ?? defaultRef;
 
   useEffect(() => {
-    if (!inputRef || !('current' in inputRef) || !inputRef.current) return;
+    const inputElement = typeof inputRef === 'function' ? null : inputRef.current;
 
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === '/' && inputRef.current !== document.activeElement) {
-        inputRef.current.focus();
+    if (!inputElement) return;
+
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === '/' && !inputElement.matches(':focus')) {
+        inputElement.focus();
         event.preventDefault();
       }
     };
 
-    inputRef.current.addEventListener('keydown', onKeyDown);
+    inputElement.addEventListener('keydown', onKeyDown);
 
-    return () => {
-      if (!inputRef || !('current' in inputRef) || !inputRef.current) return;
-
-      inputRef.current.removeEventListener('keydown', onKeyDown);
+    return (): void => {
+      inputElement.removeEventListener('keydown', onKeyDown);
     };
   }, [inputRef]);
 

--- a/src/utils/components/KubevirtFilterToolbar/hooks/useDocumentListener.ts
+++ b/src/utils/components/KubevirtFilterToolbar/hooks/useDocumentListener.ts
@@ -1,31 +1,44 @@
-/* eslint-disable */
-import { useEffect, useRef, useState } from 'react';
+import {
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
-import { KeyEventMap, KeyEventModes, textInputKeyHandler } from '../constants';
+import { type KeyEventMap, KeyEventModes, textInputKeyHandler } from '../constants';
 
 /**
  * Use this hook for components that require visibility only
  * when the user is actively interacting with the document.
  */
 
+type UseDocumentListenerReturn<T extends HTMLElement> = {
+  ref: RefObject<T | null>;
+  setVisible: Dispatch<SetStateAction<boolean>>;
+  visible: boolean;
+};
+
 export const useDocumentListener = <T extends HTMLElement>(
   keyEventMap: KeyEventMap = textInputKeyHandler,
-) => {
+): UseDocumentListenerReturn<T> => {
   const [visible, setVisible] = useState(true);
   const ref = useRef<T>(null);
 
-  const handleEvent = (e) => {
-    if (!ref?.current?.contains(e.target)) {
+  const handleEvent = (e: MouseEvent): void => {
+    if (!ref?.current?.contains(e.target as Node)) {
       setVisible(false);
     }
   };
 
-  const handleKeyEvents = (e) => {
-    const { nodeName } = e.target;
+  const handleKeyEvents = (e: KeyboardEvent): void => {
+    const target = e.target;
+    const nodeName = target instanceof Element ? target.nodeName : '';
     switch (keyEventMap[e.key]) {
       case KeyEventModes.HIDE:
         setVisible(false);
-        ref.current.blur();
+        ref.current?.blur();
         break;
       case KeyEventModes.FOCUS:
         if (
@@ -34,7 +47,7 @@ export const useDocumentListener = <T extends HTMLElement>(
           nodeName !== 'INPUT' &&
           nodeName !== 'TEXTAREA'
         ) {
-          ref.current.focus();
+          ref.current?.focus();
           e.preventDefault();
         }
         break;
@@ -46,7 +59,7 @@ export const useDocumentListener = <T extends HTMLElement>(
   useEffect(() => {
     document.addEventListener('click', handleEvent, true);
     document.addEventListener('keydown', handleKeyEvents, true);
-    return () => {
+    return (): void => {
       document.removeEventListener('click', handleEvent, true);
       document.removeEventListener('keydown', handleKeyEvents, true);
     };

--- a/src/utils/components/LabelsEditor/LabelsEditor.tsx
+++ b/src/utils/components/LabelsEditor/LabelsEditor.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useState } from 'react';
+import React, { type FC, useState } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
@@ -36,11 +35,11 @@ export const LabelsEditor: FC<LabelsEditorProps> = ({
   const { t } = useKubevirtTranslation();
   const [inputValue, setInputValue] = useState('');
 
-  const onClose = (value: string) => {
+  const onClose = (value: string): void => {
     onSelect(null, value);
   };
 
-  const onAdd = () => {
+  const onAdd = (): void => {
     onSelect(null, inputValue);
     setInputValue('');
   };

--- a/src/utils/components/LazyActionMenu/utils.ts
+++ b/src/utils/components/LazyActionMenu/utils.ts
@@ -1,11 +1,10 @@
-/* eslint-disable */
 import {
-  GroupedMenuOption,
-  MenuOption,
+  type GroupedMenuOption,
+  type MenuOption,
   MenuOptionType,
 } from '@openshift-console/dynamic-plugin-sdk';
 
-export const getMenuOptionType = (option: MenuOption) => {
+export const getMenuOptionType = (option: MenuOption): MenuOptionType => {
   // a grouped menu has children
   const isGroupMenu = Array.isArray((option as GroupedMenuOption).children);
   // a submenu menu has children and submenu property true

--- a/src/utils/components/MetadataLabels/MetadataLabels.tsx
+++ b/src/utils/components/MetadataLabels/MetadataLabels.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { useNavigate } from 'react-router';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 import { Label, LabelGroup } from '@patternfly/react-core';
 
 import { getSearchLabelHREF } from '../Labels/utils';
@@ -19,7 +18,7 @@ const MetadataLabels: FC<MetadataLabelsProps> = ({ cluster, labels, model }) => 
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
 
-  const labelsKeys = Object.keys(labels || {});
+  const labelsKeys = Object.keys(labels ?? {});
 
   if (isEmpty(labelsKeys)) {
     return <div className="pf-v6-u-text-color-subtle">{t('No labels')}</div>;

--- a/src/utils/components/ModalProvider/ModalProvider.tsx
+++ b/src/utils/components/ModalProvider/ModalProvider.tsx
@@ -1,5 +1,11 @@
-/* eslint-disable */
-import React, { ComponentType, createContext, FC, ReactNode, useContext, useState } from 'react';
+import React, {
+  type ComponentType,
+  createContext,
+  type FC,
+  type ReactNode,
+  useContext,
+  useState,
+} from 'react';
 
 import UploadProgressToastProvider from '@kubevirt-utils/hooks/useUploadProgressToast/UploadProgressToastProvider';
 
@@ -42,18 +48,18 @@ export const ModalContext = createContext<ModalContextType>({});
  *  <ExampleModal isOpen={isOpen} onClose={onClose} appendTo={appendTo} />
  * ))
  */
-export const useModal = () => useContext(ModalContext);
+export const useModal = (): ModalContextType => useContext(ModalContext);
 
 export const useModalValue = (): ModalContextType => {
   const [modal, setModal] = useState<ModalComponent>();
   const [isOpen, setIsOpen] = useState(false);
 
-  const createModal = (newModal: ModalComponent) => {
+  const createModal = (newModal: ModalComponent): void => {
     setIsOpen(true);
     setModal(() => newModal);
   };
 
-  const onClose = () => {
+  const onClose = (): void => {
     setIsOpen(false);
     setModal(undefined);
   };

--- a/src/utils/components/MultiSelect/MultiSelect.tsx
+++ b/src/utils/components/MultiSelect/MultiSelect.tsx
@@ -1,11 +1,17 @@
-/* eslint-disable */
-import React, { FC, MouseEvent as ReactMouseEvent, ReactNode, Ref, useState } from 'react';
+import React, {
+  type FC,
+  type MouseEvent as ReactMouseEvent,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+  useState,
+} from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   Label,
   MenuToggle,
-  MenuToggleElement,
+  type MenuToggleElement,
   Select,
   SelectList,
   SelectOption,
@@ -19,7 +25,7 @@ type MultiSelectProps = {
   dataTestId?: string;
   items: MultiSelectOption[];
   selectedItems: string[];
-  setSelectedItems: (items: any[]) => void;
+  setSelectedItems: (items: string[]) => void;
   toggleText?: string;
 };
 
@@ -33,11 +39,14 @@ const MultiSelect: FC<MultiSelectProps> = ({
   const { t } = useKubevirtTranslation();
   const [isOpen, setIsOpen] = useState(false);
 
-  const onToggleClick = () => {
+  const onToggleClick = (): void => {
     setIsOpen(!isOpen);
   };
 
-  const onSelect = (_event: ReactMouseEvent<Element, MouseEvent> | undefined, value: string) => {
+  const onSelect = (
+    _event: ReactMouseEvent<Element, MouseEvent> | undefined,
+    value: string,
+  ): void => {
     if (selectedItems.includes(value)) {
       setSelectedItems(selectedItems.filter((id) => id !== value));
     } else {
@@ -45,7 +54,7 @@ const MultiSelect: FC<MultiSelectProps> = ({
     }
   };
 
-  const toggle = (toggleRef: Ref<MenuToggleElement>) => (
+  const toggle = (toggleRef: Ref<MenuToggleElement>): ReactElement => (
     <MenuToggle
       className="multi-select-toggle"
       data-test={dataTestId}
@@ -53,7 +62,7 @@ const MultiSelect: FC<MultiSelectProps> = ({
       onClick={onToggleClick}
       ref={toggleRef}
     >
-      {toggleText || t('Select items')}
+      {toggleText ?? t('Select items')}
       {selectedItems.length > 0 && (
         <Label className="pf-v6-u-ml-sm">
           {selectedItems?.length === items?.length ? t('All') : selectedItems.length}

--- a/src/utils/components/NetworkIcons/utils.ts
+++ b/src/utils/components/NetworkIcons/utils.ts
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
 import { NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
 
@@ -22,7 +21,7 @@ export const getNetworkInterfaceStateIcon = (
 ): (typeof interfaceStateIcons)[keyof typeof interfaceStateIcons] =>
   interfaceStateIcons[interfaceState] ?? LinkStateNoDataIcon;
 
-export const describeNetworkState = (t: TFunction, state: NetworkInterfaceState) => {
+export const describeNetworkState = (t: TFunction, state: NetworkInterfaceState): string => {
   switch (state) {
     case NetworkInterfaceState.ABSENT:
       return t('Hot-unplugged');

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceLinkState/NetworkInterfaceLinkState.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceLinkState/NetworkInterfaceLinkState.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { Dispatch, FC, MouseEvent, SetStateAction } from 'react';
+import React, { type Dispatch, type FC, type MouseEvent, type SetStateAction } from 'react';
 
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
 import { describeNetworkState } from '@kubevirt-utils/components/NetworkIcons/utils';
@@ -20,7 +19,7 @@ const NetworkInterfaceLinkState: FC<NetworkInterfaceLinkStateProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
 
-  const handleChange = (event: MouseEvent<HTMLSelectElement>, value: string) => {
+  const handleChange = (event: MouseEvent<HTMLSelectElement>, value: string): void => {
     event.preventDefault();
     setLinkState(value);
   };

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceModelSelect.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceModelSelect.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { Dispatch, FC, MouseEvent, SetStateAction } from 'react';
+import React, { type Dispatch, type FC, type MouseEvent, type SetStateAction } from 'react';
 
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -35,7 +34,7 @@ const NetworkInterfaceModelSelect: FC<NetworkInterfaceModelSelectProps> = ({
     },
   };
 
-  const handleChange = (event: MouseEvent<HTMLSelectElement>, value: string) => {
+  const handleChange = (event: MouseEvent<HTMLSelectElement>, value: string): void => {
     event.preventDefault();
     setInterfaceModel(value);
   };
@@ -46,7 +45,10 @@ const NetworkInterfaceModelSelect: FC<NetworkInterfaceModelSelectProps> = ({
         <FormPFSelect
           onSelect={handleChange}
           selected={interfaceModel}
-          selectedLabel={interfaceModelOptions[interfaceModel].name}
+          selectedLabel={
+            Object.values(interfaceModelOptions).find(({ id }) => id === interfaceModel)?.name ??
+            interfaceModel
+          }
           toggleProps={{ isFullWidth: true }}
         >
           {Object.values(interfaceModelOptions)?.map(({ description, id, name }) => (

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/useEditNetworkSelect.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceNetworkSelect/useEditNetworkSelect.ts
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
+import { type Dispatch, type SetStateAction, useEffect, useMemo, useState } from 'react';
 
-import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
+import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 
 import {
   filterNADsForSelect,
@@ -20,6 +19,14 @@ type UseEditNetworkSelectArgs = {
   vmiNamespace: string;
 };
 
+type UseEditNetworkSelectReturn = {
+  filteredNADs: NetworkAttachmentDefinitionKind[];
+  selectedFirstOnLoad: boolean;
+  selectNetworkName: string;
+  selectTypeaheadKey: string;
+  setSelectedFirstOnLoad: Dispatch<SetStateAction<boolean>>;
+};
+
 const useEditNetworkSelect = ({
   currentlyUsedNADFullNames,
   editInitValueNetworkName,
@@ -29,7 +36,7 @@ const useEditNetworkSelect = ({
   networkName,
   setSubmitDisabled,
   vmiNamespace,
-}: UseEditNetworkSelectArgs) => {
+}: UseEditNetworkSelectArgs): UseEditNetworkSelectReturn => {
   const [selectedFirstOnLoad, setSelectedFirstOnLoad] = useState(Boolean(isEditing));
 
   const filteredNADs = useMemo(

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfacePasstSelect/NetworkInterfacePasstHelperPopover.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfacePasstSelect/NetworkInterfacePasstHelperPopover.tsx
@@ -1,14 +1,13 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { Link } from 'react-router';
 
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { VIRTUALIZATION_PATHS } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
-interface NetworkInterfacePasstHelperPopoverProps {
+type NetworkInterfacePasstHelperPopoverProps = {
   namespace?: string;
-}
+};
 
 const NetworkInterfacePasstHelperPopover: FC<NetworkInterfacePasstHelperPopoverProps> = ({
   namespace,

--- a/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceTypeSelect.tsx
+++ b/src/utils/components/NetworkInterfaceModal/components/NetworkInterfaceTypeSelect.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { Dispatch, FC, MouseEvent, SetStateAction } from 'react';
+import React, { type Dispatch, type FC, type MouseEvent, type SetStateAction } from 'react';
 
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
@@ -58,7 +57,7 @@ const NetworkInterfaceTypeSelect: FC<NetworkInterfaceTypeSelectProps> = ({
     },
   };
 
-  const handleChange = (event: MouseEvent<HTMLSelectElement>, value: string) => {
+  const handleChange = (event: MouseEvent<HTMLSelectElement>, value: string): void => {
     event.preventDefault();
     setInterfaceType(value);
   };

--- a/src/utils/components/NetworkInterfaceModal/components/hooks/types.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/hooks/types.ts
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
+import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 
 export enum ExtraNADNamespaces {
-  default = 'default',
+  Default = 'default',
   OPENSHIFT_MULTUS_NS = 'OPENSHIFT_MULTUS_NS',
   OPENSHIFT_SRIOV_NETWORK_OPERATOR_NS = 'OPENSHIFT_SRIOV_NETWORK_OPERATOR_NS',
 }
@@ -14,7 +13,7 @@ export type UseNADsData = (
   cluster?: string,
 ) => {
   loaded: boolean;
-  loadError: string;
+  loadError: Error | undefined;
   nads: NetworkAttachmentDefinitionKind[];
   primaryNADs: NetworkAttachmentDefinitionKind[];
 };

--- a/src/utils/components/NetworkInterfaceModal/components/hooks/useFetchNADs.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/hooks/useFetchNADs.ts
@@ -10,10 +10,8 @@ import { resources, watchResourceIfAllowed } from './utils';
 
 export const useFetchNADs = (
   namespace: string,
-  cluster: string,
-  // K8s watch errors are untyped from the Console SDK.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- propagated to useNADsData consumers
-): [data: NetworkAttachmentDefinitionKind[], loaded: boolean, error: any] => {
+  cluster?: string,
+): [data: NetworkAttachmentDefinitionKind[], loaded: boolean, error: Error | undefined] => {
   const allowMap = useNADListPermissions(cluster);
   const [namespaceData, namespaceLoaded, namespaceLoadError] = useK8sWatchData<
     NetworkAttachmentDefinitionKind[]

--- a/src/utils/components/NetworkInterfaceModal/components/hooks/useNADsData.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/hooks/useNADsData.ts
@@ -1,13 +1,12 @@
-/* eslint-disable */
 import { filterUDNNads } from '@kubevirt-utils/components/NetworkInterfaceModal/components/hooks/utils';
 
-import { UseNADsData } from './types';
+import { type UseNADsData } from './types';
 import { useFetchNADs } from './useFetchNADs';
 
 const useNADsData: UseNADsData = (namespace, cluster) => {
   const [nads, loaded, loadError] = useFetchNADs(namespace, cluster);
 
-  const { primary, regular: availableNADs } = filterUDNNads(nads || []);
+  const { primary, regular: availableNADs } = filterUDNNads(nads);
   return { loaded, loadError, nads: availableNADs, primaryNADs: primary };
 };
 

--- a/src/utils/components/NetworkInterfaceModal/components/hooks/utils.ts
+++ b/src/utils/components/NetworkInterfaceModal/components/hooks/utils.ts
@@ -1,17 +1,15 @@
-/* eslint-disable */
-import partition from 'lodash/partition';
-
 import { NetworkAttachmentDefinitionModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import {
   DEFAULT_NAMESPACE,
   OPENSHIFT_MULTUS_NS,
   OPENSHIFT_SRIOV_NETWORK_OPERATOR_NS,
 } from '@kubevirt-utils/constants/constants';
 import { NADRole, PRIMARY_UDN_KUBEVIRT_BINDING } from '@kubevirt-utils/resources/nad/constants';
+import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import { getLabel, getName } from '@kubevirt-utils/resources/shared';
 import { UDN_LABEL } from '@kubevirt-utils/resources/udn/constants';
-import { WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
+import { type WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
+import { type FleetWatchK8sResource } from '@stolostron/multicluster-sdk';
 
 import { getNADRole } from '../../utils/helpers';
 
@@ -33,27 +31,37 @@ export const resources = {
   },
 };
 
-export const filterUDNNads = (nads: NetworkAttachmentDefinitionKind[]) => {
+type FilterUDNNadsResult = {
+  primary: NetworkAttachmentDefinitionKind[];
+  regular: NetworkAttachmentDefinitionKind[];
+};
+
+const isRegularNad = (nad: NetworkAttachmentDefinitionKind): boolean => {
+  const role = getNADRole(nad);
+  return (
+    role !== NADRole.primary &&
+    (getLabel(nad, UDN_LABEL) === undefined || role === NADRole.secondary)
+  );
+};
+
+export const filterUDNNads = (nads: NetworkAttachmentDefinitionKind[]): FilterUDNNadsResult => {
   const vmAvailableNADs = (nads ?? []).filter(
     (nad) => getName(nad) !== PRIMARY_UDN_KUBEVIRT_BINDING,
   );
 
-  const [regular, primary] = partition(
-    vmAvailableNADs,
-    (nad) =>
-      getNADRole(nad) !== NADRole.primary &&
-      (getLabel(nad, UDN_LABEL) === undefined || getNADRole(nad) === NADRole.secondary),
-  );
+  const regular = vmAvailableNADs.filter(isRegularNad);
+  const primary = vmAvailableNADs.filter((nad) => !isRegularNad(nad));
   return { primary, regular };
 };
+
 export const watchResourceIfAllowed = (
   resourceWatch: WatchK8sResource,
   isAllowed: boolean,
   cluster: string,
-) =>
+): FleetWatchK8sResource | null =>
   isAllowed
-    ? {
-        ...(resourceWatch || {}),
+    ? ({
+        ...(resourceWatch ?? {}),
         cluster,
-      }
+      } as FleetWatchK8sResource)
     : null;

--- a/src/utils/components/NodeSelectorModal/NodeSelectorModal.tsx
+++ b/src/utils/components/NodeSelectorModal/NodeSelectorModal.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 import produce from 'immer';
 
 import { NodeModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1Node } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type IoK8sApiCoreV1Node } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getNodeSelector } from '@kubevirt-utils/resources/vm';
@@ -16,7 +15,7 @@ import NodeCheckerAlert from './components/NodeCheckerAlert';
 import { useIDEntities } from './hooks/useIDEntities';
 import { useNodeLabelQualifier } from './hooks/useNodeLabelQualifier';
 import { isEqualObject, nodeSelectorToIDLabels } from './utils/helpers';
-import { IDLabel } from './utils/types';
+import { type IDLabel } from './utils/types';
 
 type NodeSelectorModalProps = {
   isOpen: boolean;
@@ -45,14 +44,12 @@ const NodeSelectorModal: FC<NodeSelectorModalProps> = ({
 
   const qualifiedNodes = useNodeLabelQualifier(nodes, nodesLoaded, selectorLabels);
 
-  const onSelectorLabelAdd = () => onLabelAdd({ id: null, key: '', value: '' });
+  const onSelectorLabelAdd = (): void => onLabelAdd({ id: null, key: '', value: '' });
 
   const updatedVirtualMachine = useMemo(() => {
     const updatedVM = produce<V1VirtualMachine>(vm, (vmDraft: V1VirtualMachine) => {
       ensurePath(vmDraft, ['spec.template.spec.nodeSelector']);
-      if (!vmDraft.spec.template.spec.nodeSelector) {
-        vmDraft.spec.template.spec.nodeSelector = {};
-      }
+      vmDraft.spec.template.spec.nodeSelector ??= {};
 
       const k8sSelector: { [key: string]: string } = selectorLabels.reduce(
         (acc, { key, value }) => {

--- a/src/utils/components/NodeSelectorModal/components/LabelList.tsx
+++ b/src/utils/components/NodeSelectorModal/components/LabelList.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import React, { FC, ReactNode } from 'react';
+import React, { type FC, type ReactNode } from 'react';
 
 import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { K8sModel } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 import { Button, ButtonVariant, Flex, Grid, GridItem, Stack } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons';
 
@@ -27,8 +26,8 @@ const LabelsList: FC<LabelsListProps> = ({
   withKeyValueTitle,
 }) => {
   const { t } = useKubevirtTranslation();
-  const addRowTxt = addRowText || t('Add label');
-  const emptyStateAddRowTxt = emptyStateAddRowText || t('Add label to specify qualifying nodes');
+  const addRowTxt = addRowText ?? t('Add label');
+  const emptyStateAddRowTxt = emptyStateAddRowText ?? t('Add label to specify qualifying nodes');
 
   return (
     <Stack hasGutter={!isEmpty}>

--- a/src/utils/components/NodeSelectorModal/components/LabelRow.tsx
+++ b/src/utils/components/NodeSelectorModal/components/LabelRow.tsx
@@ -1,17 +1,16 @@
-/* eslint-disable */
-import React, { ClipboardEvent, FC } from 'react';
+import React, { type ClipboardEvent, type FC } from 'react';
 
 import PlainIconButton from '@kubevirt-utils/components/HardwareDevices/form/PlainIconButton';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { FormGroup, GridItem, TextInput } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 
-import { IDLabel } from '../utils/types';
+import { type IDLabel } from '../utils/types';
 
 type LabelRowProps = {
   label: IDLabel;
   onChange: (label: IDLabel) => void;
-  onDelete: (id: any) => void;
+  onDelete: (id: number) => void;
   withKeyValueTitle?: boolean;
 };
 

--- a/src/utils/components/NodeSelectorModal/utils/helpers.ts
+++ b/src/utils/components/NodeSelectorModal/utils/helpers.ts
@@ -1,10 +1,9 @@
-/* eslint-disable */
-import { IDLabel } from './types';
+import { type IDLabel } from './types';
 
 export const nodeSelectorToIDLabels = (nodeSelector: { [key: string]: string }): IDLabel[] =>
   Object.entries(nodeSelector || {}).map(([key, value], id) => ({ id, key, value }));
 
-export const isEqualObject = (object, otherObject) => {
+export const isEqualObject = (object: unknown, otherObject: unknown): boolean => {
   if (object === otherObject) {
     return true;
   }
@@ -13,23 +12,29 @@ export const isEqualObject = (object, otherObject) => {
     return false;
   }
 
-  if (object?.constructor !== otherObject?.constructor) {
+  if (typeof object !== 'object' || typeof otherObject !== 'object') {
     return false;
   }
 
-  if (typeof object !== 'object') {
+  if (object.constructor !== otherObject.constructor) {
     return false;
   }
 
-  const objectKeys = Object.keys(object);
-  const otherObjectKeys = Object.keys(otherObject);
+  const objectRecord = object as Record<string, unknown>;
+  const otherObjectRecord = otherObject as Record<string, unknown>;
+
+  const objectKeys = Object.keys(objectRecord);
+  const otherObjectKeys = Object.keys(otherObjectRecord);
 
   if (objectKeys.length !== otherObjectKeys.length) {
     return false;
   }
 
   for (const key of objectKeys) {
-    if (!otherObjectKeys.includes(key) || !isEqualObject(object[key], otherObject[key])) {
+    if (
+      !otherObjectKeys.includes(key) ||
+      !isEqualObject(objectRecord[key], otherObjectRecord[key])
+    ) {
       return false;
     }
   }

--- a/src/utils/components/OnboardingPopover/hooks/useOnboardingPopover.ts
+++ b/src/utils/components/OnboardingPopover/hooks/useOnboardingPopover.ts
@@ -1,11 +1,10 @@
-/* eslint-disable */
 import { useCallback } from 'react';
 
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
-
 import { useSignals } from '@preact/signals-react/runtime';
+
 import { dismissedPopoverKeysSignal } from '../onboardingSignals';
-import { OnboardingPopoverKey } from '../types';
+import { type OnboardingPopoverKey } from '../types';
 import { getTourStepsSeen, isCoveredByTourSteps, isPopoverVisible } from '../utils';
 
 type UseOnboardingPopoverArgs = {
@@ -41,7 +40,7 @@ const useOnboardingPopover = ({
 
   const dismiss = useCallback(() => {
     dismissedPopoverKeysSignal.value = new Set([...dismissedPopoverKeysSignal.value, popoverKey]);
-    setUserSettings({
+    void setUserSettings({
       ...userSettings,
       onboardingPopoversHidden: { ...onboardingPopoversHidden, [popoverKey]: true },
     });

--- a/src/utils/components/OnboardingPopover/utils.ts
+++ b/src/utils/components/OnboardingPopover/utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import {
   dismissOnboardingPopoverByWelcomeModalSignal,
   runningTourSignal,
@@ -8,7 +7,7 @@ import type { UserSettingsState } from '@kubevirt-utils/hooks/useKubevirtUserSet
 
 import { ONBOARDING_POPOVER_CHAIN } from './constants';
 import { dismissedPopoverKeysSignal } from './onboardingSignals';
-import { OnboardingPopoverKey, OnboardingPopoversHidden } from './types';
+import { type OnboardingPopoverKey, type OnboardingPopoversHidden } from './types';
 
 export const arePredecessorPopoversDismissed = (
   popoverKey: OnboardingPopoverKey,
@@ -33,7 +32,7 @@ export const isCoveredByTourSteps = (
 
 export const getTourStepsSeen = (
   quickStart: { tourStepsSeen?: number[] } | undefined,
-): number[] => [...(quickStart?.tourStepsSeen || []), ...tourStepsSeenSignal.value];
+): number[] => [...(quickStart?.tourStepsSeen ?? []), ...tourStepsSeenSignal.value];
 
 type IsPopoverVisibleArgs = {
   isCoveredByTour: boolean;

--- a/src/utils/components/OwnerReferences/OwnerReferences.tsx
+++ b/src/utils/components/OwnerReferences/OwnerReferences.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -7,8 +6,8 @@ import MulticlusterResourceLink from '@multicluster/components/MulticlusterResou
 import { getCluster } from '@multicluster/helpers/selectors';
 import {
   getGroupVersionKindForResource,
-  K8sResourceCommon,
-  OwnerReference,
+  type K8sResourceCommon,
+  type OwnerReference,
 } from '@openshift-console/dynamic-plugin-sdk';
 
 type OwnerReferencesProps = {
@@ -17,7 +16,7 @@ type OwnerReferencesProps = {
 
 const OwnerReferences: FC<OwnerReferencesProps> = ({ obj }) => {
   const { t } = useKubevirtTranslation();
-  const ownerReferences = (obj?.metadata?.ownerReferences || [])?.map(
+  const ownerReferences = (obj?.metadata?.ownerReferences ?? [])?.map(
     (ownerRef: OwnerReference) => (
       <MulticlusterResourceLink
         cluster={getCluster(obj)}

--- a/src/utils/components/PendingChanges/utils/computeChanges.ts
+++ b/src/utils/components/PendingChanges/utils/computeChanges.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import {
   type V1VirtualMachine,
   type V1VirtualMachineInstance,
@@ -35,7 +34,7 @@ export const checkCPUMemoryChanged = (
   const vmMemory = getMemory(vm);
   const vmCPUSockets = getCPUSockets(vm);
 
-  const vmiMemory = getMemory(vmi) || '';
+  const vmiMemory = getMemory(vmi) ?? '';
   const vmiCPUSockets = getCPUSockets(vmi);
 
   return vmMemory !== vmiMemory || vmCPUSockets !== vmiCPUSockets;

--- a/src/utils/components/PodSelectorModal/SelectorInput.tsx
+++ b/src/utils/components/PodSelectorModal/SelectorInput.tsx
@@ -1,5 +1,12 @@
-/* eslint-disable */
-import React, { ChangeEvent, FC, InputHTMLAttributes, useEffect, useRef, useState } from 'react';
+import React, {
+  type ChangeEvent,
+  type FC,
+  type InputHTMLAttributes,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import TagsInput from 'react-tagsinput';
 import classNames from 'classnames';
 
@@ -7,6 +14,13 @@ import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { Label as PfLabel } from '@patternfly/react-core';
 
 import { cleanSelectorStr, cleanTags, isTagValid } from './selectorUtils';
+
+type RenderTagProps = {
+  getTagDisplayValue: (tagValue: string) => string;
+  key: number;
+  onRemove: (tagKey: number) => void;
+  tag: string;
+};
 
 type SelectorInputProps = {
   autoFocus?: boolean;
@@ -38,12 +52,12 @@ const SelectorInput: FC<SelectorInputProps> = ({
     }
   }, [initialTags, tags]);
 
-  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>): void => {
     const value = e.target.value;
     setInputValue(value);
   };
 
-  const handleChange = (newTagsInput: string[], changed: string[]) => {
+  const handleChange = (newTagsInput: string[], changed: string[]): void => {
     const newTag = changed?.[0];
 
     if (!isTagValid(newTag, isBasic)) {
@@ -68,7 +82,7 @@ const SelectorInput: FC<SelectorInputProps> = ({
     'data-test': 'tags-input',
     id: 'tags-input',
     onChange: handleInputChange,
-    placeholder: isEmpty(tags) ? placeholder || 'app=frontend' : '',
+    placeholder: isEmpty(tags) ? (placeholder ?? 'app=frontend') : '',
     spellCheck: 'false',
     value: inputValue,
     ...inputProps,
@@ -78,7 +92,7 @@ const SelectorInput: FC<SelectorInputProps> = ({
     <div className="pf-v6-c-form-control">
       <tags-input>
         <TagsInput
-          renderTag={({ getTagDisplayValue, key, onRemove, tag }: any) => (
+          renderTag={({ getTagDisplayValue, key, onRemove, tag }: RenderTagProps): ReactNode => (
             <PfLabel
               className={classNames('co-label tag-item-content', labelClassName)}
               data-test={`label=${key}`}

--- a/src/utils/components/PodSelectorModal/types.ts
+++ b/src/utils/components/PodSelectorModal/types.ts
@@ -1,11 +1,10 @@
-/* eslint-disable */
 export type FromRequirementsOptions = {
   basic?: boolean;
   undefinedWhenEmpty?: boolean;
 };
 
-export interface Requirement {
+export type Requirement = {
   key: string;
   operator: string;
   values: string[];
-}
+};

--- a/src/utils/components/RunStrategyModal/RunStrategyModal.tsx
+++ b/src/utils/components/RunStrategyModal/RunStrategyModal.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import React, { FC, MouseEvent, useEffect, useMemo, useState } from 'react';
+import React, { type FC, type MouseEvent, useEffect, useMemo, useState } from 'react';
 
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { RunStrategy } from '@kubevirt-utils/resources/vm/utils/constants';
+import { type RunStrategy } from '@kubevirt-utils/resources/vm/utils/constants';
 import {
   Content,
   ContentVariants,
@@ -14,7 +13,6 @@ import {
 } from '@patternfly/react-core';
 
 import FormPFSelect from '../FormPFSelect/FormPFSelect';
-
 import RunStrategyWarningAlert from './RunStrategyWarningAlert';
 import {
   getRunStrategyDescriptions,
@@ -22,8 +20,8 @@ import {
   getRunStrategyWarningMessage,
   isValidRunStrategy,
   MIXED_HINT_ID,
-  RunStrategyModalProps,
-  RunStrategySelection,
+  type RunStrategyModalProps,
+  type RunStrategySelection,
 } from './utils';
 
 import './RunStrategyModal.scss';
@@ -49,7 +47,7 @@ const RunStrategyModal: FC<RunStrategyModalProps> = ({
     }
   }, [isOpen, initialRunStrategy]);
 
-  const handleChange = (_event: MouseEvent<Element>, value: string) => {
+  const handleChange = (_event: MouseEvent<Element>, value: string): void => {
     if (isValidRunStrategy(value)) {
       setRunStrategy(value);
     }
@@ -97,7 +95,11 @@ const RunStrategyModal: FC<RunStrategyModalProps> = ({
               selectedLabel={runStrategy ? labels[runStrategy] || runStrategy : undefined}
             >
               {Object.entries(labels).map(([key, label]) => (
-                <SelectOption description={descriptions[key]} key={key} value={key}>
+                <SelectOption
+                  description={isValidRunStrategy(key) ? descriptions[key] : undefined}
+                  key={key}
+                  value={key}
+                >
                   {label}
                 </SelectOption>
               ))}

--- a/src/utils/components/RunStrategyModal/RunStrategyWarningAlert.tsx
+++ b/src/utils/components/RunStrategyModal/RunStrategyWarningAlert.tsx
@@ -1,16 +1,15 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { Alert, AlertVariant, StackItem } from '@patternfly/react-core';
 
-import { WarningMessage } from './utils';
+import { type WarningMessage } from './utils';
 
 type RunStrategyWarningAlertProps = {
   warningMessage: null | WarningMessage;
 };
 
 const RunStrategyWarningAlert: FC<RunStrategyWarningAlertProps> = ({ warningMessage }) => {
-  if (!warningMessage || !warningMessage.body) return null;
+  if (!warningMessage?.body) return null;
   return (
     <StackItem>
       <Alert isInline title={warningMessage.title} variant={AlertVariant.warning}>

--- a/src/utils/components/SSHAccess/useSSHCommand.ts
+++ b/src/utils/components/SSHAccess/useSSHCommand.ts
@@ -1,37 +1,35 @@
-/* eslint-disable */
-import { IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { NODE_PORT_ADDRESS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { getCloudInitCredentials } from '@kubevirt-utils/resources/vmi';
 import { getSSHNodePort } from '@kubevirt-utils/utils/utils';
 
 import { useFeatures } from '../../hooks/useFeatures/useFeatures';
-
 import { SERVICE_TYPES } from './constants';
 
-export type useSSHCommandResult = {
+export type UseSSHCommandResult = {
   command: string;
   sshServiceRunning: boolean;
   user: string;
 };
 
-export const isLoadBalancerBonded = (sshService: IoK8sApiCoreV1Service) =>
+export const isLoadBalancerBonded = (sshService: IoK8sApiCoreV1Service): boolean =>
   Boolean(sshService?.status?.loadBalancer?.ingress?.[0]?.ip);
 
 // SSH over NodePort
 const useSSHCommand = (
   vm: V1VirtualMachine,
   sshService: IoK8sApiCoreV1Service,
-): useSSHCommandResult => {
+): UseSSHCommandResult => {
   const { featureEnabled: nodePortAddress } = useFeatures(NODE_PORT_ADDRESS);
 
-  const consoleHostname = () => {
+  const consoleHostname = (): string => {
     if (sshService?.spec?.type === SERVICE_TYPES.LOAD_BALANCER) {
-      return sshService?.status?.loadBalancer?.ingress?.[0]?.ip;
+      return sshService?.status?.loadBalancer?.ingress?.[0]?.ip ?? '';
     }
 
     if (sshService?.spec?.type === SERVICE_TYPES.NODE_PORT) {
-      return nodePortAddress;
+      return nodePortAddress ? String(nodePortAddress) : window.location.hostname;
     }
 
     return window.location.hostname; // fallback to console hostname

--- a/src/utils/components/SSHAccess/utils.ts
+++ b/src/utils/components/SSHAccess/utils.ts
@@ -1,11 +1,16 @@
-/* eslint-disable */
 import produce from 'immer';
 
 import { ServiceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineInstanceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1Pod, IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  type IoK8sApiCoreV1Pod,
+  type IoK8sApiCoreV1Service,
+} from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import {
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getCloudInitCredentials } from '@kubevirt-utils/resources/vmi';
 import { getVMILabelForServiceSelector } from '@kubevirt-utils/resources/vmi/utils/services';
 import {
@@ -16,16 +21,16 @@ import {
 } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { kubevirtK8sCreate, kubevirtK8sDelete, kubevirtK8sUpdate } from '@multicluster/k8sRequests';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 import { buildOwnerReference, getName, getNamespace } from './../../resources/shared';
-import { PORT, SERVICE_TYPES, SSH_PORT } from './constants';
+import { PORT, type SERVICE_TYPES, SSH_PORT } from './constants';
 
 const buildSSHServiceFromVM = (
   vm: V1VirtualMachine,
   type: SERVICE_TYPES,
   pod?: IoK8sApiCoreV1Pod,
-) => {
+): IoK8sApiCoreV1Service => {
   const labelSelector = getVMILabelForServiceSelector(pod, vm);
 
   return {
@@ -43,7 +48,7 @@ const buildSSHServiceFromVM = (
       ports: [
         {
           port: PORT,
-          targetPort: SSH_PORT,
+          targetPort: String(SSH_PORT),
         },
       ],
       selector: {
@@ -54,7 +59,9 @@ const buildSSHServiceFromVM = (
   };
 };
 
-export const deleteSSHService = (sshService: IoK8sApiCoreV1Service) =>
+export const deleteSSHService = (
+  sshService: IoK8sApiCoreV1Service,
+): ReturnType<typeof kubevirtK8sDelete<IoK8sApiCoreV1Service>> =>
   kubevirtK8sDelete<IoK8sApiCoreV1Service>({
     model: ServiceModel,
     name: sshService?.metadata?.name,
@@ -66,7 +73,7 @@ export const addSSHSelectorLabelToVM = async (
   vm: V1VirtualMachine,
   vmi: V1VirtualMachineInstance,
   labelSelector: { labelKey: string; labelValue: string },
-) => {
+): Promise<K8sResourceCommon> => {
   const { labelKey, labelValue } = labelSelector;
 
   const vmWithLabel = produce(vm, (draftVM) => {
@@ -115,7 +122,7 @@ export const createSSHService = async (
   });
 };
 
-export const getConsoleVirtctlCommand = (vm: V1VirtualMachine, identityFlag?: string) => {
+export const getConsoleVirtctlCommand = (vm: V1VirtualMachine, identityFlag?: string): string => {
   const [vmName, vmNamespace, userName] = [
     getName(vm),
     getNamespace(vm),

--- a/src/utils/components/SearchItem/useIsHighlighted.ts
+++ b/src/utils/components/SearchItem/useIsHighlighted.ts
@@ -1,11 +1,10 @@
-/* eslint-disable */
 import { useLocation } from 'react-router';
 
-export const idIsHighlighted = (id: string, hash: string) => {
+export const idIsHighlighted = (id: string, hash: string): boolean => {
   return hash?.toLowerCase().endsWith(id?.toLowerCase());
 };
 
-export const useIsHighlighted = (id: string) => {
+export const useIsHighlighted = (id: string): boolean => {
   const location = useLocation();
 
   return idIsHighlighted(id, location?.hash);

--- a/src/utils/components/SelectSnapshot/SelectSnapshot.tsx
+++ b/src/utils/components/SelectSnapshot/SelectSnapshot.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useCallback, useEffect, useMemo } from 'react';
+import React, { type FC, useCallback, useEffect, useMemo } from 'react';
 
 import {
   modelToGroupVersionKind,
@@ -14,7 +13,6 @@ import { initialBootableVolumeState } from '../AddBootableVolumeModal/consts';
 import ErrorAlert from '../ErrorAlert/ErrorAlert';
 import InlineFilterSelect from '../FilterSelect/InlineFilterSelect';
 import Loading from '../Loading/Loading';
-
 import useSnapshots from './useSnapshots';
 
 import './select-snapshot.scss';
@@ -37,12 +35,14 @@ const SelectSnapshot: FC<SelectSnapshotProps> = ({
   snapshotNamespaceSelected,
 }) => {
   const { t } = useKubevirtTranslation();
-  const { error, projectsLoaded, projectsWithSnapshots, snapshots, snapshotsLoaded } =
-    useSnapshots(snapshotNamespaceSelected, cluster);
+  const { error, projectsLoaded, projectsWithSnapshots, snapshots, snapshotsLoaded } = useSnapshots(
+    snapshotNamespaceSelected,
+    cluster,
+  );
 
   const onSelectProject = useCallback(
     (newProject) => {
-      selectSnapshotNamespace && selectSnapshotNamespace(newProject);
+      selectSnapshotNamespace?.(newProject);
       selectSnapshotName(undefined);
       setDiskSize?.(initialBootableVolumeState.size);
     },
@@ -62,7 +62,10 @@ const SelectSnapshot: FC<SelectSnapshotProps> = ({
   }, [snapshotNameSelected, snapshotsLoaded, getSnapshotSize, setDiskSize]);
 
   const snapshotNames = useMemo(
-    () => snapshots?.map((snapshot) => getName(snapshot))?.sort((a, b) => a?.localeCompare(b)),
+    () =>
+      snapshots
+        ?.map((snapshot) => getName(snapshot))
+        ?.sort((a, b) => (a ?? '').localeCompare(b ?? '')),
     [snapshots],
   );
 

--- a/src/utils/components/SelectSnapshot/useSnapshots.ts
+++ b/src/utils/components/SelectSnapshot/useSnapshots.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import {
@@ -8,7 +7,7 @@ import {
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 
-import { VolumeSnapshotKind } from './types';
+import { type VolumeSnapshotKind } from './types';
 
 type ProjectSnapshotCount = {
   count: number;
@@ -39,7 +38,7 @@ const useSnapshots = (projectSelected: string, cluster?: string): UseSnapshotsRe
       (acc, snapshot) => {
         const ns = getNamespace(snapshot);
         if (ns) {
-          acc[ns] = (acc[ns] || 0) + 1;
+          acc[ns] = (acc[ns] ?? 0) + 1;
         }
         return acc;
       },
@@ -55,7 +54,7 @@ const useSnapshots = (projectSelected: string, cluster?: string): UseSnapshotsRe
     () =>
       (allSnapshots || [])
         .filter((snapshot) => getNamespace(snapshot) === projectSelected)
-        .sort((a, b) => getName(a)?.localeCompare(getName(b))),
+        .sort((a, b) => (getName(a) ?? '').localeCompare(getName(b) ?? '')),
     [allSnapshots, projectSelected],
   );
 

--- a/src/utils/components/ServicesList/useServiceActionsProvider.ts
+++ b/src/utils/components/ServicesList/useServiceActionsProvider.ts
@@ -1,22 +1,29 @@
-/* eslint-disable */
-import { useMemo } from 'react';
+import { createElement, useMemo } from 'react';
 import { useNavigate } from 'react-router';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToRef, ServiceModel } from '@kubevirt-utils/models';
 import { asAccessReview, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import {
-  Action,
-  ExtensionHook,
-  K8sResourceKind,
+  type Action,
+  type ExtensionHook,
+  type K8sResourceKind,
+  type OverlayComponent,
   useAnnotationsModal,
   useDeleteModal,
   useK8sModel,
   useLabelsModal,
-  useModal,
+  useOverlay,
 } from '@openshift-console/dynamic-plugin-sdk';
 
-import PodSelectorModal, { PodSelectorModalProps } from '../PodSelectorModal/PodSelectorModal';
+import PodSelectorModal, { type PodSelectorModalProps } from '../PodSelectorModal/PodSelectorModal';
+
+type PodSelectorOverlayProps = Omit<PodSelectorModalProps, 'closeModal'>;
+
+const PodSelectorOverlay: OverlayComponent<PodSelectorOverlayProps> = ({
+  closeOverlay,
+  ...props
+}) => createElement(PodSelectorModal, { ...props, closeModal: closeOverlay });
 
 const useServiceActionsProvider: ExtensionHook<Action[], K8sResourceKind> = (obj) => {
   const { t } = useKubevirtTranslation();
@@ -30,14 +37,14 @@ const useServiceActionsProvider: ExtensionHook<Action[], K8sResourceKind> = (obj
 
   const objNamespace = getNamespace(obj);
   const objName = getName(obj);
-  const createModal = useModal();
+  const launchOverlay = useOverlay();
 
   const actions = useMemo(
     () => [
       {
         accessReview: asAccessReview(ServiceModel, obj, 'update'),
-        cta: () =>
-          createModal<PodSelectorModalProps>(PodSelectorModal, {
+        cta: (): void =>
+          launchOverlay(PodSelectorOverlay, {
             model: ServiceModel,
             resource: obj,
           }),
@@ -58,7 +65,9 @@ const useServiceActionsProvider: ExtensionHook<Action[], K8sResourceKind> = (obj
       },
       {
         accessReview: asAccessReview(ServiceModel, obj, 'update'),
-        cta: () => navigate(`/k8s/ns/${objNamespace}/${serviceModelRef}/${objName}/yaml`),
+        cta: (): void => {
+          void navigate(`/k8s/ns/${objNamespace}/${serviceModelRef}/${objName}/yaml`);
+        },
         id: 'edit-services',
         label: t('Edit Service'),
       },
@@ -70,7 +79,7 @@ const useServiceActionsProvider: ExtensionHook<Action[], K8sResourceKind> = (obj
       },
     ],
     [
-      createModal,
+      launchOverlay,
       launchAnnotationsModal,
       launchDeleteModal,
       launchLabelsModal,

--- a/src/utils/components/SidebarEditor/utils.ts
+++ b/src/utils/components/SidebarEditor/utils.ts
@@ -1,7 +1,17 @@
-/* eslint-disable */
 export type LineRange = { end: number; start: number };
 
-const getLineFromPath = (resourceYAML: string, path): LineRange => {
+type EditorSelection = {
+  endColumn: number;
+  endLineNumber: number;
+  positionColumn: number;
+  positionLineNumber: number;
+  selectionStartColumn: number;
+  selectionStartLineNumber: number;
+  startColumn: number;
+  startLineNumber: number;
+};
+
+const getLineFromPath = (resourceYAML: string, path: string): LineRange | undefined => {
   const yamlLines = resourceYAML.split('\n');
   const range = { end: yamlLines.length - 1, start: 0 };
 
@@ -11,7 +21,7 @@ const getLineFromPath = (resourceYAML: string, path): LineRange => {
     const property = properties[propertyDepth];
 
     // at every iteration, go one level deeper, remove initial indentation for that range.
-    const replaceIndentationRegex = new RegExp(`^[ ]{${2 * parseInt(propertyDepth)}}`);
+    const replaceIndentationRegex = new RegExp(`^[ ]{${2 * parseInt(propertyDepth, 10)}}`);
 
     const rangeLines = yamlLines
       .slice(range.start + 1, range.end)
@@ -47,9 +57,9 @@ export const getLinesToHighlight = (
 ): LineRange[] =>
   pathsToHighlight
     .map((path) => getLineFromPath(resourceYAML, path))
-    .filter((highlightLine) => !!highlightLine);
+    .filter((highlightLine): highlightLine is LineRange => highlightLine !== undefined);
 
-export const createSelection = (range: LineRange) => ({
+export const createSelection = (range: LineRange): EditorSelection => ({
   endColumn: 0,
   endLineNumber: range.end + 1,
   positionColumn: 0,

--- a/src/utils/components/SimpleCopyButton/SimpleCopyButton.tsx
+++ b/src/utils/components/SimpleCopyButton/SimpleCopyButton.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { ClipboardEvent, FC, MouseEventHandler, useState } from 'react';
+import React, { type ClipboardEvent, type FC, type MouseEventHandler, useState } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Button, clipboardCopyFunc, Tooltip } from '@patternfly/react-core';
@@ -15,7 +14,7 @@ const SimpleCopyButton: FC<SimpleCopyButtonProps> = ({ textToCopy }) => {
   const { t } = useKubevirtTranslation();
   const [copiedState, setCopiedState] = useState<boolean>(false);
 
-  const handleClick = (event: ClipboardEvent<HTMLInputElement>) => {
+  const handleClick = (event: ClipboardEvent<HTMLInputElement>): void => {
     clipboardCopyFunc(event, textToCopy);
     setCopiedState(true);
   };

--- a/src/utils/components/SnapshotModal/hooks/useSuffixValidation.ts
+++ b/src/utils/components/SnapshotModal/hooks/useSuffixValidation.ts
@@ -1,7 +1,6 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
   getMaxSuffixLength,
   getMaxVMNameLength,
@@ -9,13 +8,24 @@ import {
 import { getLongestNameLength } from '@kubevirt-utils/resources/shared';
 import { isDNS1123Label } from '@kubevirt-utils/utils/validation';
 
-export const useSuffixValidation = (vms: V1VirtualMachine[], snapshotSuffix: string) => {
+type UseSuffixValidationResult = {
+  isSuffixValid: boolean;
+  isSuffixValidDNS1123Label: boolean;
+  isSuffixValidLength: boolean;
+  maxSuffixLength: number;
+  maxVMNameLength: number;
+};
+
+export const useSuffixValidation = (
+  vms: V1VirtualMachine[],
+  snapshotSuffix: string,
+): UseSuffixValidationResult => {
   const maxSuffixLength = useMemo(() => getMaxSuffixLength(getLongestNameLength(vms)), [vms]);
   const maxVMNameLength = getMaxVMNameLength(snapshotSuffix.length);
 
   const isSuffixValidLength = snapshotSuffix.length <= maxSuffixLength;
   const isSuffixValidDNS1123Label = useMemo(() => isDNS1123Label(snapshotSuffix), [snapshotSuffix]);
-  const isSuffixValid = snapshotSuffix && isSuffixValidLength && isSuffixValidDNS1123Label;
+  const isSuffixValid = Boolean(snapshotSuffix && isSuffixValidLength && isSuffixValidDNS1123Label);
 
   return {
     isSuffixValid,

--- a/src/utils/components/SnapshotModal/utils/utils.ts
+++ b/src/utils/components/SnapshotModal/utils/utils.ts
@@ -1,28 +1,30 @@
-/* eslint-disable */
 import { format } from 'date-fns';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  type V1beta1VirtualMachineSnapshot,
+  type V1VirtualMachine,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { buildOwnerReference, getName } from '@kubevirt-utils/resources/shared';
 import { MAX_K8S_NAME_LENGTH } from '@kubevirt-utils/utils/constants';
-import { deadlineUnits } from '@virtualmachines/details/tabs/snapshots/utils/consts';
+import { type deadlineUnits } from '@virtualmachines/details/tabs/snapshots/utils/consts';
 import { getEmptyVMSnapshotResource } from '@virtualmachines/details/tabs/snapshots/utils/helpers';
 
 const DEFAULT_SUFFIX_LENGTH = 'snapshot-yyyyMMdd-kkmmss'.length as 24;
 const MAX_REST_LENGTH = (MAX_K8S_NAME_LENGTH - DEFAULT_SUFFIX_LENGTH) as 39;
 const RANDOM_CHARS_LENGTH = 8; // -{random 6 characters}-
 
-export const generateSnapshotName = (vm: V1VirtualMachine) => {
+export const generateSnapshotName = (vm: V1VirtualMachine): string => {
   const vmName = getName(vm);
   return `${vmName.substring(0, MAX_REST_LENGTH - 1)}-${generateSnapshotSuffix()}`;
 };
 
-export const generateSnapshotSuffix = () => {
+export const generateSnapshotSuffix = (): string => {
   const date = new Date();
   const formattedDate = format(date, 'yyyyMMdd-kkmmss');
   return `snapshot-${formattedDate}`;
 };
 
-export const getMaxSuffixLength = (vmNameLength: number) => {
+export const getMaxSuffixLength = (vmNameLength: number): number => {
   const restLength = vmNameLength + RANDOM_CHARS_LENGTH;
 
   if (restLength > MAX_REST_LENGTH) {
@@ -32,7 +34,7 @@ export const getMaxSuffixLength = (vmNameLength: number) => {
   return MAX_K8S_NAME_LENGTH - restLength;
 };
 
-export const getMaxVMNameLength = (suffixLength: number) => {
+export const getMaxVMNameLength = (suffixLength: number): number => {
   return MAX_K8S_NAME_LENGTH - suffixLength - RANDOM_CHARS_LENGTH;
 };
 
@@ -42,7 +44,7 @@ export const generateSnapshot = (
   description: string,
   deadline: string,
   deadlineUnit: deadlineUnits,
-) => {
+): V1beta1VirtualMachineSnapshot => {
   const snapshot = getEmptyVMSnapshotResource(vm);
   const ownerReference = buildOwnerReference(vm, { blockOwnerDeletion: false });
 

--- a/src/utils/components/StateHandler/StateHandler.tsx
+++ b/src/utils/components/StateHandler/StateHandler.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, ReactNode } from 'react';
+import React, { type FC, type ReactNode } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
@@ -14,17 +13,23 @@ import {
 
 import AccessDenied from '../AccessDenied/AccessDenied';
 import Loading from '../Loading/Loading';
-
 import ListSkeleton from './ListSkeleton';
+
+type StateHandlerError = {
+  message?: string;
+  response?: { status?: number };
+};
 
 type StateHandlerProps = {
   children?: ReactNode;
-  error?: any;
+  error?: StateHandlerError;
   hasData: boolean;
   loaded: boolean;
   showSkeletonLoading?: boolean;
   withBullseye?: boolean;
 };
+
+const getErrorMessage = (error: StateHandlerError): string => error.message ?? '';
 
 const StateHandler: FC<StateHandlerProps> = ({
   children,
@@ -37,10 +42,10 @@ const StateHandler: FC<StateHandlerProps> = ({
   const { t } = useKubevirtTranslation();
 
   if (error) {
-    const status = error?.response?.status;
+    const status = error.response?.status;
 
     if (status === 403) {
-      return <AccessDenied message={error.message} />;
+      return <AccessDenied message={getErrorMessage(error)} />;
     }
 
     if (status === 404) {
@@ -58,7 +63,7 @@ const StateHandler: FC<StateHandlerProps> = ({
     }
     return (
       <Alert isInline title={t('Error')} variant={AlertVariant.danger}>
-        {error?.message}
+        {getErrorMessage(error)}
       </Alert>
     );
   }

--- a/src/utils/components/SyncedEditor/components/EditorToggle.tsx
+++ b/src/utils/components/SyncedEditor/components/EditorToggle.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, FormEvent } from 'react';
+import React, { type FC, type FormEvent } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Flex, Radio } from '@patternfly/react-core';
@@ -16,7 +15,7 @@ type EditorToggleProps = {
 export const EditorToggle: FC<EditorToggleProps> = ({ onChange, value }) => {
   const { t } = useKubevirtTranslation();
 
-  const handleChange = (event: FormEvent<HTMLInputElement>) => {
+  const handleChange = (event: FormEvent<HTMLInputElement>): void => {
     onChange(event?.currentTarget?.value as EditorType);
   };
 

--- a/src/utils/components/SyncedEditor/utils/constants.ts
+++ b/src/utils/components/SyncedEditor/utils/constants.ts
@@ -1,9 +1,8 @@
-/* eslint-disable */
 const YAML_KEY_ORDER = ['apiVersion', 'kind', 'metadata', 'spec', 'status'];
 
 export const YAML_TO_JS_OPTIONS = {
   skipInvalid: true,
-  sortKeys: (a: string, b: string) => YAML_KEY_ORDER.indexOf(a) - YAML_KEY_ORDER.indexOf(b),
+  sortKeys: (a: string, b: string): number => YAML_KEY_ORDER.indexOf(a) - YAML_KEY_ORDER.indexOf(b),
 };
 
 export const YAML_PATH_SUFFIX = '/yaml';

--- a/src/utils/components/SysprepModal/SelectSysprep.tsx
+++ b/src/utils/components/SysprepModal/SelectSysprep.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { ConfigMapModel, modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -8,7 +7,6 @@ import { Alert, AlertVariant, Button, ButtonVariant } from '@patternfly/react-co
 
 import InlineFilterSelect from '../FilterSelect/InlineFilterSelect';
 import Loading from '../Loading/Loading';
-
 import useSysprepConfigMaps from './hooks/useConfigMaps';
 
 type SelectSysprepProps = {

--- a/src/utils/components/SysprepModal/SysprepFileField.tsx
+++ b/src/utils/components/SysprepModal/SysprepFileField.tsx
@@ -1,12 +1,10 @@
-/* eslint-disable */
-import React, { ChangeEvent, FC, useEffect, useState } from 'react';
-import { XMLValidator } from 'fast-xml-parser';
+import React, { type ChangeEvent, type FC, useEffect, useState } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   Content,
   ContentVariants,
-  DropEvent,
+  type DropEvent,
   FileUpload,
   ValidatedOptions,
 } from '@patternfly/react-core';
@@ -24,6 +22,12 @@ type SysprepFileFieldProps = {
   value?: string;
 };
 
+const isValidXml = (xml: string): boolean => {
+  const doc = new DOMParser().parseFromString(xml, 'application/xml');
+
+  return doc.querySelector('parsererror') === null;
+};
+
 const SysprepFileField: FC<SysprepFileFieldProps> = ({ id, onChange, value }) => {
   const { t } = useKubevirtTranslation();
   const [data, setData] = useState<SysprepFile>({
@@ -33,13 +37,10 @@ const SysprepFileField: FC<SysprepFileFieldProps> = ({ id, onChange, value }) =>
     value,
   });
 
-  const onFieldChange = (newValue: string) => {
+  const onFieldChange = (newValue: string): void => {
     setData((currentSysprepFile) => ({
       ...currentSysprepFile,
-      validated:
-        XMLValidator.validate(newValue) === true
-          ? ValidatedOptions.default
-          : ValidatedOptions.error,
+      validated: isValidXml(newValue) ? ValidatedOptions.default : ValidatedOptions.error,
       value: newValue,
     }));
   };

--- a/src/utils/components/SysprepModal/hooks/useConfigMaps.ts
+++ b/src/utils/components/SysprepModal/hooks/useConfigMaps.ts
@@ -1,25 +1,26 @@
-/* eslint-disable */
 import { ConfigMapModel, modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
-import { WatchK8sResult } from '@openshift-console/dynamic-plugin-sdk';
 
 import { AUTOUNATTEND, UNATTEND } from '../sysprep-utils';
 
-const checkEqualCaseInsensitive = (a: string, b: string) =>
+const checkEqualCaseInsensitive = (a: string, b: string): boolean =>
   a.localeCompare(b, 'en', { sensitivity: 'base' }) === 0; // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/localeCompare
 
-const useSysprepConfigMaps = (
-  namespace: string,
-  cluster?: string,
-): WatchK8sResult<IoK8sApiCoreV1ConfigMap[]> => {
+type UseSysprepConfigMapsResult = [
+  IoK8sApiCoreV1ConfigMap[] | undefined,
+  boolean,
+  Error | undefined,
+];
+
+const useSysprepConfigMaps = (namespace: string, cluster?: string): UseSysprepConfigMapsResult => {
   const clusterParam = useClusterParam();
   const [configmaps, configmapsLoaded, configmapsError] = useK8sWatchData<
     IoK8sApiCoreV1ConfigMap[]
   >({
-    cluster: cluster || clusterParam,
+    cluster: cluster ?? clusterParam,
     groupVersionKind: modelToGroupVersionKind(ConfigMapModel),
     isList: true,
     namespace,

--- a/src/utils/components/SysprepModal/sysprep-utils.ts
+++ b/src/utils/components/SysprepModal/sysprep-utils.ts
@@ -1,12 +1,14 @@
-/* eslint-disable */
 import { ConfigMapModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1Disk, V1VirtualMachine, V1Volume } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import {
+  type V1Disk,
+  type V1VirtualMachine,
+  type V1Volume,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getDisks, getVolumes } from '@kubevirt-utils/resources/vm';
 import { generatePrettyName } from '@kubevirt-utils/utils/utils';
 
 import { InterfaceTypes } from '../DiskModal/utils/types';
-
 import { SYSPREP } from './consts';
 
 export const AUTOUNATTEND = 'autounattend.xml';
@@ -24,17 +26,17 @@ export const sysprepVolume = (sysprepName: string): V1Volume => ({
   },
 });
 
-export const addSysprepConfig = (vm: V1VirtualMachine, newSysprepName: string) => {
+export const addSysprepConfig = (vm: V1VirtualMachine, newSysprepName: string): void => {
   getVolumes(vm).push({
     name: SYSPREP,
     sysprep: {
       configMap: { name: newSysprepName },
     },
   });
-  (getDisks(vm) || []).push(sysprepDisk());
+  (getDisks(vm) ?? []).push(sysprepDisk());
 };
 
-export const removeSysprepConfig = (vm: V1VirtualMachine, sysprepVolumeName: string) => {
+export const removeSysprepConfig = (vm: V1VirtualMachine, sysprepVolumeName: string): void => {
   vm.spec.template.spec.volumes = getVolumes(vm).filter(
     (volume) => sysprepVolumeName !== volume.name,
   );
@@ -43,7 +45,7 @@ export const removeSysprepConfig = (vm: V1VirtualMachine, sysprepVolumeName: str
   );
 };
 
-export const generateSysprepConfigMapName = () => generatePrettyName('sysprep-config');
+export const generateSysprepConfigMapName = (): string => generatePrettyName('sysprep-config');
 
 type GenerateNewSysprepConfig = {
   data: IoK8sApiCoreV1ConfigMap['data'];
@@ -58,8 +60,9 @@ export const generateNewSysprepConfig = ({
   data,
   kind: ConfigMapModel.kind,
   metadata: {
-    name: sysprepName || generateSysprepConfigMapName(),
+    name: sysprepName ?? generateSysprepConfigMapName(),
   },
 });
 
-export const getSysprepConfigMapName = (volume: V1Volume) => volume?.sysprep?.configMap?.name;
+export const getSysprepConfigMapName = (volume: V1Volume): string | undefined =>
+  volume?.sysprep?.configMap?.name;

--- a/src/utils/components/TabModal/BackgroundOperationAlert.tsx
+++ b/src/utils/components/TabModal/BackgroundOperationAlert.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Alert, AlertVariant } from '@patternfly/react-core';
@@ -22,7 +21,7 @@ const BackgroundOperationAlert: FC<BackgroundOperationAlertProps> = ({
   return (
     <Alert
       title={
-        description || t('You can close this dialog — the process will continue in the background.')
+        description ?? t('You can close this dialog — the process will continue in the background.')
       }
       isInline
       variant={AlertVariant.info}

--- a/src/utils/components/TemplatesFilter/hooks/useFilterDefaultTemplates.ts
+++ b/src/utils/components/TemplatesFilter/hooks/useFilterDefaultTemplates.ts
@@ -1,14 +1,13 @@
-/* eslint-disable */
 import { useEffect, useRef } from 'react';
 
-import { UniversalFilter } from '@kubevirt-utils/hooks/useUniversalFilter/useUniversalFilter';
+import { type UniversalFilter } from '@kubevirt-utils/hooks/useUniversalFilter/useUniversalFilter';
 import { TemplateFilterType } from '@templates/list/filters/types';
 import { TEMPLATE_SCOPE_ID } from '@templates/list/filters/useScopeFilter';
 
 const useFilterDefaultTemplates = (
   shouldApplyFilter: boolean,
   universalFilter: UniversalFilter,
-) => {
+): void => {
   const defaultAppliedRef = useRef(false);
   const { hasQueryKey, setValue } = universalFilter;
 

--- a/src/utils/components/TolerationsModal/TolerationEditRow.tsx
+++ b/src/utils/components/TolerationsModal/TolerationEditRow.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { K8sIoApiCoreV1TolerationEffectEnum } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -13,12 +12,12 @@ import {
 } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 
-import { TolerationLabel } from './utils/constants';
+import { type TolerationLabel } from './utils/constants';
 
 type TolerationEditRowProps = {
   label: TolerationLabel;
   onChange: (label: TolerationLabel) => void;
-  onDelete: (id: any) => void;
+  onDelete: (id: number) => void;
 };
 
 const TolerationEditRow: FC<TolerationEditRowProps> = ({ label, onChange, onDelete }) => {

--- a/src/utils/components/TolerationsModal/TolerationsModal.tsx
+++ b/src/utils/components/TolerationsModal/TolerationsModal.tsx
@@ -1,15 +1,14 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 import produce from 'immer';
 
 import { NodeModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1Node } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1Node } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import {
-  K8sIoApiCoreV1Toleration,
+  type K8sIoApiCoreV1Toleration,
   K8sIoApiCoreV1TolerationEffectEnum,
   K8sIoApiCoreV1TolerationOperatorEnum,
-  V1VirtualMachine,
-  V1VirtualMachineInstance,
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import LabelsList from '@kubevirt-utils/components/NodeSelectorModal/components/LabelList';
 import NodeCheckerAlert from '@kubevirt-utils/components/NodeSelectorModal/components/NodeCheckerAlert';
@@ -21,11 +20,11 @@ import { getTolerations } from '@kubevirt-utils/resources/vm';
 import { ensurePath, isEmpty } from '@kubevirt-utils/utils/utils';
 import { ModalVariant, Stack, StackItem } from '@patternfly/react-core';
 
-import { TolerationLabel } from './utils/constants';
-import { getNodeTaintQualifier } from './utils/helpers';
 import TolerationEditRow from './TolerationEditRow';
 import TolerationListHeaders from './TolerationListHeaders';
 import TolerationModalDescriptionText from './TolerationModalDescriptionText';
+import { type TolerationLabel } from './utils/constants';
+import { getNodeTaintQualifier } from './utils/helpers';
 
 type TolerationsModalProps = {
   isOpen: boolean;
@@ -53,14 +52,14 @@ const TolerationsModal: FC<TolerationsModalProps> = ({
     onEntityChange: onTolerationChange,
     onEntityDelete: onTolerationDelete,
   } = useIDEntities<TolerationLabel>(
-    (getTolerations(vm) || []).map((toleration, id) => ({ ...toleration, id })),
+    (getTolerations(vm) ?? []).map((toleration, id) => ({ ...toleration, id })),
   );
 
   const tolerationLabelsEmpty = tolerationsLabels?.length === 0;
 
   const qualifiedNodes = getNodeTaintQualifier(nodes, nodesLoaded, tolerationsLabels);
 
-  const onSelectorLabelAdd = () =>
+  const onSelectorLabelAdd = (): void =>
     onTolerationAdd({
       effect: K8sIoApiCoreV1TolerationEffectEnum.NoSchedule,
       id: null,

--- a/src/utils/components/TolerationsModal/utils/helpers.ts
+++ b/src/utils/components/TolerationsModal/utils/helpers.ts
@@ -1,18 +1,17 @@
-/* eslint-disable */
-import { IoK8sApiCoreV1Node } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1Node } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
-import { TolerationLabel } from '../utils/constants';
+import { type TolerationLabel } from '../utils/constants';
 
 export const getNodeTaintQualifier = <T extends TolerationLabel = TolerationLabel>(
   nodes: IoK8sApiCoreV1Node[],
   isNodesLoaded: boolean,
   constraints: T[],
-): IoK8sApiCoreV1Node[] => {
+): IoK8sApiCoreV1Node[] | undefined => {
   const filteredConstraints = constraints.filter(Boolean);
   if (!isEmpty(filteredConstraints) && isNodesLoaded) {
-    const suitableNodes = (nodes || [])?.filter((node) => {
-      const nodeTaints = node?.spec?.taints || [];
+    const suitableNodes = (nodes ?? [])?.filter((node) => {
+      const nodeTaints = node?.spec?.taints ?? [];
       // we check for every constraint if the node has the required taint
       const isConstraintsExistInNodeTaints = filteredConstraints.every(({ effect, key, value }) =>
         nodeTaints.some((taint) => {

--- a/src/utils/components/VMNameValidationHelperText/utils/utils.ts
+++ b/src/utils/components/VMNameValidationHelperText/utils/utils.ts
@@ -1,11 +1,10 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
 import { MAX_K8S_NAME_LENGTH } from '@kubevirt-utils/utils/constants';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { ValidatedOptions } from '@patternfly/react-core';
 
-export const vmNameLengthExceedsMaxLength = (vmName: string) =>
+export const vmNameLengthExceedsMaxLength = (vmName: string): boolean =>
   vmName?.length > MAX_K8S_NAME_LENGTH;
 
 export const isValidVMName = (vmName: string): boolean => {

--- a/src/utils/components/WithPermissionTooltip/WithPermissionTooltip.tsx
+++ b/src/utils/components/WithPermissionTooltip/WithPermissionTooltip.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, ReactElement, ReactNode } from 'react';
+import React, { type FC, type ReactElement, type ReactNode } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getNoPermissionTooltipContent } from '@kubevirt-utils/utils/utils';
@@ -22,7 +21,7 @@ const WithPermissionTooltip: FC<WithPermissionTooltipProps> = ({
 
   return (
     <HidableTooltip
-      content={title || getNoPermissionTooltipContent(t)}
+      content={title ?? getNoPermissionTooltipContent(t)}
       hidden={allowed}
       position={TooltipPosition.right}
     >

--- a/src/utils/components/WorkloadProfileModal/WorkloadProfileModal.tsx
+++ b/src/utils/components/WorkloadProfileModal/WorkloadProfileModal.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, MouseEvent, useState } from 'react';
+import React, { type FC, type MouseEvent, useState } from 'react';
 
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -8,7 +7,7 @@ import {
   WORKLOADS_DESCRIPTIONS,
   WORKLOADS_LABELS,
 } from '@kubevirt-utils/resources/template';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { FormGroup } from '@patternfly/react-core';
 import { SelectOption } from '@patternfly/react-core';
 
@@ -30,7 +29,7 @@ const WorkloadProfileModal: FC<WorkloadProfileModalProps> = ({
   const { t } = useKubevirtTranslation();
   const [workload, setWorkload] = useState<WORKLOADS>(initialWorkload || WORKLOADS.desktop);
 
-  const handleChange = (event: MouseEvent<HTMLSelectElement>, value: WORKLOADS) => {
+  const handleChange = (event: MouseEvent<HTMLSelectElement>, value: WORKLOADS): void => {
     event.preventDefault();
     setWorkload(value);
   };

--- a/src/utils/components/badges/NewBadge/NewBadge.tsx
+++ b/src/utils/components/badges/NewBadge/NewBadge.tsx
@@ -1,12 +1,11 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type JSX } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Label } from '@patternfly/react-core';
 
 import './new-badge.scss';
 
-const NewBadge = () => {
+const NewBadge = (): JSX.Element => {
   const { t } = useKubevirtTranslation();
   return (
     <Label className={'NewBadge--main'} color="blue" isCompact>

--- a/src/utils/components/badges/RequiredBadge/RequiredBadge.tsx
+++ b/src/utils/components/badges/RequiredBadge/RequiredBadge.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type JSX } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Label } from '@patternfly/react-core';
 
-const RequiredBadge = () => {
+const RequiredBadge = (): JSX.Element => {
   const { t } = useKubevirtTranslation();
   return (
     <Label color="orange" isCompact variant="outline">

--- a/src/utils/components/toggles/DropdownToggle.tsx
+++ b/src/utils/components/toggles/DropdownToggle.tsx
@@ -1,13 +1,16 @@
-/* eslint-disable */
-import React, { Ref } from 'react';
+import React, { type JSX, type Ref } from 'react';
 
-import { MenuToggle, MenuToggleElement } from '@patternfly/react-core';
+import { MenuToggle, type MenuToggleElement } from '@patternfly/react-core';
 
-import { MenuTogglePropsWithTestId } from './SelectToggle';
+import { type MenuTogglePropsWithTestId } from './SelectToggle';
 
 const DropdownToggle =
-  ({ children, 'data-test': dataTestId, ...props }: MenuTogglePropsWithTestId) =>
-  (toggleRef: Ref<MenuToggleElement>) => (
+  ({
+    children,
+    'data-test': dataTestId,
+    ...props
+  }: MenuTogglePropsWithTestId): ((toggleRef: Ref<MenuToggleElement>) => JSX.Element) =>
+  (toggleRef: Ref<MenuToggleElement>): JSX.Element => (
     <MenuToggle data-test={dataTestId} ref={toggleRef} {...props}>
       {children}
     </MenuToggle>

--- a/src/utils/components/toggles/SelectToggle.tsx
+++ b/src/utils/components/toggles/SelectToggle.tsx
@@ -1,18 +1,21 @@
-/* eslint-disable */
-import React, { Ref } from 'react';
+import React, { type JSX, type ReactNode, type Ref } from 'react';
 
-import { MenuToggle, MenuToggleElement, MenuToggleProps } from '@patternfly/react-core';
+import { MenuToggle, type MenuToggleElement, type MenuToggleProps } from '@patternfly/react-core';
 
 export type MenuTogglePropsWithTestId = MenuToggleProps & {
   'data-test'?: string;
 };
 
 type SelectToggleProps = MenuTogglePropsWithTestId & {
-  selected: any;
+  selected: ReactNode;
 };
 
-const SelectToggle = ({ 'data-test': dataTestID, selected, ...menuProps }: SelectToggleProps) => {
-  return (toggleRef: Ref<MenuToggleElement>) => (
+const SelectToggle = ({
+  'data-test': dataTestID,
+  selected,
+  ...menuProps
+}: SelectToggleProps): ((toggleRef: Ref<MenuToggleElement>) => JSX.Element) => {
+  return (toggleRef: Ref<MenuToggleElement>): JSX.Element => (
     <MenuToggle data-test={dataTestID} ref={toggleRef} {...menuProps}>
       {menuProps.children ?? selected}
     </MenuToggle>

--- a/src/utils/components/toggles/ToolbarFilterToggle.tsx
+++ b/src/utils/components/toggles/ToolbarFilterToggle.tsx
@@ -1,13 +1,12 @@
-/* eslint-disable */
-import React, { ReactNode, Ref } from 'react';
+import React, { type JSX, type ReactNode, type Ref } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   Badge,
   MenuToggle,
-  MenuToggleElement,
-  MenuToggleProps,
+  type MenuToggleElement,
+  type MenuToggleProps,
   Tooltip,
 } from '@patternfly/react-core';
 
@@ -35,16 +34,16 @@ const ToolbarFilterToggle = ({
   size,
   title,
   tooltipContent,
-}: ToolbarFilterToggleProps) => {
+}: ToolbarFilterToggleProps): ((toggleRef: Ref<MenuToggleElement>) => JSX.Element) => {
   const { t } = useKubevirtTranslation();
   const hasSelectedValues = !isEmpty(selectedValues);
 
-  return (toggleRef: Ref<MenuToggleElement>) => {
+  return (toggleRef: Ref<MenuToggleElement>): JSX.Element => {
     const menuToggle = (
       <MenuToggle
         badge={
-          badgeNumber || hasSelectedValues || showAllBadge ? (
-            <Badge isRead>{badgeNumber || selectedValues.length || t('All')}</Badge>
+          badgeNumber != null || hasSelectedValues || showAllBadge ? (
+            <Badge isRead>{badgeNumber ?? (selectedValues.length || t('All'))}</Badge>
           ) : null
         }
         data-test={dataTestId}

--- a/src/utils/resources/preference/helper.ts
+++ b/src/utils/resources/preference/helper.ts
@@ -13,17 +13,17 @@ export const getPreferredBootmode = (preference: V1beta1VirtualMachinePreference
     preference?.spec?.firmware?.preferredUseSecureBoot ||
     preference?.spec?.firmware?.preferredEfi?.secureBoot
   )
-    return BootMode.uefiSecure;
+    return BootMode.UefiSecure;
   if (
     preference?.spec?.firmware?.preferredUseEfi ||
     preference?.spec?.firmware?.preferredEfi?.secureBoot === false
   )
-    return BootMode.uefi;
+    return BootMode.UEFI;
   if (
     preference?.spec?.firmware?.preferredUseBios ||
     preference?.spec?.firmware?.preferredUseBiosSerial
   )
-    return BootMode.bios;
+    return BootMode.BIOS;
 };
 
 export const getPreferenceModelFromMatcher = (preferenceMatcher: V1PreferenceMatcher): K8sModel =>


### PR DESCRIPTION
## 📝 Description

Adds eslint typescript rules to the code base part- 4


## 🔗 Links

https://redhat.atlassian.net/browse/CNV-90382


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved empty-string and other valid falsy values in filters, labels, descriptions, boot options, and related selectors.
  * Improved handling of unknown network interface models and missing SSH addresses.
  * Strengthened XML validation and prevented errors when optional configuration data is unavailable.

* **Refactor**
  * Improved type safety across utility components, hooks, forms, and selectors.
  * Standardized boot mode and namespace naming.
  * Updated the pod selector modal to use the newer overlay experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->