### PR TITLE
CNV-90382: add typescript-linters-part-7

### DIFF
--- a/src/multicluster/components/CrossClusterMigration/hooks/useAdvisorRouteURL.ts
+++ b/src/multicluster/components/CrossClusterMigration/hooks/useAdvisorRouteURL.ts
@@ -1,3 +1,4 @@
+import { type RouteResource } from '@kubevirt-utils/resources/route/types';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -8,12 +9,6 @@ type ConsolePluginResource = K8sResourceCommon & {
         namespace?: string;
       };
     };
-  };
-};
-
-type RouteResource = K8sResourceCommon & {
-  spec?: {
-    host?: string;
   };
 };
 

--- a/src/multicluster/hooks/useK8sGetData.ts
+++ b/src/multicluster/hooks/useK8sGetData.ts
@@ -2,12 +2,14 @@ import { useEffect, useState } from 'react';
 
 import useDeepCompareMemoize from '@kubevirt-utils/hooks/useDeepCompareMemoize/useDeepCompareMemoize';
 import { kubevirtK8sGet } from '@multicluster/k8sRequests';
-import { type K8sResourceCommon, type WatchK8sResult } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { type FleetK8sGetOptions } from '@stolostron/multicluster-sdk';
+
+type K8sGetResult<T> = [T | undefined, boolean, Error | undefined];
 
 const useK8sGetData = <T extends K8sResourceCommon>(
   options: false | FleetK8sGetOptions | null,
-): WatchK8sResult<T> => {
+): K8sGetResult<T> => {
   const [data, setData] = useState<T>();
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<Error>();

--- a/src/utils/errors/errorTypes.ts
+++ b/src/utils/errors/errorTypes.ts
@@ -1,0 +1,22 @@
+/**
+ * Shape of a Kubernetes API error response.
+ * K8s REST errors typically carry `code` and/or a nested `response.status`.
+ */
+export type K8sApiError = Error & {
+  code?: number;
+  response?: { status?: number };
+};
+
+/**
+ * Narrow an unknown caught value to a K8sApiError when it has the expected shape.
+ */
+export const isK8sApiError = (error: unknown): error is K8sApiError =>
+  typeof error === 'object' && error !== null && 'message' in error;
+
+/**
+ * Check whether an unknown error represents an HTTP 409 Conflict.
+ */
+export const isConflictError = (error: unknown): boolean => {
+  if (!isK8sApiError(error)) return false;
+  return error.response?.status === 409 || error.code === 409;
+};

--- a/src/utils/hooks/useInfrastructureAlerts/utils/utils.ts
+++ b/src/utils/hooks/useInfrastructureAlerts/utils/utils.ts
@@ -12,7 +12,7 @@ const getHealthImpact = (alert: Alert): string | undefined =>
   alert?.labels?.[OPERATOR_HEALTH_IMPACT_LABEL];
 
 export const isCriticalHealthImpactAlert = (alert: Alert): boolean =>
-  getHealthImpact(alert) === HealthImpactLevel.critical;
+  getHealthImpact(alert) === HealthImpactLevel.Critical;
 
 export const sortAlertsBySeverity = (alerts: Alert[]): AlertsBySeverity =>
   alerts?.reduce(

--- a/src/utils/resources/route/types.ts
+++ b/src/utils/resources/route/types.ts
@@ -1,0 +1,7 @@
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+
+export type RouteResource = K8sResourceCommon & {
+  spec?: {
+    host?: string;
+  };
+};

--- a/src/views/checkups/self-validation/components/SelfValidationCheckupRunButton.tsx
+++ b/src/views/checkups/self-validation/components/SelfValidationCheckupRunButton.tsx
@@ -1,5 +1,5 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import type { FC } from 'react';
+import React, { useMemo } from 'react';
 import { useNavigate } from 'react-router';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -13,7 +13,6 @@ import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import { CHECKUP_URLS } from '../../utils/constants';
 import { getSelectProjectText } from '../../utils/utils';
-
 import {
   getActionState,
   SELF_VALIDATION_ACTION_MODE,
@@ -31,7 +30,7 @@ const SelfValidationCheckupRunButton: FC = () => {
   const namespace = namespaces?.[0];
   const isAllNamespaces = isEmpty(namespace);
 
-  const cluster = clusterParam?.[0] || hubClusterName;
+  const cluster = clusterParam?.[0] ?? hubClusterName;
 
   const { t } = useKubevirtTranslation();
 
@@ -46,7 +45,7 @@ const SelfValidationCheckupRunButton: FC = () => {
             hasOtherRunningJobs: false,
             isCreateSelfValidationPermitted,
             otherRunningJobs: [],
-            runningSelfValidationJobs: runningSelfValidationJobs || [],
+            runningSelfValidationJobs: runningSelfValidationJobs ?? [],
           })
         : null,
     [isCreateSelfValidationPermitted, runningSelfValidationJobs, jobsLoaded],
@@ -60,9 +59,9 @@ const SelfValidationCheckupRunButton: FC = () => {
       return true;
     }
     return selfValidationActionState ? !selfValidationActionState.isEnabled : true;
-  }, [namespace, selfValidationActionState, jobsLoaded, jobsError]);
+  }, [isAllNamespaces, selfValidationActionState, jobsLoaded, jobsError]);
 
-  const handleRunCheckup = () => {
+  const handleRunCheckup = (): void => {
     if (!namespace || isDisabled || !selfValidationActionState?.isEnabled) return;
 
     if (isACMpage) {

--- a/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationActionFactory.tsx
+++ b/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationActionFactory.tsx
@@ -1,20 +1,18 @@
-/* eslint-disable */
 import React from 'react';
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
 import {
-  IoK8sApiBatchV1Job,
-  IoK8sApiCoreV1ConfigMap,
+  type IoK8sApiBatchV1Job,
+  type IoK8sApiCoreV1ConfigMap,
 } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
+import { type ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
 import DeleteModal from '@kubevirt-utils/components/DeleteModal/DeleteModal';
 import { trimLastHistoryPath } from '@kubevirt-utils/components/HorizontalNavbar/utils/utils';
-import { ModalComponent } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
-import { ToastActions } from '@kubevirt-utils/hooks/useKubevirtToast';
+import { type ModalComponent } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import { type ToastActions } from '@kubevirt-utils/hooks/useKubevirtToast';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 
 import { deleteSelfValidationCheckup } from '../../utils';
-
 import { getConfigMapInfo } from './CheckupsSelfValidationActionsUtils';
 import {
   createGoToRunningCheckupAction,
@@ -73,7 +71,7 @@ export const createCheckupsSelfValidationActionFactory = (
     };
 
     return {
-      cta: () => {
+      cta: (): void => {
         createModal((props) => (
           <DeleteModal
             {...props}

--- a/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationHistoryActions.tsx
+++ b/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationHistoryActions.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import React, { FC, useCallback, useMemo, useState } from 'react';
+import React, { type FC, useCallback, useMemo, useState } from 'react';
 
-import { IoK8sApiBatchV1Job } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiBatchV1Job } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import ActionsDropdown from '@kubevirt-utils/components/ActionsDropdown/ActionsDropdown';
-import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
+import { type ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
 import DeleteModal from '@kubevirt-utils/components/DeleteModal/DeleteModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import useKubevirtToast from '@kubevirt-utils/hooks/useKubevirtToast';
@@ -12,9 +11,10 @@ import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { Spinner } from '@patternfly/react-core';
 
+import DownloadResultsErrorModal from '../DownloadResultsErrorModal';
+
 import { deleteSelfValidationJob } from '../../utils';
 import { getDefaultErrorMessage } from '../../utils/downloadResults';
-import DownloadResultsErrorModal from '../DownloadResultsErrorModal';
 import { useDownloadResults } from '../hooks/useDownloadResults';
 
 type CheckupsSelfValidationHistoryActionsProps = {
@@ -30,7 +30,7 @@ const CheckupsSelfValidationHistoryActions: FC<CheckupsSelfValidationHistoryActi
   const [isDeleting, setIsDeleting] = useState<boolean>(false);
   const { download, isDownloading } = useDownloadResults();
   const isJobCompleted = job?.status?.succeeded === 1 && job?.status?.terminating !== 1;
-  const namespace = getNamespace(job) || null;
+  const namespace = getNamespace(job) ?? null;
 
   const handleDeleteClick = useCallback(() => {
     createModal((props) => (

--- a/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationSharedActionFactory.tsx
+++ b/src/views/checkups/self-validation/components/actions/CheckupsSelfValidationSharedActionFactory.tsx
@@ -1,21 +1,19 @@
-/* eslint-disable */
-import React, { ReactNode } from 'react';
-import { TFunction } from 'i18next';
+import React, { type ReactNode } from 'react';
+import { type TFunction } from 'i18next';
 
 import {
-  IoK8sApiBatchV1Job,
-  IoK8sApiCoreV1ConfigMap,
+  type IoK8sApiBatchV1Job,
+  type IoK8sApiCoreV1ConfigMap,
 } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
-import { ModalComponent } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
-import { ToastActions } from '@kubevirt-utils/hooks/useKubevirtToast';
+import { type ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
+import { type ModalComponent } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import { type ToastActions } from '@kubevirt-utils/hooks/useKubevirtToast';
 import { getSelfValidationCheckupURL } from '@kubevirt-utils/resources/checkups/urls';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 
 import { createCheckupRerunHandler } from '../../../utils/createCheckupRerunHandler';
 import { rerunSelfValidationCheckup } from '../../utils';
-
-import { ActionState, getRerunModeState } from './CheckupsSelfValidationActionsUtils';
+import { type ActionState, getRerunModeState } from './CheckupsSelfValidationActionsUtils';
 import RunningCheckupWarningDescription from './RunningCheckupWarningDescription';
 
 type RerunActionParams = {
@@ -100,7 +98,7 @@ export const createGoToRunningCheckupAction = ({
     return null;
   }
 
-  const handleGoToRunningCheckup = () => {
+  const handleGoToRunningCheckup = (): void => {
     const path = getSelfValidationCheckupURL(
       configMapInfo.name,
       configMapInfo.namespace,

--- a/src/views/checkups/self-validation/components/form/CheckupsSelfValidationFormActions.tsx
+++ b/src/views/checkups/self-validation/components/form/CheckupsSelfValidationFormActions.tsx
@@ -1,5 +1,5 @@
-/* eslint-disable */
-import React, { FC, ReactNode, useMemo, useState } from 'react';
+import type { FC, ReactNode } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
@@ -19,10 +19,9 @@ import {
 } from '../actions/CheckupsSelfValidationActionsUtils';
 import { useAllRunningSelfValidationJobs } from '../hooks/useAllRunningSelfValidationJobs';
 import useCheckupsSelfValidationPermissions from '../hooks/useCheckupsSelfValidationPermissions';
-
 import HeavyLoadCheckupConfirmationModal from './HeavyLoadCheckupConfirmationModal';
 import RunButtonWithTooltip from './RunButtonWithTooltip';
-import { CheckupsSelfValidationFormActionsProps } from './types';
+import { type CheckupsSelfValidationFormActionsProps } from './types';
 import { isValidWinImageDownloadUrl } from './utils';
 
 const CheckupsSelfValidationFormActions: FC<CheckupsSelfValidationFormActionsProps> = ({
@@ -58,7 +57,7 @@ const CheckupsSelfValidationFormActions: FC<CheckupsSelfValidationFormActionsPro
         hasOtherRunningJobs: false,
         isCreateSelfValidationPermitted,
         otherRunningJobs: [],
-        runningSelfValidationJobs: runningSelfValidationJobs || [],
+        runningSelfValidationJobs: runningSelfValidationJobs ?? [],
       }),
     [isCreateSelfValidationPermitted, runningSelfValidationJobs],
   );
@@ -85,7 +84,7 @@ const CheckupsSelfValidationFormActions: FC<CheckupsSelfValidationFormActionsPro
 
   const showTooltip = eulaPendingConfirmation || showRunningCheckupTooltip;
 
-  const executeRun = async () => {
+  const executeRun = async (): Promise<void> => {
     if (
       windowsServerTesting &&
       trimmedWinImageDownloadUrl &&
@@ -128,12 +127,12 @@ const CheckupsSelfValidationFormActions: FC<CheckupsSelfValidationFormActionsPro
     }
   };
 
-  const handleOpenConfirmation = () => {
+  const handleOpenConfirmation = (): void => {
     createModal(({ isOpen, onClose }) => (
       <HeavyLoadCheckupConfirmationModal
         onConfirm={() => {
           onClose();
-          executeRun();
+          void executeRun();
         }}
         isOpen={isOpen}
         onClose={onClose}

--- a/src/views/checkups/self-validation/components/hooks/useCheckupsSelfValidationData.ts
+++ b/src/views/checkups/self-validation/components/hooks/useCheckupsSelfValidationData.ts
@@ -1,14 +1,15 @@
-/* eslint-disable */
 import { Operator } from '@openshift-console/dynamic-plugin-sdk';
 
 import useCheckupsData from '../../../utils/hooks/useCheckupsData';
 import { SELF_VALIDATION_LABEL_VALUE, SELF_VALIDATION_RESULTS_ONLY_LABEL } from '../../utils';
 
+type UseCheckupsSelfValidationDataResult = ReturnType<typeof useCheckupsData>;
+
 const SELF_VALIDATION_JOB_MATCH_EXPRESSIONS = [
   { key: SELF_VALIDATION_RESULTS_ONLY_LABEL, operator: Operator.DoesNotExist },
 ];
 
-const useCheckupsSelfValidationData = () =>
+const useCheckupsSelfValidationData = (): UseCheckupsSelfValidationDataResult =>
   useCheckupsData({
     jobMatchExpressions: SELF_VALIDATION_JOB_MATCH_EXPRESSIONS,
     labelValue: SELF_VALIDATION_LABEL_VALUE,

--- a/src/views/checkups/self-validation/components/hooks/useJobResults.ts
+++ b/src/views/checkups/self-validation/components/hooks/useJobResults.ts
@@ -1,18 +1,22 @@
-/* eslint-disable */
 import { useEffect, useMemo } from 'react';
 
 import { ConfigMapModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import {
-  IoK8sApiBatchV1Job,
-  IoK8sApiCoreV1ConfigMap,
+  type IoK8sApiBatchV1Job,
+  type IoK8sApiCoreV1ConfigMap,
 } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import useK8sGetData from '@multicluster/hooks/useK8sGetData';
 
-import { CONFIGMAP_NAME, getJobContainers } from '../../../utils/utils';
-import { JobResults, parseResults } from '../../utils';
+import {
+  CONFIGMAP_NAME,
+  getJobContainers,
+  STATUS_COMPLETION_TIME_STAMP,
+  STATUS_START_TIME_STAMP,
+} from '../../../utils/utils';
+import { type JobResults, parseResults } from '../../utils';
 
 type UseJobResultsProps = {
   cluster: string;
@@ -85,7 +89,10 @@ export const useJobResults = ({
     if (!configMapLoaded || configMapError || !configMap)
       return { parseError: false, results: null };
 
-    if (getName(configMap) !== configMapName || getNamespace(configMap) !== namespace) {
+    if (
+      configMapName != null &&
+      (getName(configMap) !== configMapName || getNamespace(configMap) !== namespace)
+    ) {
       return { parseError: false, results: null };
     }
 
@@ -98,8 +105,8 @@ export const useJobResults = ({
       results: {
         tests: parsedResults,
         timestamps: {
-          completionTimestamp: configMap.data?.['status.completionTimestamp'],
-          startTimestamp: configMap.data?.['status.startTimestamp'],
+          completionTimestamp: configMap.data?.[STATUS_COMPLETION_TIME_STAMP],
+          startTimestamp: configMap.data?.[STATUS_START_TIME_STAMP],
         },
       },
     };
@@ -134,7 +141,9 @@ export const useJobResults = ({
   }, [nameResolutionError, jobSucceeded, namespace, configMapName, configMapError, parseError, t]);
 
   const configMapIsStale =
-    !!configMap && (getName(configMap) !== configMapName || getNamespace(configMap) !== namespace);
+    !!configMap &&
+    configMapName != null &&
+    (getName(configMap) !== configMapName || getNamespace(configMap) !== namespace);
 
   const isLoading =
     !nameResolutionError &&

--- a/src/views/checkups/self-validation/details/CheckupsSelfValidationDetailsPage.tsx
+++ b/src/views/checkups/self-validation/details/CheckupsSelfValidationDetailsPage.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable */
+import type { FC } from 'react';
 import React, { useMemo } from 'react';
 
 import StateHandler from '@kubevirt-utils/components/StateHandler/StateHandler';
@@ -6,14 +6,13 @@ import useHideYamlTab, { removeYamlTabs } from '@kubevirt-utils/hooks/useHideYam
 import { HorizontalNav } from '@openshift-console/dynamic-plugin-sdk';
 
 import CheckupsNotFound from '../../components/CheckupsNotFound';
-
+import CheckupsSelfValidationDetailsPageHeader from './CheckupsSelfValidationDetailsPageHeader';
 import { useCheckupsSelfValidationTabs } from './hooks/useCheckupsSelfValidationTabs';
 import useWatchCheckupData from './hooks/useWatchCheckupData';
-import CheckupsSelfValidationDetailsPageHeader from './CheckupsSelfValidationDetailsPageHeader';
 
 import './checkups-self-validation-details-page.scss';
 
-const CheckupsSelfValidationDetailsPage = () => {
+const CheckupsSelfValidationDetailsPage: FC = () => {
   const { configMap, error, jobMatches, loaded } = useWatchCheckupData();
 
   const pages = useCheckupsSelfValidationTabs();

--- a/src/views/checkups/self-validation/details/components/DownloadResultsButton.tsx
+++ b/src/views/checkups/self-validation/details/components/DownloadResultsButton.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import {
-  IoK8sApiBatchV1Job,
-  IoK8sApiCoreV1ConfigMap,
+  type IoK8sApiBatchV1Job,
+  type IoK8sApiCoreV1ConfigMap,
 } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import useKubevirtToast from '@kubevirt-utils/hooks/useKubevirtToast';
@@ -30,13 +29,13 @@ const DownloadResultsButton: FC<DownloadResultsButtonProps> = ({ configMap, job 
 
   const jobStatus = job ? getJobStatus(job) : null;
   const isCompleted = jobStatus === CheckupsStatus.Done;
-  const namespace = configMap?.metadata?.namespace || null;
+  const namespace = configMap?.metadata?.namespace ?? null;
 
   if (!configMap || !job) {
     return null;
   }
 
-  const handleDownloadResults = async () => {
+  const handleDownloadResults = async (): Promise<void> => {
     if (!isCompleted) {
       kubevirtConsole.log('Checkup not completed yet. Status:', jobStatus);
       return;

--- a/src/views/checkups/self-validation/details/components/progress/OverallProgressCard.tsx
+++ b/src/views/checkups/self-validation/details/components/progress/OverallProgressCard.tsx
@@ -1,5 +1,5 @@
-/* eslint-disable */
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import type { FC, ReactNode } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -21,7 +21,6 @@ import {
 import { InProgressIcon } from '@patternfly/react-icons';
 
 import TestStatistics from '../../../components/shared/TestStatistics';
-
 import { getTestSuiteLabel, getTotalSkippedTests } from './utils/progressTracker';
 import type { OverallProgress } from './utils/types';
 
@@ -56,7 +55,7 @@ const OverallProgressCard: FC<OverallProgressCardProps> = ({ progress: overallPr
       setElapsedSeconds(getElapsedTimeInSeconds(overallProgress?.startTime));
     }, 1000);
 
-    return () => clearInterval(intervalId);
+    return (): void => clearInterval(intervalId);
   }, [isJobActive, overallProgress?.startTime]);
 
   const elapsedTime = elapsedSeconds > 0 ? formatElapsedTime(t, elapsedSeconds) : null;
@@ -66,7 +65,7 @@ const OverallProgressCard: FC<OverallProgressCardProps> = ({ progress: overallPr
     [overallProgress?.suites],
   );
 
-  const getOverallStatusIcon = () => {
+  const getOverallStatusIcon = (): ReactNode => {
     if (!overallProgress) return null;
     if (overallProgress.failedSuites > 0) {
       return <RedExclamationCircleIcon />;

--- a/src/views/checkups/self-validation/details/tabs/details/CheckupsSelfValidationDetailsTab.tsx
+++ b/src/views/checkups/self-validation/details/tabs/details/CheckupsSelfValidationDetailsTab.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC, useCallback } from 'react';
+import React, { type FC, useCallback } from 'react';
 
-import { IoK8sApiBatchV1Job } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiBatchV1Job } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { Divider, PageSection } from '@patternfly/react-core';
@@ -14,7 +13,6 @@ import useJobResults from '../../../components/hooks/useJobResults';
 import useProgressTracking from '../../components/progress/hooks/useProgressTracking';
 import TestProgressOverview from '../../components/progress/TestProgressOverview';
 import useWatchCheckupData from '../../hooks/useWatchCheckupData';
-
 import CheckupsSelfValidationDetailsPageSection from './CheckupsSelfValidationDetailsPageSection';
 
 const CheckupsSelfValidationDetailsTab: FC = () => {
@@ -28,7 +26,7 @@ const CheckupsSelfValidationDetailsTab: FC = () => {
   } = useJobResults({
     cluster: getCluster(configMap),
     job: currentJob,
-    namespace: getNamespace(configMap) || '',
+    namespace: getNamespace(configMap) ?? '',
   });
 
   const isJobCompleted = getIsJobCompleted(currentJob);
@@ -42,7 +40,7 @@ const CheckupsSelfValidationDetailsTab: FC = () => {
     cluster: getCluster(configMap),
     enabled: isJobRunning,
     job: currentJob,
-    namespace: getNamespace(configMap) || '',
+    namespace: getNamespace(configMap) ?? '',
   });
 
   const renderCustomActions = useCallback(

--- a/src/views/checkups/self-validation/details/tabs/details/TestSuiteCard.tsx
+++ b/src/views/checkups/self-validation/details/tabs/details/TestSuiteCard.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
@@ -41,12 +40,12 @@ type TestSuiteCardProps = {
 const TestSuiteCard: FC<TestSuiteCardProps> = ({ isExpanded, onToggle, suiteData, suiteName }) => {
   const { t } = useKubevirtTranslation();
 
-  const totalTests = suiteData.tests_run || 0;
-  const testsFailed = suiteData.tests_failures || 0;
-  const testsPassed = suiteData.tests_passed || 0;
-  const testsSkipped = suiteData.tests_skipped || 0;
+  const totalTests = suiteData.tests_run ?? 0;
+  const testsFailed = suiteData.tests_failures ?? 0;
+  const testsPassed = suiteData.tests_passed ?? 0;
+  const testsSkipped = suiteData.tests_skipped ?? 0;
 
-  const failedTests = useMemo(() => suiteData.failed_tests || [], [suiteData.failed_tests]);
+  const failedTests = useMemo(() => suiteData.failed_tests ?? [], [suiteData.failed_tests]);
   const testDuration = useMemo(
     () => formatGoDuration(suiteData.tests_duration),
     [suiteData.tests_duration],

--- a/src/views/checkups/self-validation/details/tabs/details/components/CheckupsSelfValidationDetailsDescriptionList.tsx
+++ b/src/views/checkups/self-validation/details/tabs/details/components/CheckupsSelfValidationDetailsDescriptionList.tsx
@@ -1,11 +1,10 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import CheckupsStatusIcon from 'src/views/checkups/CheckupsStatusIcon';
 
 import { modelToGroupVersionKind, NamespaceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import {
-  IoK8sApiBatchV1Job,
-  IoK8sApiCoreV1ConfigMap,
+  type IoK8sApiBatchV1Job,
+  type IoK8sApiCoreV1ConfigMap,
 } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -15,9 +14,10 @@ import { getCluster } from '@multicluster/helpers/selectors';
 import { Timestamp } from '@openshift-console/dynamic-plugin-sdk';
 import { DescriptionList, Grid, GridItem } from '@patternfly/react-core';
 
-import { STATUS_COMPLETION_TIME_STAMP, STATUS_START_TIME_STAMP } from '../../../../../utils/utils';
-import { JobResults } from '../../../../utils';
 import ResultsStatus from '../ResultsStatus';
+
+import { STATUS_COMPLETION_TIME_STAMP, STATUS_START_TIME_STAMP } from '../../../../../utils/utils';
+import { type JobResults } from '../../../../utils';
 
 type CheckupsSelfValidationDetailsDescriptionListProps = {
   configMap: IoK8sApiCoreV1ConfigMap;
@@ -50,7 +50,7 @@ const CheckupsSelfValidationDetailsDescriptionList: FC<
             descriptionData={
               <Timestamp
                 timestamp={
-                  results?.timestamps?.startTimestamp || configMap?.data?.[STATUS_START_TIME_STAMP]
+                  results?.timestamps?.startTimestamp ?? configMap?.data?.[STATUS_START_TIME_STAMP]
                 }
               />
             }
@@ -88,7 +88,7 @@ const CheckupsSelfValidationDetailsDescriptionList: FC<
             descriptionData={
               <Timestamp
                 timestamp={
-                  results?.timestamps?.completionTimestamp ||
+                  results?.timestamps?.completionTimestamp ??
                   configMap?.data?.[STATUS_COMPLETION_TIME_STAMP]
                 }
               />

--- a/src/views/checkups/self-validation/list/CheckupsSelfValidationList.tsx
+++ b/src/views/checkups/self-validation/list/CheckupsSelfValidationList.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 
-import { IoK8sApiBatchV1Job } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiBatchV1Job } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import KubevirtFilterToolbar from '@kubevirt-utils/components/KubevirtFilterToolbar/KubevirtFilterToolbar';
 import KubevirtTable from '@kubevirt-utils/components/KubevirtTable/KubevirtTable';
 import useKubevirtDataViewFilters from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/useKubevirtDataViewFilters';
@@ -20,14 +19,14 @@ import { ListPageBody } from '@openshift-console/dynamic-plugin-sdk';
 import { Pagination } from '@patternfly/react-core';
 import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
+import { getCheckupsSelfValidationListFilters } from '../utils';
+
 import { CHECKUPS_COLUMN_KEYS } from '../../utils/constants';
 import { getCheckupsConfigMapRowId, getJobByName } from '../../utils/utils';
 import useCheckupsSelfValidationData from '../components/hooks/useCheckupsSelfValidationData';
 import useCheckupsSelfValidationPermissions from '../components/hooks/useCheckupsSelfValidationPermissions';
-import { getCheckupsSelfValidationListFilters } from '../utils';
-
 import {
-  CheckupsSelfValidationCallbacks,
+  type CheckupsSelfValidationCallbacks,
   getCheckupsSelfValidationColumns,
 } from './checkupsSelfValidationListDefinition';
 import CheckupsSelfValidationListEmptyState from './CheckupsSelfValidationListEmptyState';
@@ -47,7 +46,7 @@ const CheckupsSelfValidationList: FC = () => {
     loading: loadingPermissions,
   } = useCheckupsSelfValidationPermissions();
   const { configMaps, error: dataError, jobs, loaded } = useCheckupsSelfValidationData();
-  const error = dataError || permissionsError;
+  const error = dataError ?? permissionsError;
 
   const filterDefinitions = useMemo(() => getCheckupsSelfValidationListFilters(t), [t]);
   const { clearAllFilters, filteredData, filters, onSetFilters } = useKubevirtDataViewFilters({

--- a/src/views/checkups/self-validation/list/checkupsSelfValidationCells.tsx
+++ b/src/views/checkups/self-validation/list/checkupsSelfValidationCells.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 import { Link } from 'react-router';
 
 import { ConfigMapModel, modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getSelfValidationCheckupURL } from '@kubevirt-utils/resources/checkups/urls';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
@@ -12,10 +11,6 @@ import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
-import CheckupsStatusIcon from '../../CheckupsStatusIcon';
-import { ClusterCell, NamespaceCell } from '../../components/cells/CheckupsSharedCells';
-import { getIsJobCompleted, STATUS_START_TIME_STAMP } from '../../utils/utils';
-import CheckupsSelfValidationActions from '../components/actions/CheckupsSelfValidationActions';
 import {
   formatStatusTimestamp,
   getCompletedSummaryText,
@@ -23,19 +18,23 @@ import {
   getResultsConfigMapName,
 } from '../utils';
 
-import { CheckupsSelfValidationCallbacks } from './checkupsSelfValidationListDefinition';
+import CheckupsStatusIcon from '../../CheckupsStatusIcon';
+import { ClusterCell, NamespaceCell } from '../../components/cells/CheckupsSharedCells';
+import { getIsJobCompleted, STATUS_START_TIME_STAMP } from '../../utils/utils';
+import CheckupsSelfValidationActions from '../components/actions/CheckupsSelfValidationActions';
+import { type CheckupsSelfValidationCallbacks } from './checkupsSelfValidationListDefinition';
 
 export { ClusterCell, NamespaceCell };
 
 export const NameCell: FC<{ row: IoK8sApiCoreV1ConfigMap }> = ({ row }) => {
   const [hubClusterName] = useHubClusterName();
   const isACMPage = useIsACMPage();
-  const cluster = getCluster(row) || hubClusterName;
+  const cluster = getCluster(row) ?? hubClusterName;
   const name = row?.metadata?.name;
   const namespace = row?.metadata?.namespace;
 
   if (!name || !namespace) {
-    return <>{name || NO_DATA_DASH}</>;
+    return <>{name ?? NO_DATA_DASH}</>;
   }
 
   return (
@@ -71,7 +70,7 @@ export const TimeCell: FC<TimeCellProps> = ({ callbacks, row, type }) => {
 
   const timestamp =
     type === 'start'
-      ? latestJob?.status?.startTime || row?.data?.[STATUS_START_TIME_STAMP]
+      ? (latestJob?.status?.startTime ?? row?.data?.[STATUS_START_TIME_STAMP])
       : latestJob?.status?.completionTime;
 
   return <>{formatStatusTimestamp(timestamp, t, NO_DATA_DASH)}</>;
@@ -83,7 +82,7 @@ export const SummaryCell: FC<{
 }> = ({ callbacks, row }) => {
   const { t } = useKubevirtTranslation();
   const [hubClusterName] = useHubClusterName();
-  const cluster = getCluster(row) || hubClusterName;
+  const cluster = getCluster(row) ?? hubClusterName;
   const jobs = callbacks.getJobByName(row?.metadata?.name, false);
   const latestJob = jobs?.[0];
 
@@ -91,7 +90,7 @@ export const SummaryCell: FC<{
 
   const resultsConfigMapName = useMemo(
     () => (latestJob?.metadata?.name ? getResultsConfigMapName(latestJob.metadata.name) : null),
-    [latestJob?.metadata?.name],
+    [latestJob],
   );
 
   const resultsConfigMapWatchConfig = useMemo(
@@ -105,7 +104,7 @@ export const SummaryCell: FC<{
             namespace: latestJob.metadata.namespace,
           }
         : null,
-    [isJobCompleted, resultsConfigMapName, latestJob?.metadata?.namespace, cluster],
+    [isJobCompleted, resultsConfigMapName, latestJob, cluster],
   );
 
   const [resultsConfigMap] = useK8sWatchData<IoK8sApiCoreV1ConfigMap>(resultsConfigMapWatchConfig);

--- a/src/views/checkups/self-validation/list/checkupsSelfValidationListDefinition.tsx
+++ b/src/views/checkups/self-validation/list/checkupsSelfValidationListDefinition.tsx
@@ -1,16 +1,17 @@
-/* eslint-disable */
 import React from 'react';
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
 import {
-  IoK8sApiBatchV1Job,
-  IoK8sApiCoreV1ConfigMap,
+  type IoK8sApiBatchV1Job,
+  type IoK8sApiCoreV1ConfigMap,
 } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
+import { type ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { ACTIONS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { SortByDirection } from '@patternfly/react-table';
+
+import { groupJobsByConfigMapName } from '../utils';
 
 import { CHECKUPS_COLUMN_KEYS } from '../../utils/constants';
 import {
@@ -21,8 +22,6 @@ import {
   getJobStatus,
   STATUS_START_TIME_STAMP,
 } from '../../utils/utils';
-import { groupJobsByConfigMapName } from '../utils';
-
 import {
   ActionsCell,
   ClusterCell,
@@ -55,7 +54,8 @@ export const getCheckupsSelfValidationColumns = (
     ...(isACMPage
       ? [
           {
-            getValue: (row: IoK8sApiCoreV1ConfigMap) => getCluster(row) || hubClusterName || '',
+            getValue: (row: IoK8sApiCoreV1ConfigMap): string =>
+              getCluster(row) ?? hubClusterName ?? '',
             key: 'cluster',
             label: t('Cluster'),
             renderCell: (row: IoK8sApiCoreV1ConfigMap) => <ClusterCell row={row} />,
@@ -71,14 +71,14 @@ export const getCheckupsSelfValidationColumns = (
       sortable: true,
     },
     {
-      getValue: (row, callbacks) => {
+      getValue: (row, callbacks): string => {
         const latestJob = callbacks?.getJobByName(getName(row), false)?.[0];
         return getCSVExportStatusLabel(getConfigMapStatus(row, getJobStatus(latestJob)), t);
       },
       key: 'status',
       label: t('Status'),
       renderCell: (row, callbacks) => <StatusCell callbacks={callbacks} row={row} />,
-      sort: (data, sortDirection) => {
+      sort: (data, sortDirection): IoK8sApiCoreV1ConfigMap[] => {
         const statusOrder = {
           [CheckupsStatus.Deleting]: 5,
           [CheckupsStatus.Done]: 2,
@@ -93,8 +93,8 @@ export const getCheckupsSelfValidationColumns = (
           const statusA = getConfigMapStatus(a, getJobStatus(jobA));
           const statusB = getConfigMapStatus(b, getJobStatus(jobB));
 
-          const orderA = statusOrder[statusA] || 999;
-          const orderB = statusOrder[statusB] || 999;
+          const orderA = statusOrder[statusA] ?? 999;
+          const orderB = statusOrder[statusB] ?? 999;
 
           return sortDirection === SortByDirection.asc ? orderA - orderB : orderB - orderA;
         });
@@ -102,9 +102,9 @@ export const getCheckupsSelfValidationColumns = (
       sortable: true,
     },
     {
-      getValue: (row, callbacks) => {
+      getValue: (row, callbacks): string => {
         const latestJob = callbacks?.getJobByName(row?.metadata?.name, false)?.[0];
-        return latestJob?.status?.startTime || row?.data?.[STATUS_START_TIME_STAMP] || '';
+        return latestJob?.status?.startTime ?? row?.data?.[STATUS_START_TIME_STAMP] ?? '';
       },
       key: CHECKUPS_COLUMN_KEYS.START_TIME_CAMEL,
       label: t('Start time'),
@@ -113,16 +113,16 @@ export const getCheckupsSelfValidationColumns = (
       sortable: true,
     },
     {
-      getValue: (row, callbacks) => {
+      getValue: (row, callbacks): string => {
         const latestJob = callbacks?.getJobByName(row?.metadata?.name, false)?.[0];
-        return latestJob?.status?.completionTime || '';
+        return latestJob?.status?.completionTime ?? '';
       },
       key: 'completionTime',
       label: t('Completion time'),
       renderCell: (row, callbacks) => (
         <TimeCell callbacks={callbacks} row={row} type="completion" />
       ),
-      sort: (data, sortDirection) => {
+      sort: (data, sortDirection): IoK8sApiCoreV1ConfigMap[] => {
         return data.toSorted((a, b) => {
           const jobA = jobsByConfigMapName.get(a?.metadata?.name)?.[0];
           const jobB = jobsByConfigMapName.get(b?.metadata?.name)?.[0];

--- a/src/views/checkups/self-validation/utils/filters.ts
+++ b/src/views/checkups/self-validation/utils/filters.ts
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
-import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
+import { type IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 
 import { SELF_VALIDATION_RESULTS_KEY } from './constants';
 
@@ -19,7 +18,7 @@ export const getCheckupsSelfValidationListFilters = (
   {
     categoryLabel: t('Status'),
     id: SELF_VALIDATION_STATUS_FILTER_ID,
-    match: (obj, selected) => {
+    match: (obj, selected): boolean => {
       const status = obj?.data?.[SELF_VALIDATION_RESULTS_KEY]
         ? SELF_VALIDATION_STATUS.completed
         : SELF_VALIDATION_STATUS.running;

--- a/src/views/checkups/self-validation/utils/selfValidationJob/jobExtraction.ts
+++ b/src/views/checkups/self-validation/utils/selfValidationJob/jobExtraction.ts
@@ -1,10 +1,8 @@
-/* eslint-disable */
 import { JobModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiBatchV1Job } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiBatchV1Job } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { k8sList } from '@openshift-console/dynamic-plugin-sdk';
 
-import { getJobContainers, isJobRunning, KUBEVIRT_VM_LATENCY_LABEL } from '../../../utils/utils';
 import {
   JOB_ENV_ACCEPT_WINDOWS_EULA,
   JOB_ENV_DRY_RUN,
@@ -17,6 +15,8 @@ import {
   JOB_VOLUME_RESULTS,
   SELF_VALIDATION_LABEL_VALUE,
 } from '../constants';
+
+import { getJobContainers, isJobRunning, KUBEVIRT_VM_LATENCY_LABEL } from '../../../utils/utils';
 
 // ===========================
 // Job Information Extraction
@@ -62,7 +62,7 @@ export const getStorageCapabilitiesFromJob = (job: IoK8sApiBatchV1Job): string[]
 };
 
 export const getCheckupImageFromJob = (job: IoK8sApiBatchV1Job): string =>
-  getJobContainers(job)?.[0]?.image || '';
+  getJobContainers(job)?.[0]?.image ?? '';
 
 export { isJobRunning } from '../../../utils/utils';
 
@@ -83,7 +83,7 @@ export const getAllRunningSelfValidationJobs = async (): Promise<IoK8sApiBatchV1
       },
     });
 
-    const jobs = Array.isArray(response) ? response : response?.items || [];
+    const jobs = Array.isArray(response) ? response : (response?.items ?? []);
     return jobs.filter(isJobRunning);
   } catch (error) {
     kubevirtConsole.error('Failed to fetch running self-validation jobs:', error);

--- a/src/views/checkups/self-validation/utils/selfValidationJob/resourceTemplates.test.ts
+++ b/src/views/checkups/self-validation/utils/selfValidationJob/resourceTemplates.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { JOB_ENV_ACCEPT_WINDOWS_EULA, JOB_ENV_WIN_IMAGE_DOWNLOAD_URL } from '../constants';
 
 import { selfValidationJob } from './resourceTemplates';
@@ -15,7 +14,7 @@ describe('selfValidationJob Windows env', () => {
 
   it('should omit WIN_IMAGE_DOWNLOAD_URL when the URL is empty', () => {
     const job = selfValidationJob({ ...baseOptions, winImageDownloadUrl: '' });
-    const env = job.spec?.template?.spec?.containers?.[0]?.env || [];
+    const env = job.spec?.template?.spec?.containers?.[0]?.env ?? [];
 
     expect(env.some((entry) => entry.name === JOB_ENV_ACCEPT_WINDOWS_EULA)).toBe(true);
     expect(env.some((entry) => entry.name === JOB_ENV_WIN_IMAGE_DOWNLOAD_URL)).toBe(false);
@@ -24,7 +23,7 @@ describe('selfValidationJob Windows env', () => {
   it('should include WIN_IMAGE_DOWNLOAD_URL when a URL is provided', () => {
     const url = 'https://example.com/windows.iso';
     const job = selfValidationJob({ ...baseOptions, winImageDownloadUrl: url });
-    const env = job.spec?.template?.spec?.containers?.[0]?.env || [];
+    const env = job.spec?.template?.spec?.containers?.[0]?.env ?? [];
     const downloadEnv = env.find((entry) => entry.name === JOB_ENV_WIN_IMAGE_DOWNLOAD_URL);
 
     expect(downloadEnv?.value).toBe(url);
@@ -35,7 +34,7 @@ describe('selfValidationJob Windows env', () => {
       ...baseOptions,
       winImageDownloadUrl: 'https://example.com/windows.iso',
     });
-    const env = job.spec?.template?.spec?.containers?.[0]?.env || [];
+    const env = job.spec?.template?.spec?.containers?.[0]?.env ?? [];
 
     expect(env.some((entry) => entry.name === 'WIN_IMAGE_NAME')).toBe(false);
   });

--- a/src/views/checkups/self-validation/utils/selfValidationJob/resultsResources.ts
+++ b/src/views/checkups/self-validation/utils/selfValidationJob/resultsResources.ts
@@ -1,6 +1,6 @@
-/* eslint-disable */
 import { JobModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiBatchV1Job } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiBatchV1Job } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { isConflictError } from '@kubevirt-utils/errors/errorTypes';
 import { kubevirtK8sCreate, kubevirtK8sGet } from '@multicluster/k8sRequests';
 
 import { type ValidatedJobParameters } from '../constants';
@@ -61,9 +61,8 @@ export const createResultsResourcesJob = async (
       model: JobModel,
     });
     return job;
-  } catch (error: any) {
-    // If job already exists (409), fetch and return the existing job
-    if (error?.response?.status === 409 || error?.code === 409) {
+  } catch (error: unknown) {
+    if (isConflictError(error)) {
       const existingJob = await kubevirtK8sGet<IoK8sApiBatchV1Job>({
         cluster,
         model: JobModel,

--- a/src/views/checkups/self-validation/utils/selfValidationMessages.tsx
+++ b/src/views/checkups/self-validation/utils/selfValidationMessages.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable */
-import React, { ReactElement } from 'react';
+import React, { type ReactElement } from 'react';
 import { Link } from 'react-router';
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 import { extractConfigMapName } from 'src/views/checkups/utils/utils';
 
-import { IoK8sApiBatchV1Job } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiBatchV1Job } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { getSelfValidationCheckupURL } from '@kubevirt-utils/resources/checkups/urls';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getCluster } from '@multicluster/helpers/selectors';
@@ -17,7 +16,7 @@ export const getRunningCheckupErrorMessage = (
   const jobLinks = runningJobs.flatMap((job, index) => {
     const configMapInfo = extractConfigMapName(job);
 
-    const jobName = getName(job) || t('Unknown');
+    const jobName = getName(job) ?? t('Unknown');
     const key = getName(job) ?? `job-${index}`;
     const cluster = getCluster(job);
     const url = getSelfValidationCheckupURL(getName(job), getNamespace(job), cluster);

--- a/src/views/checkups/storage/components/CheckupsStorageActions.tsx
+++ b/src/views/checkups/storage/components/CheckupsStorageActions.tsx
@@ -1,10 +1,10 @@
-/* eslint-disable */
+import type { FC } from 'react';
 import React, { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import {
-  IoK8sApiBatchV1Job,
-  IoK8sApiCoreV1ConfigMap,
+  type IoK8sApiBatchV1Job,
+  type IoK8sApiCoreV1ConfigMap,
 } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import DeleteModal from '@kubevirt-utils/components/DeleteModal/DeleteModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
@@ -21,14 +21,16 @@ import { createCheckupRerunHandler } from '../../utils/createCheckupRerunHandler
 import { getCheckupImageFromNewestJob } from '../../utils/utils';
 import { deleteStorageCheckup, rerunStorageCheckup } from '../utils/utils';
 
-const CheckupsStorageActions = ({
-  configMap,
-  isKebab = false,
-  jobs,
-}: {
+type CheckupsStorageActionsProps = {
   configMap: IoK8sApiCoreV1ConfigMap;
   isKebab?: boolean;
   jobs: IoK8sApiBatchV1Job[];
+};
+
+const CheckupsStorageActions: FC<CheckupsStorageActionsProps> = ({
+  configMap,
+  isKebab = false,
+  jobs,
 }) => {
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
@@ -39,7 +41,7 @@ const CheckupsStorageActions = ({
   const toast = useKubevirtToast();
   const [isActionsOpen, setIsActionsOpen] = useState<boolean>(false);
 
-  const onToggle = () => setIsActionsOpen((prevIsOpen) => !prevIsOpen);
+  const onToggle = (): void => setIsActionsOpen((prevIsOpen) => !prevIsOpen);
 
   const Toggle = isKebab
     ? KebabToggle({ isExpanded: isActionsOpen, onClick: onToggle })

--- a/src/views/checkups/storage/components/hooks/useCheckupsStorageData.ts
+++ b/src/views/checkups/storage/components/hooks/useCheckupsStorageData.ts
@@ -1,7 +1,9 @@
-/* eslint-disable */
 import useCheckupsData from '../../../utils/hooks/useCheckupsData';
 import { KUBEVIRT_STORAGE_LABEL_VALUE } from '../../utils/consts';
 
-const useCheckupsStorageData = () => useCheckupsData({ labelValue: KUBEVIRT_STORAGE_LABEL_VALUE });
+type UseCheckupsStorageDataResult = ReturnType<typeof useCheckupsData>;
+
+const useCheckupsStorageData = (): UseCheckupsStorageDataResult =>
+  useCheckupsData({ labelValue: KUBEVIRT_STORAGE_LABEL_VALUE });
 
 export default useCheckupsStorageData;

--- a/src/views/checkups/storage/components/hooks/useCheckupsStoragePermissions.ts
+++ b/src/views/checkups/storage/components/hooks/useCheckupsStoragePermissions.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 import { findObjectByName } from 'src/views/checkups/utils/utils';
 
@@ -10,10 +9,10 @@ import {
   ServiceAccountModel,
 } from '@kubevirt-ui-ext/kubevirt-api/console';
 import {
-  IoK8sApiCoreV1ServiceAccount,
-  IoK8sApiRbacV1ClusterRoleBinding,
-  IoK8sApiRbacV1Role,
-  IoK8sApiRbacV1RoleBinding,
+  type IoK8sApiCoreV1ServiceAccount,
+  type IoK8sApiRbacV1ClusterRoleBinding,
+  type IoK8sApiRbacV1Role,
+  type IoK8sApiRbacV1RoleBinding,
 } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
@@ -27,7 +26,14 @@ import {
   STORAGE_CLUSTER_ROLE_BINDING,
 } from '../../utils/consts';
 
-export const useCheckupsStoragePermissions = () => {
+type UseCheckupsStoragePermissionsResult = {
+  clusterRoleBinding: IoK8sApiRbacV1ClusterRoleBinding | undefined;
+  isPermitted: boolean;
+  isPermittedToInstall: boolean;
+  loading: boolean;
+};
+
+export const useCheckupsStoragePermissions = (): UseCheckupsStoragePermissionsResult => {
   const namespace = useActiveNamespace();
   const cluster = useSelectedCluster();
   const isAllNamespace = namespace === ALL_NAMESPACES_SESSION_KEY;

--- a/src/views/checkups/storage/list/checkupsStorageCells.tsx
+++ b/src/views/checkups/storage/list/checkupsStorageCells.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { Link } from 'react-router';
 
-import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { getStorageCheckupURL } from '@kubevirt-utils/resources/checkups/urls';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
@@ -19,20 +18,19 @@ import {
   STATUS_START_TIME_STAMP,
 } from '../../utils/utils';
 import CheckupsStorageActions from '../components/CheckupsStorageActions';
-
-import { CheckupsStorageCallbacks } from './checkupsStorageListDefinition';
+import { type CheckupsStorageCallbacks } from './checkupsStorageListDefinition';
 
 export { ClusterCell, NamespaceCell };
 
 export const NameCell: FC<{ row: IoK8sApiCoreV1ConfigMap }> = ({ row }) => {
   const [hubClusterName] = useHubClusterName();
   const isACMPage = useIsACMPage();
-  const cluster = getCluster(row) || hubClusterName;
+  const cluster = getCluster(row) ?? hubClusterName;
   const name = getName(row);
   const namespace = getNamespace(row);
 
   if (!name || !namespace) {
-    return <>{name || NO_DATA_DASH}</>;
+    return <>{name ?? NO_DATA_DASH}</>;
   }
 
   return (
@@ -56,8 +54,8 @@ export const StatusCell: FC<{
 };
 
 export const FailureCell: FC<{ row: IoK8sApiCoreV1ConfigMap }> = ({ row }) => (
-  <span data-test={`checkup-failure-${getName(row) || row?.metadata?.uid || 'unknown'}`}>
-    {row?.data?.[STATUS_FAILURE_REASON] || NO_DATA_DASH}
+  <span data-test={`checkup-failure-${getName(row) ?? row?.metadata?.uid ?? 'unknown'}`}>
+    {row?.data?.[STATUS_FAILURE_REASON] ?? NO_DATA_DASH}
   </span>
 );
 

--- a/src/views/checkups/storage/list/checkupsStorageListDefinition.tsx
+++ b/src/views/checkups/storage/list/checkupsStorageListDefinition.tsx
@@ -1,12 +1,11 @@
-/* eslint-disable */
 import React from 'react';
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
 import {
-  IoK8sApiBatchV1Job,
-  IoK8sApiCoreV1ConfigMap,
+  type IoK8sApiBatchV1Job,
+  type IoK8sApiCoreV1ConfigMap,
 } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
+import { type ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { ACTIONS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getCluster } from '@multicluster/helpers/selectors';
@@ -22,7 +21,6 @@ import {
   STATUS_START_TIME_STAMP,
   STATUS_SUCCEEDED,
 } from '../../utils/utils';
-
 import {
   ActionsCell,
   ClusterCell,
@@ -54,7 +52,8 @@ export const getCheckupsStorageColumns = (
   ...(isACMPage
     ? [
         {
-          getValue: (row: IoK8sApiCoreV1ConfigMap) => getCluster(row) || hubClusterName || '',
+          getValue: (row: IoK8sApiCoreV1ConfigMap): string =>
+            getCluster(row) ?? hubClusterName ?? '',
           key: 'cluster',
           label: t('Cluster'),
           renderCell: (row: IoK8sApiCoreV1ConfigMap) => <ClusterCell row={row} />,
@@ -74,7 +73,7 @@ export const getCheckupsStorageColumns = (
       ]
     : []),
   {
-    getValue: (row, callbacks) => {
+    getValue: (row, callbacks): string => {
       const latestJob = callbacks?.getJobByName(getName(row))?.[0];
       return getCSVExportStatusLabel(getConfigMapStatus(row, getJobStatus(latestJob)), t);
     },
@@ -85,7 +84,7 @@ export const getCheckupsStorageColumns = (
     sortable: true,
   },
   {
-    getValue: (row) => row?.data?.[STATUS_FAILURE_REASON] || '',
+    getValue: (row): string => row?.data?.[STATUS_FAILURE_REASON] ?? '',
     key: 'failure',
     label: t('Failure reason'),
     renderCell: (row) => <FailureCell row={row} />,
@@ -93,7 +92,7 @@ export const getCheckupsStorageColumns = (
     sortable: true,
   },
   {
-    getValue: (row) => row?.data?.[STATUS_START_TIME_STAMP] || '',
+    getValue: (row): string => row?.data?.[STATUS_START_TIME_STAMP] ?? '',
     key: CHECKUPS_COLUMN_KEYS.START_TIME,
     label: t('Start time'),
     renderCell: (row) => <StartTimeCell row={row} />,
@@ -101,7 +100,7 @@ export const getCheckupsStorageColumns = (
     sortable: true,
   },
   {
-    getValue: (row) => row?.data?.[STATUS_COMPLETION_TIME_STAMP] || '',
+    getValue: (row): string => row?.data?.[STATUS_COMPLETION_TIME_STAMP] ?? '',
     key: CHECKUPS_COLUMN_KEYS.COMPLETE_TIME,
     label: t('Completion time'),
     renderCell: (row) => <CompleteTimeCell row={row} />,

--- a/src/views/checkups/utils/createCheckupRerunHandler.tsx
+++ b/src/views/checkups/utils/createCheckupRerunHandler.tsx
@@ -1,17 +1,15 @@
-/* eslint-disable */
 import React from 'react';
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
 import {
-  IoK8sApiBatchV1Job,
-  IoK8sApiCoreV1ConfigMap,
+  type IoK8sApiBatchV1Job,
+  type IoK8sApiCoreV1ConfigMap,
 } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { ModalComponent } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
-import { ToastActions } from '@kubevirt-utils/hooks/useKubevirtToast';
+import { type ModalComponent } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
+import { type ToastActions } from '@kubevirt-utils/hooks/useKubevirtToast';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 
 import RerunCheckupModal from '../components/RerunCheckupModal';
-
 import { showRerunToast } from './showRerunToast';
 import { isJobRunning } from './utils';
 
@@ -40,7 +38,7 @@ export const createCheckupRerunHandler = ({
   t,
   toast,
 }: CreateCheckupRerunHandlerParams): (() => void) => {
-  const executeRerun = async () => {
+  const executeRerun = async (): Promise<void> => {
     try {
       await rerun();
       if (isKebab) {
@@ -64,14 +62,14 @@ export const createCheckupRerunHandler = ({
           {...props}
           onConfirm={() => {
             props.onClose();
-            executeRerun();
+            void executeRerun();
           }}
           message={runningJobWarningMessage}
           variant="warning"
         />
       ));
     } else {
-      executeRerun();
+      void executeRerun();
     }
   };
 };

--- a/src/views/checkups/utils/showRerunToast.tsx
+++ b/src/views/checkups/utils/showRerunToast.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
 import React from 'react';
+import { type TFunction } from 'i18next';
 
-import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { ToastActions } from '@kubevirt-utils/hooks/useKubevirtToast';
+import { type IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type ToastActions } from '@kubevirt-utils/hooks/useKubevirtToast';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getCluster } from '@multicluster/helpers/selectors';
 
@@ -17,7 +16,13 @@ type ShowRerunToastParams = {
   toast: ToastActions;
 };
 
-export const showRerunToast = ({ configMap, getUrl, navigate, t, toast }: ShowRerunToastParams) => {
+export const showRerunToast = ({
+  configMap,
+  getUrl,
+  navigate,
+  t,
+  toast,
+}: ShowRerunToastParams): void => {
   const name = getName(configMap);
   const url = getUrl(name, getNamespace(configMap), getCluster(configMap));
 

--- a/src/views/dashboard-extensions/Activity.tsx
+++ b/src/views/dashboard-extensions/Activity.tsx
@@ -1,13 +1,12 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { Link } from 'react-router';
 
 import { TemplateModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { type V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import {
   getGroupVersionKindForModel,
-  K8sActivityProps,
-  K8sResourceCommon,
+  type K8sActivityProps,
   ResourceIcon,
   ResourceLink,
 } from '@openshift-console/dynamic-plugin-sdk';
@@ -16,19 +15,15 @@ import { ActivityItem } from '@openshift-console/dynamic-plugin-sdk-internal';
 import ActivityProgress from './ActivityProgress';
 import { diskImportKindMapping, VIRTUALMACHINES_TEMPLATES_BASE_URL } from './utils';
 
-export const DiskImportActivity: FC<
-  K8sActivityProps<
-    K8sResourceCommon & {
-      data?: { [key: string]: any };
-      spec?: {
-        [key: string]: any;
-      };
-      status?: { [key: string]: any };
-    }
-  >
-> = ({ resource }) => {
-  const progress = parseInt(resource?.status?.progress, 10);
-  const { kind, name, uid } = resource.metadata.ownerReferences[0];
+export const DiskImportActivity: FC<K8sActivityProps<V1beta1DataVolume>> = ({ resource }) => {
+  const progress = parseInt(resource?.status?.progress ?? '', 10);
+  const ownerReference = resource.metadata?.ownerReferences?.[0];
+
+  if (!ownerReference) {
+    return null;
+  }
+
+  const { kind, name, uid } = ownerReference;
   const model = diskImportKindMapping[kind];
   const ownerLink =
     model === TemplateModel ? (

--- a/src/views/dashboard-extensions/KubevirtHealthPopup/components/HealthPopupChart.tsx
+++ b/src/views/dashboard-extensions/KubevirtHealthPopup/components/HealthPopupChart.tsx
@@ -1,15 +1,14 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 
+import { type AlertType } from '@kubevirt-utils/components/AlertsCard/utils/types';
 import SubTitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/SubTitleChartLabel';
 import TitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/TitleChartLabel';
-import { AlertsBySeverity } from '@kubevirt-utils/hooks/useInfrastructureAlerts/useInfrastructureAlerts';
+import { type AlertsBySeverity } from '@kubevirt-utils/hooks/useInfrastructureAlerts/useInfrastructureAlerts';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { ChartDonut } from '@patternfly/react-charts/victory';
 
 import { alertTypeToColorMap } from '../utils/utils';
-
 import EmptyStateNoAlerts from './EmptyStateNoAlerts';
 
 type HealthPopupChartProps = {
@@ -17,18 +16,24 @@ type HealthPopupChartProps = {
   numberOfAlerts?: number;
 };
 
+type ChartDatum = {
+  fill: string;
+  x: AlertType;
+  y: number;
+};
+
 const HealthPopupChart: FC<HealthPopupChartProps> = ({ alerts, numberOfAlerts }) => {
   const { t } = useKubevirtTranslation();
   const totalNumberAlerts = useMemo(
-    () => Object.values(alerts)?.reduce((acc, alertType) => acc + (alertType?.length || 0), 0),
+    () => Object.values(alerts)?.reduce((acc, alertType) => acc + (alertType?.length ?? 0), 0),
     [alerts],
   );
 
   const chartData = useMemo(
     () =>
-      Object.keys(alerts)?.reduce((acc, alertType) => {
-        const numAlertsForType: number = alerts[alertType]?.length;
-        const percentage: number = Math.round((numAlertsForType / totalNumberAlerts) * 100);
+      (Object.keys(alerts) as AlertType[]).reduce<ChartDatum[]>((acc, alertType) => {
+        const numAlertsForType = alerts[alertType]?.length ?? 0;
+        const percentage = Math.round((numAlertsForType / totalNumberAlerts) * 100);
         acc.push({
           fill: alertTypeToColorMap[alertType],
           x: alertType,

--- a/src/views/dashboard-extensions/KubevirtHealthPopup/utils/types.ts
+++ b/src/views/dashboard-extensions/KubevirtHealthPopup/utils/types.ts
@@ -1,6 +1,5 @@
-/* eslint-disable */
 export enum HealthImpactLevel {
-  critical = 'critical',
-  none = 'none',
-  warning = 'warning',
+  Critical = 'critical',
+  None = 'none',
+  Warning = 'warning',
 }

--- a/src/views/dashboard-extensions/utils.ts
+++ b/src/views/dashboard-extensions/utils.ts
@@ -1,8 +1,9 @@
-/* eslint-disable */
+import { DataVolumeModel, modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { TemplateModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { DataVolumeModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineInstanceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { type V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 export { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 
 export const diskImportKindMapping = {
@@ -82,19 +83,22 @@ export const printableStatusToLabel = {
   [printableVmStatus.WaitingForVolumeBinding]: VMStatusSimpleLabel.Starting,
 };
 
-export const getVmStatusLabelFromPrintable = (printableStatus: string) =>
-  printableStatusToLabel?.[printableStatus] || StatusSimpleLabel.Other;
+export const getVmStatusLabelFromPrintable = (
+  printableStatus: string,
+): StatusSimpleLabel | VMStatusSimpleLabel =>
+  printableStatusToLabel?.[printableStatus] ?? StatusSimpleLabel.Other;
 
 export const VIRTUALMACHINES_TEMPLATES_BASE_URL = 'virtualmachinetemplates';
 
-export const getTimestamp = (resource) => new Date(resource.metadata.creationTimestamp);
+export const getTimestamp = (resource: K8sResourceCommon): Date | undefined =>
+  resource.metadata?.creationTimestamp ? new Date(resource.metadata.creationTimestamp) : undefined;
 
-export const isDVActivity = (resource) =>
+export const isDVActivity = (resource: V1beta1DataVolume): boolean =>
   resource?.status?.phase === 'ImportInProgress' &&
-  Object.keys(diskImportKindMapping).includes(resource?.metadata?.ownerReferences?.[0]?.kind);
+  Object.keys(diskImportKindMapping).includes(resource?.metadata?.ownerReferences?.[0]?.kind ?? '');
 
 export const k8sDVResource = {
+  groupVersionKind: modelToGroupVersionKind(DataVolumeModel),
   isList: true,
-  kind: DataVolumeModel,
   prop: 'dvs',
 };

--- a/src/views/datasources/actions/DataSourceActions.tsx
+++ b/src/views/datasources/actions/DataSourceActions.tsx
@@ -1,12 +1,11 @@
-/* eslint-disable */
-import React, { FC, useState } from 'react';
+import React, { type FC, useState } from 'react';
 
-import { V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import DropdownToggle from '@kubevirt-utils/components/toggles/DropdownToggle';
 import KebabToggle from '@kubevirt-utils/components/toggles/KebabToggle';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getContentScrollableElement } from '@kubevirt-utils/utils/utils';
-import { Action } from '@openshift-console/dynamic-plugin-sdk';
+import { type Action } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Divider,
   Dropdown,
@@ -37,7 +36,7 @@ const DataSourceActions: FC<DataSourceActionProps> = ({
   const dsActions = actions.filter((a) => a.id !== 'datasource-action-manage-source');
   const manageAction = actions.find((a) => a.id === 'datasource-action-manage-source');
 
-  const onToggle = () => {
+  const onToggle = (): void => {
     setIsOpen((prevIsOpen) => {
       if (!prevIsOpen) onLazyOpen();
 
@@ -49,7 +48,7 @@ const DataSourceActions: FC<DataSourceActionProps> = ({
     ? KebabToggle({ isExpanded: isOpen, onClick: onToggle })
     : DropdownToggle({ children: t('Actions'), isExpanded: isOpen, onClick: onToggle });
 
-  const handleClick = (action: Action) => {
+  const handleClick = (action: Action): void => {
     if (typeof action?.cta === 'function') {
       action.cta();
     }

--- a/src/views/datasources/dataimportcron/details/DataImportCronManageDetails/DataImportCronManageDetails.tsx
+++ b/src/views/datasources/dataimportcron/details/DataImportCronManageDetails/DataImportCronManageDetails.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import {
-  V1beta1DataImportCron,
-  V1beta1DataSource,
+  type V1beta1DataImportCron,
+  type V1beta1DataSource,
 } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
@@ -34,7 +33,7 @@ export const DataImportCronManageDetails: FC<DataImportCronManageDetailsProps> =
   const { t } = useKubevirtTranslation();
 
   const source = dataImportCron?.spec?.template.spec?.source?.registry?.url;
-  const importsToKeep = dataImportCron?.spec?.importsToKeep?.toString() || t('3 (default)');
+  const importsToKeep = dataImportCron?.spec?.importsToKeep?.toString() ?? t('3 (default)');
   const isAutoUpdated = isDataImportCronAutoUpdated(dataSource, dataImportCron);
   const isOwnedBySSP = isDataResourceOwnedBySSP(dataImportCron);
 

--- a/src/views/datasources/details/components/DataSourceAnnotations/DataSourceAnnotations.tsx
+++ b/src/views/datasources/details/components/DataSourceAnnotations/DataSourceAnnotations.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { Link } from 'react-router';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -10,7 +9,7 @@ type DataSourceAnnotationsProps = {
 
 const DataSourceAnnotations: FC<DataSourceAnnotationsProps> = ({ annotations }) => {
   const { t } = useKubevirtTranslation();
-  const keys = Object.keys(annotations || {});
+  const keys = Object.keys(annotations ?? {});
   return <Link to="#">{t('{{annotations}} Annotations', { annotations: keys?.length })}</Link>;
 };
 

--- a/src/views/datasources/details/components/DataSourceDetailsGrid/DataSourceDetailsGrid.tsx
+++ b/src/views/datasources/details/components/DataSourceDetailsGrid/DataSourceDetailsGrid.tsx
@@ -1,10 +1,8 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { getDataSourceCronJob } from 'src/views/datasources/utils';
 
-import { PersistentVolumeClaimModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { DataSourceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import PreferencePopoverContent from '@kubevirt-utils/components/AddBootableVolumeModal/components/VolumeMetadata/components/PreferenceSelect/PreferencePopoverContent';
 import DescriptionItemAnnotations from '@kubevirt-utils/components/DescriptionItem/components/DescriptionItemAnnotations';
 import DescriptionItemCreatedAt from '@kubevirt-utils/components/DescriptionItem/components/DescriptionItemCreatedAt';
@@ -14,12 +12,12 @@ import DescriptionItemNamespace from '@kubevirt-utils/components/DescriptionItem
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import OwnerDetailsItem from '@kubevirt-utils/components/OwnerDetailsItem/OwnerDetailsItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { modelToGroupVersionKind, PersistentVolumeClaimModel } from '@kubevirt-utils/models';
 import { OLSPromptType } from '@lightspeed/utils/prompts';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 import { DescriptionList, Grid, GridItem } from '@patternfly/react-core';
 
 import DataSourceImportCronDescription from '../DataSourceImportCronDescription/DataSourceImportCronDescription';
-
 import DataSourceInstanceTypeLink from './DataSourceInstanceTypeLink';
 import DataSourcePreferenceLink from './DataSourcePreferenceLink';
 
@@ -31,7 +29,7 @@ export const DataSourceDetailsGrid: FC<DataSourceDetailsGridProps> = ({ dataSour
   const { t } = useKubevirtTranslation();
   const dataImportCron = getDataSourceCronJob(dataSource);
   const { name: pvcSourceName, namespace: pvcSourceNamespace } =
-    dataSource?.spec?.source?.pvc || {};
+    dataSource?.spec?.source?.pvc ?? {};
 
   return (
     <Grid hasGutter>
@@ -58,7 +56,7 @@ export const DataSourceDetailsGrid: FC<DataSourceDetailsGridProps> = ({ dataSour
             <DescriptionItem
               descriptionData={
                 <ResourceLink
-                  kind={PersistentVolumeClaimModel.kind}
+                  groupVersionKind={modelToGroupVersionKind(PersistentVolumeClaimModel)}
                   name={pvcSourceName}
                   namespace={pvcSourceNamespace}
                 />

--- a/src/views/datasources/list/CreateDataSourceModal/utils.ts
+++ b/src/views/datasources/list/CreateDataSourceModal/utils.ts
@@ -1,11 +1,10 @@
-/* eslint-disable */
 import produce from 'immer';
 
 import { DataImportCronModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { DataSourceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import {
-  V1beta1DataImportCron,
-  V1beta1DataSource,
+  type V1beta1DataImportCron,
+  type V1beta1DataSource,
 } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import { CDI_BIND_REQUESTED_ANNOTATION } from '@kubevirt-utils/hooks/useCDIUpload/consts';
 import { buildOwnerReference } from '@kubevirt-utils/resources/shared';
@@ -60,7 +59,7 @@ export const createDataSourceWithImportCron = async ({
   schedule: string;
   size: string;
   url: string;
-}) => {
+}): Promise<void> => {
   const dataImportCronName = `${dataSourceName}-import-cron`;
   const dataImportCron = produce(initialDataImportCron, (draft) => {
     draft.metadata.name = dataImportCronName;

--- a/src/views/datasources/list/cells/DataSourceNamespaceCell.tsx
+++ b/src/views/datasources/list/cells/DataSourceNamespaceCell.tsx
@@ -1,7 +1,7 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { modelToGroupVersionKind, NamespaceModel } from '@kubevirt-utils/models';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -10,7 +10,10 @@ type DataSourceNamespaceCellProps = {
 };
 
 const DataSourceNamespaceCell: FC<DataSourceNamespaceCellProps> = ({ row }) => (
-  <ResourceLink kind="Namespace" name={getNamespace(row)} />
+  <ResourceLink
+    groupVersionKind={modelToGroupVersionKind(NamespaceModel)}
+    name={getNamespace(row)}
+  />
 );
 
 export default DataSourceNamespaceCell;

--- a/src/views/lightspeed/components/LightspeedHelpButton/LightspeedHelpButton.tsx
+++ b/src/views/lightspeed/components/LightspeedHelpButton/LightspeedHelpButton.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useResourceEvents from '@kubevirt-utils/hooks/useResourceEvents/useResourceEvents';
@@ -8,7 +7,7 @@ import { isEmpty } from '@kubevirt-utils/utils/utils';
 import AIExperienceIcon from '@lightspeed/components/AIExperienceIcon';
 import useLightspeedActions from '@lightspeed/hooks/useLightspeedActions/useLightspeedActions';
 import { DEFAULT_MAX_EVENTS, RESOURCE_EVENTS_TIMEOUT_MS } from '@lightspeed/utils/constants';
-import { getOLSPrompt, OLSPromptType } from '@lightspeed/utils/prompts';
+import { getOLSPrompt, type OLSPromptType } from '@lightspeed/utils/prompts';
 import {
   asOLSEventsAttachment,
   asOLSYAMLAttachment,
@@ -47,7 +46,7 @@ const LightspeedHelpButton: FC<LightspeedHelpButtonProps> = ({
   const yamlAttachment = obj ? asOLSYAMLAttachment(obj) : null;
   const prompt = getOLSPrompt(promptType, isVM(obj) && { vm: obj });
 
-  const handleClick = async () => {
+  const handleClick = async (): Promise<void> => {
     onClick?.();
     clearAttachments();
     clearContextEvents();

--- a/src/views/lightspeed/hooks/useLightspeedActions/useLightspeedActions.ts
+++ b/src/views/lightspeed/hooks/useLightspeedActions/useLightspeedActions.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useDispatch } from 'react-redux';
 
 import {
@@ -13,7 +12,13 @@ import {
   updateChatHistoryByID,
   updateChatHistoryTool,
 } from '@lightspeed/hooks/useLightspeedActions/utils/lightspeedActions';
-import { Attachment, ChatEntry, Tool } from '@lightspeed/hooks/useLightspeedActions/utils/types';
+import {
+  type Attachment,
+  type ChatEntry,
+  type Tool,
+} from '@lightspeed/hooks/useLightspeedActions/utils/types';
+
+type OLSDispatch = (action: { payload?: unknown; type: string }) => void;
 
 type UseLightspeedActions = () => {
   clearAttachments: () => void;
@@ -29,7 +34,7 @@ type UseLightspeedActions = () => {
 };
 
 const useLightspeedActions: UseLightspeedActions = () => {
-  const dispatch = useDispatch();
+  const dispatch = useDispatch() as OLSDispatch;
 
   return {
     clearAttachments: () => dispatch(attachmentsClear()),

--- a/src/views/lightspeed/hooks/useLightspeedActions/utils/lightspeedActions.ts
+++ b/src/views/lightspeed/hooks/useLightspeedActions/utils/lightspeedActions.ts
@@ -1,7 +1,10 @@
-/* eslint-disable */
-import { action } from 'typesafe-actions';
+import { action, type EmptyAction, type PayloadAction } from 'typesafe-actions';
 
-import { Attachment, ChatEntry, Tool } from '@lightspeed/hooks/useLightspeedActions/utils/types';
+import {
+  type Attachment,
+  type ChatEntry,
+  type Tool,
+} from '@lightspeed/hooks/useLightspeedActions/utils/types';
 
 export enum OLSActionType {
   AttachmentsClear = 'attachmentsClear',
@@ -16,26 +19,47 @@ export enum OLSActionType {
   SetQuery = 'setQuery',
 }
 
-export const attachmentsClear = () => action(OLSActionType.AttachmentsClear);
+export const attachmentsClear = (): EmptyAction<OLSActionType.AttachmentsClear> =>
+  action(OLSActionType.AttachmentsClear);
 
-export const clearContextEvents = () => action(OLSActionType.ClearContextEvents);
+export const clearContextEvents = (): EmptyAction<OLSActionType.ClearContextEvents> =>
+  action(OLSActionType.ClearContextEvents);
 
-export const closeOLSDrawer = () => action(OLSActionType.CloseOLS);
+export const closeOLSDrawer = (): EmptyAction<OLSActionType.CloseOLS> =>
+  action(OLSActionType.CloseOLS);
 
-export const openOLSDrawer = () => action(OLSActionType.OpenOLS);
+export const openOLSDrawer = (): EmptyAction<OLSActionType.OpenOLS> =>
+  action(OLSActionType.OpenOLS);
 
-export const setQuery = (query: string) => action(OLSActionType.SetQuery, { query });
+export const setQuery = (query: string): PayloadAction<OLSActionType.SetQuery, { query: string }> =>
+  action(OLSActionType.SetQuery, { query });
 
-export const pushChatHistory = (entry: ChatEntry) =>
+export const pushChatHistory = (
+  entry: ChatEntry,
+): PayloadAction<OLSActionType.ChatHistoryPush, { entry: ChatEntry }> =>
   action(OLSActionType.ChatHistoryPush, { entry });
 
-export const updateChatHistoryByID = (id: string, entry: Partial<ChatEntry>) =>
+export const updateChatHistoryByID = (
+  id: string,
+  entry: Partial<ChatEntry>,
+): PayloadAction<OLSActionType.ChatHistoryUpdateByID, { entry: Partial<ChatEntry>; id: string }> =>
   action(OLSActionType.ChatHistoryUpdateByID, { entry, id });
 
-export const updateChatHistoryTool = (id: string, toolID: string, tool: Partial<Tool>) =>
-  action(OLSActionType.ChatHistoryUpdateTool, { id, tool, toolID });
+export const updateChatHistoryTool = (
+  id: string,
+  toolID: string,
+  tool: Partial<Tool>,
+): PayloadAction<
+  OLSActionType.ChatHistoryUpdateTool,
+  { id: string; tool: Partial<Tool>; toolID: string }
+> => action(OLSActionType.ChatHistoryUpdateTool, { id, tool, toolID });
 
-export const setAttachment = (attachment: Attachment) =>
+export const setAttachment = (
+  attachment: Attachment,
+): PayloadAction<OLSActionType.AttachmentSet, Attachment> =>
   action(OLSActionType.AttachmentSet, attachment);
 
-export const setConversationID = (id: string) => action(OLSActionType.SetConversationID, { id });
+export const setConversationID = (
+  id: string,
+): PayloadAction<OLSActionType.SetConversationID, { id: string }> =>
+  action(OLSActionType.SetConversationID, { id });

--- a/src/views/lightspeed/utils/api.ts
+++ b/src/views/lightspeed/utils/api.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_LIGHTSPEED_API_BASE_URL, OLS_API_BASE_URL } from '@lightspeed/utils/constants';
 
 export const getAPIURL = (path: string): string => {
-  const base = (String(OLS_API_BASE_URL || '') || DEFAULT_LIGHTSPEED_API_BASE_URL).replace(
+  const base = (String(OLS_API_BASE_URL ?? '') || DEFAULT_LIGHTSPEED_API_BASE_URL).replace(
     /\/+$/,
     '',
   );

--- a/src/views/lightspeed/utils/constants.ts
+++ b/src/views/lightspeed/utils/constants.ts
@@ -1,8 +1,13 @@
-/* eslint-disable */
+type OLSApiBaseUrlEnv = {
+  OLS_API_BASE_URL?: string;
+};
+
+const olsApiBaseUrlEnv = process.env.OLS_API_BASE_URL as OLSApiBaseUrlEnv | undefined;
+
 export const OLS_SUBMIT_BUTTON_ELEMENT_CLASS = 'pf-chatbot__button--send';
 
 export const DEFAULT_LIGHTSPEED_API_BASE_URL = '/api/proxy/plugin/lightspeed-console-plugin/ols';
-export const OLS_API_BASE_URL = process.env.OLS_API_BASE_URL?.['OLS_API_BASE_URL'];
+export const OLS_API_BASE_URL = olsApiBaseUrlEnv?.OLS_API_BASE_URL;
 
 export const DEFAULT_MAX_EVENTS = 10;
 

--- a/src/views/migrationpolicies/components/MigrationPolicyConfigurations/MigrationPolicyConfigurations.tsx
+++ b/src/views/migrationpolicies/components/MigrationPolicyConfigurations/MigrationPolicyConfigurations.tsx
@@ -1,17 +1,16 @@
-/* eslint-disable */
-import React, { Dispatch, FC, SetStateAction } from 'react';
+import React, { type ComponentType, type Dispatch, type FC, type SetStateAction } from 'react';
 
 import { Button, ButtonVariant, Form, FormGroup, Split, SplitItem } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 
-import { InitialMigrationPolicyState } from '../../list/components/MigrationPolicyCreateForm/utils/utils';
+import { type InitialMigrationPolicyState } from '../../list/components/MigrationPolicyCreateForm/utils/utils';
 import { migrationPolicySpecKeys } from '../../utils/constants';
 import {
-  EditMigrationPolicyInitialState,
-  MigrationPolicyStateDispatch,
+  type EditMigrationPolicyInitialState,
+  type MigrationPolicyStateDispatch,
 } from '../MigrationPolicyEditModal/utils/constants';
-
 import MigrationPolicyConfigurationDropdown from './compnents/MigrationPolicyConfigurationDropdown/MigrationPolicyConfigurationDropdown';
+import { type MigrationPolicyConfigurationComponentProps } from './utils/constants';
 import { getMigrationPolicyConfigurationOptions } from './utils/utils';
 
 type MigrationPolicyConfigurationsProps = {
@@ -39,38 +38,47 @@ const MigrationPolicyConfigurations: FC<MigrationPolicyConfigurationsProps> = ({
       />
       {hasConfigSelected && (
         <Form isHorizontal>
-          {Object.entries(options).map(
-            ([key, { component: Component, label }]) =>
-              key in state && (
-                <FormGroup
-                  data-test={`${key}-selected`}
-                  fieldId={key}
-                  hasNoPaddingTop
-                  key={key}
-                  label={label}
-                >
-                  <Split>
-                    <SplitItem>
-                      <Component setState={setStateField(key)} state={state?.[key]} />
-                    </SplitItem>
-                    <SplitItem>
-                      <Button
-                        onClick={() =>
-                          setState((prev) => {
-                            const newState = { ...prev };
-                            delete newState[key];
-                            return newState;
-                          })
-                        }
-                        icon={<MinusCircleIcon />}
-                        isInline
-                        variant={ButtonVariant.plain}
-                      />
-                    </SplitItem>
-                  </Split>
-                </FormGroup>
-              ),
-          )}
+          {Object.entries(options).map(([key, { component, label }]) => {
+            if (!(key in state)) {
+              return null;
+            }
+
+            const ConfigurationComponent =
+              component as ComponentType<MigrationPolicyConfigurationComponentProps>;
+
+            return (
+              <FormGroup
+                data-test={`${key}-selected`}
+                fieldId={key}
+                hasNoPaddingTop
+                key={key}
+                label={label}
+              >
+                <Split>
+                  <SplitItem>
+                    <ConfigurationComponent
+                      setState={setStateField(key)}
+                      state={state[key] as MigrationPolicyStateDispatch}
+                    />
+                  </SplitItem>
+                  <SplitItem>
+                    <Button
+                      onClick={() =>
+                        setState((prev) => {
+                          const newState = { ...prev };
+                          delete newState[key];
+                          return newState;
+                        })
+                      }
+                      icon={<MinusCircleIcon />}
+                      isInline
+                      variant={ButtonVariant.plain}
+                    />
+                  </SplitItem>
+                </Split>
+              </FormGroup>
+            );
+          })}
         </Form>
       )}
     </>

--- a/src/views/migrationpolicies/components/MigrationPolicyConfigurations/compnents/BandwidthInput/BandwidthInput.tsx
+++ b/src/views/migrationpolicies/components/MigrationPolicyConfigurations/compnents/BandwidthInput/BandwidthInput.tsx
@@ -8,7 +8,6 @@ import React, {
 
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { type QuantityUnit } from '@kubevirt-utils/utils/unitConstants';
 import { BinaryUnit } from '@kubevirt-utils/utils/unitConstants';
 import { addByteSuffix } from '@kubevirt-utils/utils/units';
 import { NumberInput, SelectOption, Split, SplitItem } from '@patternfly/react-core';
@@ -16,12 +15,12 @@ import { NumberInput, SelectOption, Split, SplitItem } from '@patternfly/react-c
 type BandwidthInputProps = {
   setState: Dispatch<
     SetStateAction<{
-      unit: QuantityUnit;
+      unit: BinaryUnit;
       value: number;
     }>
   >;
   state: {
-    unit: QuantityUnit;
+    unit: BinaryUnit;
     value: number;
   };
 };
@@ -32,7 +31,7 @@ const BandwidthInput: FC<BandwidthInputProps> = ({ setState, state }) => {
   const { t } = useKubevirtTranslation();
 
   const onSelectUnit = useCallback(
-    (_event, newUnit: QuantityUnit) => {
+    (_event, newUnit: BinaryUnit) => {
       setState((prev) => ({ ...prev, unit: newUnit }));
     },
     [setState],

--- a/src/views/migrationpolicies/components/MigrationPolicyConfigurations/compnents/MigrationPolicyConfigurationDropdown/MigrationPolicyConfigurationDropdown.tsx
+++ b/src/views/migrationpolicies/components/MigrationPolicyConfigurations/compnents/MigrationPolicyConfigurationDropdown/MigrationPolicyConfigurationDropdown.tsx
@@ -1,16 +1,15 @@
-/* eslint-disable */
-import React, { Dispatch, FC, SetStateAction, useState } from 'react';
+import React, { type Dispatch, type FC, type SetStateAction, useState } from 'react';
 
 import DropdownToggle from '@kubevirt-utils/components/toggles/DropdownToggle';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core';
 
-import { InitialMigrationPolicyState } from '../../../../list/components/MigrationPolicyCreateForm/utils/utils';
+import { type InitialMigrationPolicyState } from '../../../../list/components/MigrationPolicyCreateForm/utils/utils';
 import {
-  EditMigrationPolicyInitialState,
-  MigrationPolicyStateDispatch,
+  type EditMigrationPolicyInitialState,
+  type MigrationPolicyStateDispatch,
 } from '../../../MigrationPolicyEditModal/utils/constants';
-import { MigrationPolicyConfigurationOption } from '../../utils/constants';
+import { type MigrationPolicyConfigurationOption } from '../../utils/constants';
 
 type MigrationPolicyConfigurationDropdownProps = {
   isDisabled: boolean;
@@ -28,12 +27,12 @@ const MigrationPolicyConfigurationDropdown: FC<MigrationPolicyConfigurationDropd
   const { t } = useKubevirtTranslation();
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleOptionClick = (key: string, defaultValue: MigrationPolicyStateDispatch) => {
+  const handleOptionClick = (key: string, defaultValue: MigrationPolicyStateDispatch): void => {
     setState((prev) => ({ ...prev, [key]: defaultValue }));
     setIsOpen(false);
   };
 
-  const onToggle = () => setIsOpen((prevIsOpen) => !prevIsOpen);
+  const onToggle = (): void => setIsOpen((prevIsOpen) => !prevIsOpen);
   return (
     <Dropdown
       toggle={DropdownToggle({

--- a/src/views/migrationpolicies/components/MigrationPolicyConfigurations/utils/constants.ts
+++ b/src/views/migrationpolicies/components/MigrationPolicyConfigurations/utils/constants.ts
@@ -1,13 +1,29 @@
-/* eslint-disable */
-import { FC } from 'react';
+import { type ComponentType, type Dispatch, type SetStateAction } from 'react';
 
-import { MigrationPolicyStateDispatch } from '../../MigrationPolicyEditModal/utils/constants';
+import { type BinaryUnit } from '@kubevirt-utils/utils/unitConstants';
+
+import { type MigrationPolicyStateDispatch } from '../../MigrationPolicyEditModal/utils/constants';
+
+export type MigrationPolicyConfigurationComponentProps<
+  T extends MigrationPolicyStateDispatch = MigrationPolicyStateDispatch,
+> = {
+  setState: Dispatch<SetStateAction<T>>;
+  state: T;
+};
+
+type MigrationPolicyConfigurationEntry<T extends MigrationPolicyStateDispatch> = {
+  component: ComponentType<MigrationPolicyConfigurationComponentProps<T>>;
+  defaultValue: T;
+  description?: string;
+  label: string;
+};
 
 export type MigrationPolicyConfigurationOption = {
-  [key: string]: {
-    component: FC<any>;
-    defaultValue: MigrationPolicyStateDispatch;
-    description?: string;
-    label: string;
-  };
+  allowAutoConverge: MigrationPolicyConfigurationEntry<boolean>;
+  allowPostCopy: MigrationPolicyConfigurationEntry<boolean>;
+  bandwidthPerMigration: MigrationPolicyConfigurationEntry<{
+    unit: BinaryUnit;
+    value: number;
+  }>;
+  completionTimeoutPerGiB: MigrationPolicyConfigurationEntry<number>;
 };

--- a/src/views/migrationpolicies/components/MigrationPolicyConfigurations/utils/utils.ts
+++ b/src/views/migrationpolicies/components/MigrationPolicyConfigurations/utils/utils.ts
@@ -4,8 +4,7 @@ import { BinaryUnit } from '@kubevirt-utils/utils/unitConstants';
 import BandwidthInput from '../compnents/BandwidthInput/BandwidthInput';
 import CompletionTimeout from '../compnents/CompletionTimeout/CompletionTimeout';
 import YesNoDropdown from '../compnents/YesNoDropdown/YesNoDropdown';
-
-import type { MigrationPolicyConfigurationOption } from './constants';
+import { type MigrationPolicyConfigurationOption } from './constants';
 
 export const getMigrationPolicyConfigurationOptions = (): MigrationPolicyConfigurationOption => {
   return {

--- a/src/views/migrationpolicies/details/hooks/useMigrationPolicyTabs.ts
+++ b/src/views/migrationpolicies/details/hooks/useMigrationPolicyTabs.ts
@@ -1,22 +1,27 @@
-/* eslint-disable */
+import { useMemo } from 'react';
+import { type TabConfig } from 'src/views/checkups/utils/types';
+
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
 import MigrationPolicyDetailsPage from '../tabs/details/MigrationPolicyDetailsPage';
 import MigrationPolicyYAMLPage from '../tabs/yaml/MigrationPolicyYAMLPage';
 
-export const useMigrationPolicyTabs = () => {
+export const useMigrationPolicyTabs = (): TabConfig[] => {
   const { t } = useKubevirtTranslation();
 
-  return [
-    {
-      component: MigrationPolicyDetailsPage,
-      href: '',
-      name: t('Details'),
-    },
-    {
-      component: MigrationPolicyYAMLPage,
-      href: 'yaml',
-      name: t('YAML'),
-    },
-  ];
+  return useMemo(
+    () => [
+      {
+        component: MigrationPolicyDetailsPage,
+        href: '',
+        name: t('Details'),
+      },
+      {
+        component: MigrationPolicyYAMLPage,
+        href: 'yaml',
+        name: t('YAML'),
+      },
+    ],
+    [t],
+  );
 };

--- a/src/views/migrationpolicies/hooks/useMigrationPoliciesListURL.ts
+++ b/src/views/migrationpolicies/hooks/useMigrationPoliciesListURL.ts
@@ -1,11 +1,10 @@
-/* eslint-disable */
 import { MigrationPolicyModelRef } from '@kubevirt-utils/models';
 import { CLUSTER_LIST_FILTER_PARAM } from '@kubevirt-utils/utils/constants';
 import { FLEET_MIGRATION_POLICIES_PATH } from '@multicluster/constants';
 import useCluster from '@multicluster/hooks/useCluster';
 import useIsACMPage from '@multicluster/useIsACMPage';
 
-export const useMigrationPoliciesListURL = () => {
+export const useMigrationPoliciesListURL = (): string => {
   const isACMPage = useIsACMPage();
   const cluster = useCluster();
 

--- a/src/views/migrationpolicies/list/components/MigrationPolicyCreateForm/copmonents/MigrationPolicyFormFooter/MigrationPolicyFormFooter.tsx
+++ b/src/views/migrationpolicies/list/components/MigrationPolicyCreateForm/copmonents/MigrationPolicyFormFooter/MigrationPolicyFormFooter.tsx
@@ -1,11 +1,11 @@
-/* eslint-disable */
-import React, { FC, MouseEventHandler, useState } from 'react';
+import React, { type FC, type MouseEventHandler, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { getMigrationPolicyURL } from 'src/views/migrationpolicies/utils/utils';
 
 import { MigrationPolicyModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1alpha1MigrationPolicy } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1alpha1MigrationPolicy } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { type K8sLikeError } from '@kubevirt-utils/utils/formatK8sError';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { kubevirtK8sCreate } from '@multicluster/k8sRequests';
 import {
@@ -29,7 +29,7 @@ const MigrationPolicyFormFooter: FC<MigrationPolicyFormFooterProps> = ({ migrati
   const cluster = useClusterParam();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState(undefined);
+  const [error, setError] = useState<K8sLikeError | undefined>();
   const migrationPolicyName = migrationPolicy?.metadata?.name;
 
   const handleSubmit: MouseEventHandler<HTMLButtonElement> = (e) => {
@@ -43,7 +43,7 @@ const MigrationPolicyFormFooter: FC<MigrationPolicyFormFooterProps> = ({ migrati
       .finally(() => setIsSubmitting(false));
   };
 
-  const closeModal = () => {
+  const closeModal = (): void => {
     setError(undefined);
     setIsSubmitting(false);
     navigate(-1);

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/SSHConfiguration/SSHConfiguration.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/SSHConfiguration/SSHConfiguration.tsx
@@ -63,7 +63,7 @@ const SSHConfiguration: FC<SSHConfigurationProps> = ({ newBadge }) => {
     [cluster, featureConfigMap],
   );
 
-  const onTextChange = useDebounceCallback((val: string, field) => {
+  const onTextChange = useDebounceCallback((val: string, field: string) => {
     onChange(val, field);
   }, 700);
 

--- a/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/AutomaticSubscriptionRHELGuests.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/AutomaticSubscriptionRHELGuests.tsx
@@ -100,7 +100,9 @@ const AutomaticSubscriptionRHELGuests: FC<AutomaticSubscriptionRHELGuestsProps> 
                 {selected?.value ===
                   AutomaticSubscriptionTypeEnum.MONITOR_AND_MANAGE_SUBSCRIPTIONS && (
                   <AutomaticSubscriptionCustomUrl
+                    canEdit={formProps.canEdit}
                     customUrl={formProps.subscriptionData?.customUrl}
+                    updateSubscription={formProps.updateSubscription}
                   />
                 )}
               </>

--- a/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/components/AutomaticSubscriptionCustomUrl/AutomaticSubscriptionCustomUrl.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/components/AutomaticSubscriptionCustomUrl/AutomaticSubscriptionCustomUrl.tsx
@@ -1,31 +1,25 @@
 import React, { type FC, useEffect, useMemo, useState } from 'react';
 
-import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
-import { AUTOMATIC_SUBSCRIPTION_CUSTOM_URL } from '@kubevirt-utils/hooks/useFeatures/constants';
-import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { type RHELAutomaticSubscriptionData } from '@kubevirt-utils/hooks/useRHELAutomaticSubscription/utils/types';
 import { debounce } from '@kubevirt-utils/utils/debounce';
 import { Checkbox, Content, Flex, PopoverPosition, TextInput } from '@patternfly/react-core';
-import { useSettingsCluster } from '@settings/context/SettingsClusterContext';
 
 import './automatic-subscription-custom-url.scss';
 
 type AutomaticSubscriptionCustomUrlProps = {
+  canEdit: boolean;
   customUrl: string;
-  isDisabled?: boolean;
+  updateSubscription: (data: Partial<RHELAutomaticSubscriptionData>) => void;
 };
 
 const AutomaticSubscriptionCustomUrl: FC<AutomaticSubscriptionCustomUrlProps> = ({
+  canEdit,
   customUrl,
-  isDisabled,
+  updateSubscription,
 }) => {
   const { t } = useKubevirtTranslation();
-  const cluster = useSettingsCluster();
-  const { error, toggleFeature: patchCustomUrl } = useFeatures(
-    AUTOMATIC_SUBSCRIPTION_CUSTOM_URL,
-    cluster,
-  );
   const [isChecked, setIsChecked] = useState<boolean>(!!customUrl);
   const [inputValue, setInputValue] = useState<string>(customUrl);
 
@@ -37,9 +31,9 @@ const AutomaticSubscriptionCustomUrl: FC<AutomaticSubscriptionCustomUrlProps> = 
   const debounceUpdateCustomUrl = useMemo(
     () =>
       debounce((url: string): void => {
-        void patchCustomUrl(url);
+        updateSubscription({ customUrl: url });
       }, 1000),
-    [patchCustomUrl],
+    [updateSubscription],
   );
 
   return (
@@ -47,12 +41,14 @@ const AutomaticSubscriptionCustomUrl: FC<AutomaticSubscriptionCustomUrlProps> = 
       <Flex alignItems={{ default: 'alignItemsCenter' }} gap={{ default: 'gapSm' }}>
         <Checkbox
           id="auto-register-rhel"
-          isChecked={isChecked && !isDisabled}
-          isDisabled={isDisabled}
+          isChecked={isChecked}
+          isDisabled={!canEdit}
           label={t('Use custom registration server url')}
           onChange={() =>
             setIsChecked((prevIsChecked) => {
-              if (prevIsChecked) debounceUpdateCustomUrl('');
+              if (prevIsChecked) {
+                debounceUpdateCustomUrl('');
+              }
               return !prevIsChecked;
             })
           }
@@ -62,22 +58,20 @@ const AutomaticSubscriptionCustomUrl: FC<AutomaticSubscriptionCustomUrlProps> = 
           position={PopoverPosition.right}
         />
       </Flex>
-      {isChecked && !isDisabled && (
-        <>
-          <Flex>
-            <Content component="p">{t('URL')}</Content>
-            <TextInput
-              className="AutomaticSubscriptionCustomUrl--input"
-              id="custom-url-input"
-              onChange={(_event, value: string) => {
-                setInputValue(value);
-                debounceUpdateCustomUrl(value);
-              }}
-              value={inputValue}
-            />
-          </Flex>
-          <ErrorAlert error={error} />
-        </>
+      {isChecked && (
+        <Flex>
+          <Content component="p">{t('URL')}</Content>
+          <TextInput
+            className="AutomaticSubscriptionCustomUrl--input"
+            id="custom-url-input"
+            isDisabled={!canEdit}
+            onChange={(_event, value: string) => {
+              setInputValue(value);
+              debounceUpdateCustomUrl(value);
+            }}
+            value={inputValue}
+          />
+        </Flex>
       )}
     </div>
   );

--- a/src/views/virtualmachines/node/inventoryitem/NodeInventoryItem.tsx
+++ b/src/views/virtualmachines/node/inventoryitem/NodeInventoryItem.tsx
@@ -108,13 +108,21 @@ export const NodeInventoryItem: FC<{ obj: NodeKind }> = ({ obj }) => {
               <FlexItem>
                 <NodeInventoryStatusItem
                   count={primaryStatuses.Error}
-                  icon={<vmStatusIcon.Error size="xl" />}
+                  icon={
+                    <Icon size="xl">
+                      <vmStatusIcon.Error />
+                    </Icon>
+                  }
                 />
               </FlexItem>
               <FlexItem>
                 <NodeInventoryStatusItem
                   count={primaryStatuses.Running}
-                  icon={<vmStatusIcon.Running size="xl" />}
+                  icon={
+                    <Icon size="xl">
+                      <vmStatusIcon.Running />
+                    </Icon>
+                  }
                 />
               </FlexItem>
               <FlexItem>


### PR DESCRIPTION
## 📝 Description

Adds eslint typescript rules to the code base part- 7


## 🔗 Links

https://redhat.atlassian.net/browse/CNV-90382


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected critical health alert handling so critical alerts are identified reliably.
  * Improved preservation of valid empty or zero values across checkup, data source, and dashboard displays.
  * Prevented errors when activity resources lack owner information or timestamp metadata.
  * Improved handling of conflicting checkup resource requests.

* **Settings**
  * Custom RHEL guest subscription URLs now respect edit permissions and update through the settings form.

* **UI Improvements**
  * Updated node inventory status icons for clearer, more consistent sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->