### PR TITLE
CNV-90382: add typescript-linters-part-8

### DIFF
--- a/src/views/migrationpolicies/list/components/MigrationPolicyCreateForm/utils/utils.ts
+++ b/src/views/migrationpolicies/list/components/MigrationPolicyCreateForm/utils/utils.ts
@@ -1,8 +1,7 @@
-/* eslint-disable */
 import produce from 'immer';
 
-import { V1alpha1MigrationPolicy } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { BinaryUnit } from '@kubevirt-utils/utils/unitConstants';
+import { type V1alpha1MigrationPolicy } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type BinaryUnit } from '@kubevirt-utils/utils/unitConstants';
 import { generatePrettyName, isEmpty } from '@kubevirt-utils/utils/utils';
 
 import { getEmptyMigrationPolicy } from '../../../../utils/utils';
@@ -24,7 +23,9 @@ export const initialMigrationPolicyState: InitialMigrationPolicyState = {
   vmiSelectorMatchLabel: {},
 };
 
-export const produceMigrationPolicy = (state: InitialMigrationPolicyState) =>
+export const produceMigrationPolicy = (
+  state: InitialMigrationPolicyState,
+): V1alpha1MigrationPolicy =>
   produce<V1alpha1MigrationPolicy>(
     getEmptyMigrationPolicy(),
     (mpDraft: V1alpha1MigrationPolicy) => {
@@ -37,11 +38,11 @@ export const produceMigrationPolicy = (state: InitialMigrationPolicyState) =>
         migrationPolicyName,
         namespaceSelectorMatchLabel,
         vmiSelectorMatchLabel,
-      } = state || {};
+      } = state;
 
       mpDraft.metadata.name = migrationPolicyName;
 
-      mpDraft.metadata.annotations['description'] = description ? description : null;
+      mpDraft.metadata.annotations['description'] = description ?? null;
 
       mpDraft.spec.allowAutoConverge = allowAutoConverge;
 

--- a/src/views/migrationpolicies/list/migrationPoliciesDefinition.tsx
+++ b/src/views/migrationpolicies/list/migrationPoliciesDefinition.tsx
@@ -1,15 +1,13 @@
-/* eslint-disable */
 import React from 'react';
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
-import { V1alpha1MigrationPolicy } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
+import { type V1alpha1MigrationPolicy } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { ACTIONS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
 import { getName, getUID } from '@kubevirt-utils/resources/shared';
 import { getCluster } from '@multicluster/helpers/selectors';
 
 import { MIGRATION_POLICY_COLUMN_KEYS } from '../utils/constants';
-
 import {
   ActionsCell,
   AutoConvergeCell,
@@ -111,7 +109,7 @@ export const getMigrationPoliciesRowId = (row: V1alpha1MigrationPolicy, index: n
   const uid = getUID(row);
   if (uid) return uid;
 
-  const cluster = getCluster(row) || 'local';
+  const cluster = getCluster(row) ?? 'local';
   const name = getName(row);
 
   if (name) {

--- a/src/views/migrationpolicies/utils/utils.ts
+++ b/src/views/migrationpolicies/utils/utils.ts
@@ -1,12 +1,11 @@
-/* eslint-disable */
 import { MigrationPolicyModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1alpha1MigrationPolicy } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1alpha1MigrationPolicy } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind } from '@kubevirt-utils/models';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import { getClusterResourceRoute } from '@multicluster/urls';
-import { ExtensionK8sModel } from '@openshift-console/dynamic-plugin-sdk';
+import { type ExtensionK8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
 export const getBooleanText = (value: boolean): string => (value ? t('Yes') : t('No'));
 
@@ -15,8 +14,8 @@ export const getBandwidthPerMigrationText = (bandwidth: number | string): string
   return `${bandwidth}`;
 };
 
-export const getCompletionTimeoutText = (completionTimeout: number): string =>
-  completionTimeout !== undefined ? `${completionTimeout} sec` : NO_DATA_DASH;
+export const getCompletionTimeoutText = (completionTimeout: number | undefined): string =>
+  completionTimeout != null ? `${completionTimeout} sec` : NO_DATA_DASH;
 
 export const getEmptyMigrationPolicy = (): V1alpha1MigrationPolicy => ({
   apiVersion: `${MigrationPolicyModel.apiGroup}/${MigrationPolicyModel.apiVersion}`,
@@ -25,7 +24,7 @@ export const getEmptyMigrationPolicy = (): V1alpha1MigrationPolicy => ({
   spec: { selectors: {} },
 });
 
-export const getMigrationPolicyURL = (name: string, cluster?: string) =>
+export const getMigrationPolicyURL = (name: string, cluster?: string): string =>
   getClusterResourceRoute({
     cluster,
     model: modelToGroupVersionKind(MigrationPolicyModel) as ExtensionK8sModel,

--- a/src/views/preferences/list/clusterPreferenceDefinition.tsx
+++ b/src/views/preferences/list/clusterPreferenceDefinition.tsx
@@ -1,13 +1,12 @@
-/* eslint-disable */
-import React from 'react';
-import { TFunction } from 'i18next';
+import React, { type FC } from 'react';
+import { type TFunction } from 'i18next';
 
 import { VirtualMachineClusterPreferenceModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1beta1VirtualMachineClusterPreference } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getK8sRowId } from '@kubevirt-utils/components/KubevirtTable/utils';
 import RedHatLabel from '@kubevirt-utils/components/RedHatLabel/RedHatLabel';
 import { VENDOR_LABEL } from '@kubevirt-utils/constants/constants';
-import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
+import { type ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { getLabel, getName } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
@@ -15,7 +14,11 @@ import { getCluster } from '@multicluster/helpers/selectors';
 
 import ClusterPreferenceActions from '../actions/ClusterPreferenceActions';
 
-const NameCell = ({ row }: { row: V1beta1VirtualMachineClusterPreference }) => (
+type ClusterPreferenceCellProps = {
+  row: V1beta1VirtualMachineClusterPreference;
+};
+
+const NameCell: FC<ClusterPreferenceCellProps> = ({ row }) => (
   <>
     <MulticlusterResourceLink
       cluster={getCluster(row)}
@@ -27,11 +30,11 @@ const NameCell = ({ row }: { row: V1beta1VirtualMachineClusterPreference }) => (
   </>
 );
 
-const VendorCell = ({ row }: { row: V1beta1VirtualMachineClusterPreference }) => (
+const VendorCell: FC<ClusterPreferenceCellProps> = ({ row }) => (
   <>{getLabel(row, VENDOR_LABEL, NO_DATA_DASH)}</>
 );
 
-const ActionsCell = ({ row }: { row: V1beta1VirtualMachineClusterPreference }) => (
+const ActionsCell: FC<ClusterPreferenceCellProps> = ({ row }) => (
   <ClusterPreferenceActions isKebabToggle preference={row} />
 );
 

--- a/src/views/preferences/list/userPreferenceDefinition.tsx
+++ b/src/views/preferences/list/userPreferenceDefinition.tsx
@@ -1,13 +1,12 @@
-/* eslint-disable */
-import React from 'react';
-import { TFunction } from 'i18next';
+import React, { type FC } from 'react';
+import { type TFunction } from 'i18next';
 
 import { VirtualMachinePreferenceModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1beta1VirtualMachinePreference } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1beta1VirtualMachinePreference } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getK8sRowId } from '@kubevirt-utils/components/KubevirtTable/utils';
 import RedHatLabel from '@kubevirt-utils/components/RedHatLabel/RedHatLabel';
 import { VENDOR_LABEL } from '@kubevirt-utils/constants/constants';
-import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
+import { type ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { getLabel, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
@@ -15,7 +14,11 @@ import { getCluster } from '@multicluster/helpers/selectors';
 
 import UserPreferenceActions from '../actions/UserPreferenceActions';
 
-const NameCell = ({ row }: { row: V1beta1VirtualMachinePreference }) => (
+type UserPreferenceCellProps = {
+  row: V1beta1VirtualMachinePreference;
+};
+
+const NameCell: FC<UserPreferenceCellProps> = ({ row }) => (
   <>
     <MulticlusterResourceLink
       cluster={getCluster(row)}
@@ -28,15 +31,15 @@ const NameCell = ({ row }: { row: V1beta1VirtualMachinePreference }) => (
   </>
 );
 
-const NamespaceCell = ({ row }: { row: V1beta1VirtualMachinePreference }) => (
+const NamespaceCell: FC<UserPreferenceCellProps> = ({ row }) => (
   <>{getNamespace(row) ?? NO_DATA_DASH}</>
 );
 
-const VendorCell = ({ row }: { row: V1beta1VirtualMachinePreference }) => (
+const VendorCell: FC<UserPreferenceCellProps> = ({ row }) => (
   <>{getLabel(row, VENDOR_LABEL, NO_DATA_DASH)}</>
 );
 
-const ActionsCell = ({ row }: { row: V1beta1VirtualMachinePreference }) => (
+const ActionsCell: FC<UserPreferenceCellProps> = ({ row }) => (
   <UserPreferenceActions isKebabToggle preference={row} />
 );
 

--- a/src/views/quotas/details/types.ts
+++ b/src/views/quotas/details/types.ts
@@ -3,3 +3,17 @@ export enum ResourceKeyKind {
   CPU = 'CPU',
   MEMORY = 'MEMORY',
 }
+
+export type StatusChartInfo = {
+  available: number;
+  availableText: string;
+  max: number;
+  maxText: string;
+  percentage: number;
+  resourceKeyKind: ResourceKeyKind;
+  resourceLabel: string;
+  subTitle: string;
+  title: string;
+  used: number;
+  usedText: string;
+};

--- a/src/views/quotas/details/utils.ts
+++ b/src/views/quotas/details/utils.ts
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 import {
   getQuotaNumbers,
   getResourceKeyKind,
@@ -9,7 +8,7 @@ import {
 import { humanizeCpuCores } from '@kubevirt-utils/utils/humanize.js';
 import { getHumanizedSize } from '@kubevirt-utils/utils/units';
 
-import { ResourceKeyKind } from './types';
+import { ResourceKeyKind, type StatusChartInfo } from './types';
 
 export const getCountText = (
   count: number,
@@ -30,7 +29,7 @@ export const getStatusChartInfo = (
   usedValue: string,
   maxValue: string,
   t: TFunction,
-) => {
+): StatusChartInfo => {
   const resourceLabel = getResourceLabel(resourceKey, t);
   const resourceKeyKind = getResourceKeyKind(resourceKey);
 

--- a/src/views/quotas/form/QuotaYAMLEditor.tsx
+++ b/src/views/quotas/form/QuotaYAMLEditor.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, { type FC, Suspense, useState } from 'react';
 import { load } from 'js-yaml';
 
@@ -15,7 +14,7 @@ const QuotaYAMLEditor: FC<YAMLEditorProps> = ({ initialYAML = '', isEdit = false
   const [error, setError] = useState<Error | null>(null);
   const onQuotaSubmit = useOnQuotaSubmit(setError, isEdit);
 
-  const onSave = async (yaml: string) => {
+  const onSave = async (yaml: string): Promise<void> => {
     const quota = load(yaml) as ApplicationAwareQuota;
     await onQuotaSubmit(quota);
   };

--- a/src/views/quotas/form/hooks/useOnQuotaSubmit.ts
+++ b/src/views/quotas/form/hooks/useOnQuotaSubmit.ts
@@ -1,15 +1,14 @@
-/* eslint-disable */
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router';
 
-import { ApplicationAwareQuota } from '@kubevirt-utils/resources/quotas/types';
+import { type ApplicationAwareQuota } from '@kubevirt-utils/resources/quotas/types';
 import { kubevirtK8sCreate, kubevirtK8sUpdate } from '@multicluster/k8sRequests';
 
 import { getQuotaDetailsURL } from '../../utils/url';
 import { getQuotaModel } from '../../utils/utils';
 
 type UseOnQuotaSubmit = (
-  onError: (error: any) => void,
+  onError: (error: unknown) => void,
   isEdit: boolean,
 ) => (quota: ApplicationAwareQuota) => Promise<void>;
 

--- a/src/views/quotas/form/hooks/useOnQuotaUpdate.ts
+++ b/src/views/quotas/form/hooks/useOnQuotaUpdate.ts
@@ -1,6 +1,5 @@
-/* eslint-disable */
 import useNamespaceParam from '@kubevirt-utils/hooks/useNamespaceParam';
-import { ApplicationAwareResourceQuota } from '@kubevirt-utils/resources/quotas/types';
+import { type ApplicationAwareResourceQuota } from '@kubevirt-utils/resources/quotas/types';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 
 type UseOnQuotaUpdate = (
@@ -14,17 +13,17 @@ type UseOnQuotaUpdate = (
 const useOnQuotaUpdate: UseOnQuotaUpdate = (formData, onChange) => {
   const namespace = useNamespaceParam();
 
-  const updateFormData = (updated: ApplicationAwareResourceQuota) => {
+  const updateFormData = (updated: ApplicationAwareResourceQuota): void => {
     onChange?.({
       ...updated,
       metadata: {
         ...updated?.metadata,
-        namespace: getNamespace(updated) || namespace,
+        namespace: getNamespace(updated) ?? namespace,
       },
     });
   };
 
-  const updateMetadata = (key: string, value: string) => {
+  const updateMetadata = (key: string, value: string): void => {
     updateFormData({
       ...formData,
       metadata: {
@@ -34,7 +33,7 @@ const useOnQuotaUpdate: UseOnQuotaUpdate = (formData, onChange) => {
     });
   };
 
-  const updateHardValue = (key: string, value: number, unit = '') => {
+  const updateHardValue = (key: string, value: number, unit = ''): void => {
     updateFormData({
       ...formData,
       spec: {

--- a/src/views/quotas/list/hooks/useQuotasListTab.ts
+++ b/src/views/quotas/list/hooks/useQuotasListTab.ts
@@ -1,12 +1,12 @@
-/* eslint-disable */
-import { MouseEvent } from 'react';
+import { type MouseEvent } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
 import { ALL_NAMESPACES_SESSION_KEY } from '@kubevirt-utils/hooks/constants';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 
-import { CLUSTER_QUOTA_LIST_URL, getQuotaListURL } from '../../utils/url';
 import { QuotaScope } from '../constants';
+
+import { CLUSTER_QUOTA_LIST_URL, getQuotaListURL } from '../../utils/url';
 
 export type UseQuotasListTab = () => {
   activeTab: QuotaScope;
@@ -22,8 +22,11 @@ const useQuotasListTab: UseQuotasListTab = () => {
   const isClusterScoped = location.pathname.includes(CLUSTER_QUOTA_LIST_URL);
   const activeTab = isClusterScoped ? QuotaScope.CLUSTER : QuotaScope.PROJECT;
 
-  const handleTabSelect = (_event: MouseEvent, tabKey: QuotaScope) =>
-    navigate(tabKey === QuotaScope.CLUSTER ? CLUSTER_QUOTA_LIST_URL : getQuotaListURL(namespace));
+  const handleTabSelect = (_event: MouseEvent, tabKey: QuotaScope): void => {
+    void navigate(
+      tabKey === QuotaScope.CLUSTER ? CLUSTER_QUOTA_LIST_URL : getQuotaListURL(namespace),
+    );
+  };
 
   return { activeTab, handleTabSelect };
 };

--- a/src/views/quotas/utils/utils.ts
+++ b/src/views/quotas/utils/utils.ts
@@ -1,23 +1,23 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
 import {
   ApplicationAwareClusterResourceQuotaModel,
   ApplicationAwareResourceQuotaModel,
 } from '@kubevirt-utils/models';
 import {
-  ApplicationAwareResourceQuota,
-  QuotaStatus,
-  ResourceInfo,
+  type ApplicationAwareResourceQuota,
+  type QuotaStatus,
+  type ResourceInfo,
 } from '@kubevirt-utils/resources/quotas/types';
-import { ApplicationAwareQuota } from '@kubevirt-utils/resources/quotas/types';
+import { type ApplicationAwareQuota } from '@kubevirt-utils/resources/quotas/types';
 import { convertToBaseValue } from '@kubevirt-utils/utils/humanize.js';
 
 import { ResourceKeyKind } from '../details/types';
-
 import { RESOURCE_KEYS } from './constants';
 
-export const getQuotaModel = (quota: ApplicationAwareQuota) => {
+export const getQuotaModel = (
+  quota: ApplicationAwareQuota,
+): typeof ApplicationAwareResourceQuotaModel | typeof ApplicationAwareClusterResourceQuotaModel => {
   return isNamespacedQuota(quota)
     ? ApplicationAwareResourceQuotaModel
     : ApplicationAwareClusterResourceQuotaModel;
@@ -35,7 +35,9 @@ export const getStatus = (quota: ApplicationAwareQuota): QuotaStatus =>
 export const getSpecLimits = (quota: ApplicationAwareQuota): ResourceInfo =>
   isNamespacedQuota(quota) ? quota?.spec?.hard : quota?.spec?.quota?.hard;
 
-export const getMainResourceKeys = (isDedicatedVirtualResources: boolean) => {
+export const getMainResourceKeys = (
+  isDedicatedVirtualResources: boolean,
+): { cpu: string; memory: string; vmiCount: string } => {
   return {
     cpu: isDedicatedVirtualResources ? RESOURCE_KEYS.cpuRequestsVMI : RESOURCE_KEYS.cpuRequests,
     memory: isDedicatedVirtualResources

--- a/src/views/search/components/AdvancedSearchIcon.tsx
+++ b/src/views/search/components/AdvancedSearchIcon.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type FC } from 'react';
 import classNames from 'classnames';
 
 import { createIcon } from '@patternfly/react-icons/dist/esm/createIcon';
@@ -23,7 +22,7 @@ type AdvancedSearchIconProps = {
   isLarge?: boolean;
 };
 
-const AdvancedSearchIcon = ({ isLarge = false }: AdvancedSearchIconProps) => {
+const AdvancedSearchIcon: FC<AdvancedSearchIconProps> = ({ isLarge = false }) => {
   return (
     <AdvancedSearchIconComponent className={classNames('advanced-search-icon', { isLarge })} />
   );

--- a/src/views/search/components/AdvancedSearchModal/formFields/DateCreatedField.tsx
+++ b/src/views/search/components/AdvancedSearchModal/formFields/DateCreatedField.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { FormGroup } from '@patternfly/react-core';
@@ -23,7 +22,7 @@ const DateCreatedField: FC = () => {
   );
   const { setValue: setDateOption, value: dateOption } = useAdvancedSearchField('dateOption');
 
-  const effectiveDateOption = dateOption || (dateCreated as DateSelectOption);
+  const effectiveDateOption = dateOption ?? (dateCreated as DateSelectOption);
 
   return (
     <FormGroup label={t('Date created')}>

--- a/src/views/search/components/SavedSearchesDropdown/SavedSearchesDropdown.tsx
+++ b/src/views/search/components/SavedSearchesDropdown/SavedSearchesDropdown.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { type FC, useMemo, useState } from 'react';
+import React, { type FC, type JSX, useMemo, useState } from 'react';
 
 import {
   type KubevirtFilterState,
@@ -48,7 +47,9 @@ const SavedSearchesDropdown: FC<SavedSearchesDropdownProps> = ({ filters, onSetF
       return getSavedSearchesItemsToDisplay(sorted);
     }, [searches, filterText]);
 
-  const savedSearchesItemsToDropdownItems = (savedSearchesItems: SavedSearchEntry[]) =>
+  const savedSearchesItemsToDropdownItems = (
+    savedSearchesItems: SavedSearchEntry[],
+  ): JSX.Element[] =>
     savedSearchesItems.map(({ description, isFavorited, name }) => (
       <SavedSearchItem
         description={description}

--- a/src/views/search/components/SavedSearchesDropdown/utils/utils.ts
+++ b/src/views/search/components/SavedSearchesDropdown/utils/utils.ts
@@ -1,8 +1,10 @@
-/* eslint-disable */
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { type SavedSearchEntry } from '@search/savedSearches/types';
 
-export const getSortedSavedsearches = (searches: SavedSearchEntry[], filterText: string) => {
+export const getSortedSavedsearches = (
+  searches: SavedSearchEntry[],
+  filterText: string,
+): SavedSearchEntry[] => {
   const sorted = [...searches].sort((a, b) => Number(b.isFavorited) - Number(a.isFavorited));
   if (!filterText) return sorted;
   const lower = filterText.toLowerCase();

--- a/src/views/search/components/SearchDropdown/components/SearchByKeys/components/SearchKeysList.tsx
+++ b/src/views/search/components/SearchDropdown/components/SearchByKeys/components/SearchKeysList.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { MenuList } from '@patternfly/react-core';
-import { SearchKeyBadge } from '@search/components/SearchDropdown/types';
+import { type SearchKeyBadge } from '@search/components/SearchDropdown/types';
 
 import SearchKeyItem from './SearchKeyItem';
 
@@ -22,7 +21,7 @@ const SearchKeysList: FC<SearchKeysListProps> = ({
   startIndex = 0,
 }) => {
   const getCategoryLabel = (badge: SearchKeyBadge): string =>
-    labelLookup.get(badge.filterType) || badge.searchKey;
+    labelLookup.get(badge.filterType) ?? badge.searchKey;
 
   return (
     <MenuList>

--- a/src/views/search/components/SearchDropdown/hooks/useAutocompleteMode/utils.ts
+++ b/src/views/search/components/SearchDropdown/hooks/useAutocompleteMode/utils.ts
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import { KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
+import { type KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getFilterDefinition } from '@search/searchLanguage/utils';
 
-import { SearchKeyBadge } from '../../types';
+import { type SearchKeyBadge } from '../../types';
 
 export const getSearchBadge = (
   key: string,
@@ -27,7 +26,7 @@ export const getValuesPart = (
 
   const valuesPart = input.slice(colonIndex + 1);
   const segments = valuesPart.split(',');
-  const activeSegment = segments[segments.length - 1] || '';
+  const activeSegment = segments[segments.length - 1] ?? '';
   const selectedValues = segments.slice(0, -1).filter(Boolean);
 
   return { activeSegment, selectedValues };

--- a/src/views/search/searchLanguage/parser.ts
+++ b/src/views/search/searchLanguage/parser.ts
@@ -1,6 +1,5 @@
-/* eslint-disable */
 import { NUMERIC_OPERATOR_REGEX, SEARCH_KEY_TO_FILTER_TYPE } from './constants';
-import { SearchToken } from './types';
+import { type SearchToken } from './types';
 import { getSanitizedInput, isExcludedToken } from './utils';
 
 export const parseSearchToken = (input: string): SearchToken => {
@@ -9,7 +8,7 @@ export const parseSearchToken = (input: string): SearchToken => {
   const text = getSanitizedInput(trimmedInput);
   const exclude = isExcludedToken(trimmedInput);
 
-  const numericMatch = text.match(NUMERIC_OPERATOR_REGEX);
+  const numericMatch = NUMERIC_OPERATOR_REGEX.exec(text);
   if (numericMatch) {
     const [, rawKey, operator, value] = numericMatch;
     const searchKey = rawKey.toLowerCase();

--- a/src/views/search/searchLanguage/validateAndBuildFilterState/utils.ts
+++ b/src/views/search/searchLanguage/validateAndBuildFilterState/utils.ts
@@ -1,12 +1,11 @@
-/* eslint-disable */
-import { KubevirtFilterState } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
+import { type KubevirtFilterState } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 
 export const setFilter = (
   filterState: Partial<KubevirtFilterState>,
   tokenOrder: string[],
   key: string,
   value: string,
-) => {
+): void => {
   filterState[key] = [value];
   if (!tokenOrder.includes(key)) tokenOrder.push(key);
 };

--- a/src/views/settings/ExpandSection/ExpandSection.tsx
+++ b/src/views/settings/ExpandSection/ExpandSection.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, ReactNode, useEffect } from 'react';
+import React, { type FC, type ReactNode, useEffect } from 'react';
 import classNames from 'classnames';
 
 import { ExpandableSection } from '@patternfly/react-core';
@@ -37,7 +36,11 @@ const ExpandSection: FC<ExpandSectionProps> = ({
     if (isDisabled) setIsExpanded(false);
   }, [isDisabled, setIsExpanded]);
 
-  const handleToggle = (expanded: boolean) => (isDisabled ? null : setIsExpanded(expanded));
+  const handleToggle = (expanded: boolean): void => {
+    if (!isDisabled) {
+      setIsExpanded(expanded);
+    }
+  };
 
   return (
     <ExpandableSection

--- a/src/views/settings/ExpandSection/hooks/useIsExpandedAndHighlighted.ts
+++ b/src/views/settings/ExpandSection/hooks/useIsExpandedAndHighlighted.ts
@@ -1,11 +1,16 @@
-/* eslint-disable */
-import { useEffect, useMemo, useState } from 'react';
+import { type Dispatch, type SetStateAction, useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router';
 
 import { idIsHighlighted } from '@kubevirt-utils/components/SearchItem/useIsHighlighted';
 import { isSearchItemChildrenHighlighted } from '@settings/search/search';
 
-const useIsExpandedAndHighlighted = (searchItemId?: string) => {
+type UseIsExpandedAndHighlightedReturn = {
+  isExpanded: boolean;
+  isHighlighted: boolean;
+  setIsExpanded: Dispatch<SetStateAction<boolean>>;
+};
+
+const useIsExpandedAndHighlighted = (searchItemId?: string): UseIsExpandedAndHighlightedReturn => {
   const location = useLocation();
 
   const isHighlighted = useMemo(

--- a/src/views/settings/SettingsPage.tsx
+++ b/src/views/settings/SettingsPage.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useCallback, useState } from 'react';
+import React, { type FC, useCallback, useState } from 'react';
 import { Link } from 'react-router';
 
 import ClusterDropdown from '@kubevirt-utils/components/ClusterProjectDropdown/ClusterDropdown';
@@ -41,7 +40,7 @@ const SettingsPage: FC = () => {
   const [selectedCluster, setSelectedCluster] = useState<string>();
 
   const showClusterDropdown = clusterNames?.length > 1;
-  const activeCluster = selectedCluster || hubClusterName;
+  const activeCluster = selectedCluster ?? hubClusterName;
 
   const contextCluster =
     activeCluster && activeCluster !== hubClusterName ? activeCluster : undefined;

--- a/src/views/settings/SettingsTab.tsx
+++ b/src/views/settings/SettingsTab.tsx
@@ -1,5 +1,5 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { createElement, type FC } from 'react';
+import classNames from 'classnames';
 
 import { Card, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
 
@@ -7,7 +7,6 @@ import { useSettingsTabs } from './hooks/useSettingsTabs';
 
 import './settings-tab.scss';
 import '@kubevirt-utils/styles/cursor.scss';
-import classNames from 'classnames';
 
 const SettingsTab: FC = () => {
   const { activeTab, redirectTab, tabs } = useSettingsTabs();
@@ -29,7 +28,7 @@ const SettingsTab: FC = () => {
       </div>
       <div className="settings-tab__scrollable">
         <Card className="settings-tab__card">
-          {tabs.map(({ Component, dataTest, isFullWidth, name }) =>
+          {tabs.map(({ Component: tabComponent, dataTest, isFullWidth, name }) =>
             activeTab === name ? (
               <div
                 className={classNames('settings-tab__content', {
@@ -38,7 +37,7 @@ const SettingsTab: FC = () => {
                 data-test={dataTest}
                 key={name}
               >
-                <Component />
+                {createElement(tabComponent)}
               </div>
             ) : null,
           )}

--- a/src/views/settings/hooks/useSettingsTabs.ts
+++ b/src/views/settings/hooks/useSettingsTabs.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
@@ -6,9 +5,13 @@ import { VIRTUALIZATION_PATHS } from '@kubevirt-utils/constants/constants';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
-import { getTabs } from '../tabs';
+import { getTabs, type SettingsTabConfig } from '../tabs';
 
-export const useSettingsTabs = () => {
+export const useSettingsTabs = (): {
+  activeTab: string;
+  redirectTab: (name: string, replace?: boolean) => void;
+  tabs: SettingsTabConfig[];
+} => {
   const { t } = useKubevirtTranslation();
   const navigate = useNavigate();
   const location = useLocation();
@@ -37,7 +40,7 @@ export const useSettingsTabs = () => {
 
   const [activeTab, setActiveTab] = useState<string>(() => {
     const tabFromURL = getActiveTabFromURL();
-    return tabFromURL || tabs[0]?.name || '';
+    return tabFromURL ?? tabs[0]?.name ?? '';
   });
 
   const redirectTab = useCallback(

--- a/src/views/settings/tabs/ClusterTab/components/GeneralInformation/GeneralInformation.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralInformation/GeneralInformation.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC, type ReactNode } from 'react';
 
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { SubscriptionKind } from '@overview/utils/types';
+import { type SubscriptionKind } from '@overview/utils/types';
 import {
   Alert,
   AlertVariant,
@@ -42,7 +41,7 @@ const GeneralInformation: FC<GeneralInformationProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
 
-  const getUpdateStatusContent = () => {
+  const getUpdateStatusContent = (): ReactNode => {
     if (!loaded) return <Skeleton />;
     if (catalogSourceMissing) return <SourceMissingStatus />;
     return <SubscriptionStatus operatorLink={operatorLink} subscription={kubevirtSubscription} />;

--- a/src/views/settings/tabs/ClusterTab/components/GeneralInformation/components/SubscriptionStatus.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralInformation/components/SubscriptionStatus.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { SubscriptionKind, SubscriptionState } from '@overview/utils/types';
+import { type SubscriptionKind, SubscriptionState } from '@overview/utils/types';
 
 import SubscriptionStateAtLatest from './SubscriptionStates/SubscriptionStateAtLatest';
 import SubscriptionStateDefault from './SubscriptionStates/SubscriptionStateDefault';
@@ -25,7 +24,7 @@ const SubscriptionStatus: FC<SubscriptionStatusType> = ({ operatorLink, subscrip
     ),
   };
 
-  return Component[subscription?.status?.state || 'default'];
+  return Component[subscription?.status?.state ?? 'default'];
 };
 
 export default SubscriptionStatus;

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/AdvancedCDROMFeatures/hooks/useAdvancedCDROMFeatureFlag.ts
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/AdvancedCDROMFeatures/hooks/useAdvancedCDROMFeatureFlag.ts
@@ -1,21 +1,27 @@
-/* eslint-disable */
 import { useState } from 'react';
 
 import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { K8S_OPS } from '@kubevirt-utils/constants/constants';
 import useHyperConvergeConfiguration, {
-  HyperConverged,
+  type HyperConverged,
 } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
 
 import { DECLARATIVE_HOTPLUG_VOLUMES_FEATURE_GATE } from './constants';
 
+type AdvancedCDROMFeatureFlag = {
+  canEdit: boolean;
+  featureEnabled: boolean;
+  loading: boolean;
+  toggleFeature: (val: boolean) => Promise<HyperConverged | undefined>;
+};
+
 const updateDeclarativeHotplugVolumesFeatureGate = (
   hcoCR: HyperConverged,
   switchState: boolean,
   cluster?: string,
-) => {
+): Promise<HyperConverged> => {
   const featureGates = hcoCR.spec?.featureGates;
   const hasGate = featureGates?.hasOwnProperty(DECLARATIVE_HOTPLUG_VOLUMES_FEATURE_GATE);
 
@@ -34,7 +40,7 @@ const updateDeclarativeHotplugVolumesFeatureGate = (
   });
 };
 
-const useAdvancedCDROMFeatureFlag = (cluster?: string) => {
+const useAdvancedCDROMFeatureFlag = (cluster?: string): AdvancedCDROMFeatureFlag => {
   const [loading, setLoading] = useState(false);
   const [hyperConvergeConfiguration, hcoLoaded] = useHyperConvergeConfiguration(cluster);
   const isAdmin = useIsAdmin();

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/AutomaticallyGrantVirtualizationRoles/AutomaticallyGrantVirtualizationRoles.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/AutomaticallyGrantVirtualizationRoles/AutomaticallyGrantVirtualizationRoles.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable */
-import React, { FC, useMemo, useState } from 'react';
+import React, { type FC, useMemo, useState } from 'react';
 
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
 import { CONTROL_DEFAULT_VIRTUALIZATION_PERMISSIONS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import { type HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getErrorMessage } from '@kubevirt-utils/utils/utils';
@@ -14,7 +13,6 @@ import ExpandSection from '@settings/ExpandSection/ExpandSection';
 import { CLUSTER_TAB_IDS } from '@settings/search/constants';
 
 import { getGeneralSettingsLabels } from '../consts/consts';
-
 import { isAutomaticRoleGrantEnabled, setRoleAggregationStrategy } from './utils/utils';
 
 type AutomaticallyGrantVirtualizationRolesProps = {
@@ -39,14 +37,14 @@ const AutomaticallyGrantVirtualizationRoles: FC<AutomaticallyGrantVirtualization
   );
 
   const switchIsOn = useMemo(() => isAutomaticRoleGrantEnabled(hyperConverge), [hyperConverge]);
-  const displayError = useMemo(() => error || hyperError?.message, [error, hyperError]);
+  const displayError = useMemo(() => error ?? hyperError?.message, [error, hyperError]);
 
   const isDisabled = useMemo(
     () => !isAdmin || !hyperLoaded || isLoading || Boolean(hyperError) || !previewFeatureEnabled,
     [isAdmin, hyperLoaded, isLoading, hyperError, previewFeatureEnabled],
   );
 
-  const onChange = async (checked: boolean) => {
+  const onChange = async (checked: boolean): Promise<void> => {
     if (!hyperConverge || !isAdmin) {
       return;
     }
@@ -56,8 +54,8 @@ const AutomaticallyGrantVirtualizationRoles: FC<AutomaticallyGrantVirtualization
 
     try {
       await setRoleAggregationStrategy(hyperConverge, checked, cluster);
-    } catch (error) {
-      setError(getErrorMessage(error));
+    } catch (updateError) {
+      setError(getErrorMessage(updateError));
     } finally {
       setIsLoading(false);
     }

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/AutomaticallyGrantVirtualizationRoles/utils/utils.ts
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/AutomaticallyGrantVirtualizationRoles/utils/utils.ts
@@ -1,10 +1,10 @@
-/* eslint-disable */
 import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { K8S_OPS } from '@kubevirt-utils/constants/constants';
 import { HCO_MANUAL_ROLE_AGGREGATION_STRATEGY } from '@kubevirt-utils/flags/consts';
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import { type HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { getHCORoleAggregationStrategy } from '@kubevirt-utils/resources/hyperconverged/selectors';
 import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
+
 import {
   HCO_AGGREGATE_TO_DEFAULT_ROLE_AGGREGATION_STRATEGY,
   HCO_ROLE_AGGREGATION_STRATEGY_PATH,
@@ -17,7 +17,7 @@ export const setRoleAggregationStrategy = (
   hyperConverge: HyperConverged,
   automaticallyGrant: boolean,
   cluster?: string,
-) => {
+): Promise<HyperConverged> => {
   const hasStrategy = Boolean(getHCORoleAggregationStrategy(hyperConverge));
 
   return kubevirtK8sPatch<HyperConverged>({

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/GeneralSettings.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/GeneralSettings.tsx
@@ -1,16 +1,14 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { createElement, type FC } from 'react';
 
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Stack, StackItem } from '@patternfly/react-core';
 import ExpandSection from '@settings/ExpandSection/ExpandSection';
 import { CLUSTER_TAB_IDS } from '@settings/search/constants';
 
-import { getGeneralSettingsSections } from './consts/consts';
+import { getGeneralSettingsSections, type HyperConvergeConfigurationWatch } from './consts/consts';
 
 type GeneralSettingsProps = {
-  hyperConvergeConfiguration: [hyperConvergeConfig: HyperConverged, loaded: boolean, error: any];
+  hyperConvergeConfiguration: HyperConvergeConfigurationWatch;
   newBadge?: boolean;
 };
 
@@ -24,12 +22,9 @@ const GeneralSettings: FC<GeneralSettingsProps> = ({ hyperConvergeConfiguration,
       toggleText={t('General settings')}
     >
       <Stack hasGutter>
-        {getGeneralSettingsSections(t).map(({ Component, label }) => (
+        {getGeneralSettingsSections(t).map(({ Component: sectionComponent, label }) => (
           <StackItem key={label} isFilled>
-            <Component
-              hyperConvergeConfiguration={hyperConvergeConfiguration}
-              newBadge={newBadge}
-            />
+            {createElement(sectionComponent, { hyperConvergeConfiguration, newBadge })}
           </StackItem>
         ))}
       </Stack>

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/HideYamlTab/HideYamlTab.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/HideYamlTab/HideYamlTab.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
 import { HIDE_YAML_TAB } from '@kubevirt-utils/hooks/useFeatures/constants';
@@ -23,7 +22,7 @@ const HideYamlTab: FC<HideYamlTabProps> = ({ newBadge = false }) => {
     cluster,
   );
 
-  const onChange = async (checked: boolean) => {
+  const onChange = async (checked: boolean): Promise<void> => {
     await toggleFeature(checked);
   };
 

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/LiveMigrationSection/Limits/Limits.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/LiveMigrationSection/Limits/Limits.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { useEffect, useState } from 'react';
+import React, { type FC, useEffect, useState } from 'react';
 
 import {
   logVMMigrationClusterLimitConfigured,
@@ -7,6 +6,7 @@ import {
   logVMMigrationNodeLimitConfigured,
   logVMMigrationNodeLimitReached,
 } from '@kubevirt-utils/extensions/telemetry/vm-migration';
+import { type HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { OLSPromptType } from '@lightspeed/utils/prompts';
 import { useDebounceCallback } from '@overview/utils/hooks/useDebounceCallback';
@@ -19,12 +19,15 @@ import {
   MIGRATION_PER_NODE,
   updateLiveMigrationConfig,
 } from '../utils/utils';
-
 import MigrationNumberInput from './MigrationNumberInput';
 
 const MIN_MIGRATION_LIMIT = 0;
 
-const Limits = ({ hyperConverge }) => {
+type LimitsProps = {
+  hyperConverge: HyperConverged;
+};
+
+const Limits: FC<LimitsProps> = ({ hyperConverge }) => {
   const { t } = useKubevirtTranslation();
   const cluster = useSettingsCluster();
 
@@ -36,19 +39,19 @@ const Limits = ({ hyperConverge }) => {
   const updateConfigWithDebounceNode: typeof updateLiveMigrationConfig =
     useDebounceCallback(updateLiveMigrationConfig);
 
-  const updateValueCluster = (value: number) => {
+  const updateValueCluster = (value: number): void => {
     if (value < MIN_MIGRATION_LIMIT) return;
 
     logVMMigrationClusterLimitConfigured(value);
-    logVMMigrationClusterLimitReached(value, migrationPerCluster || 0);
-    updateConfigWithDebounceCluster(hyperConverge, value, MIGRATION_PER_CLUSTER, cluster);
+    logVMMigrationClusterLimitReached(value, migrationPerCluster ?? 0);
+    void updateConfigWithDebounceCluster(hyperConverge, value, MIGRATION_PER_CLUSTER, cluster);
   };
-  const updateValueNode = (value: number) => {
+  const updateValueNode = (value: number): void => {
     if (value < MIN_MIGRATION_LIMIT) return;
 
     logVMMigrationNodeLimitConfigured(value);
-    logVMMigrationNodeLimitReached(value, migrationPerNode || 0);
-    updateConfigWithDebounceNode(hyperConverge, value, MIGRATION_PER_NODE, cluster);
+    logVMMigrationNodeLimitReached(value, migrationPerNode ?? 0);
+    void updateConfigWithDebounceNode(hyperConverge, value, MIGRATION_PER_NODE, cluster);
   };
 
   useEffect(() => {

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/LiveMigrationSection/Network/Network.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/LiveMigrationSection/Network/Network.tsx
@@ -1,13 +1,13 @@
-/* eslint-disable */
-import React, { MouseEvent, useEffect, useState } from 'react';
+import React, { type FC, type MouseEvent, useEffect, useState } from 'react';
 
 import { NetworkAttachmentDefinitionModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import FormPFSelect from '@kubevirt-utils/components/FormPFSelect/FormPFSelect';
+import { type HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
+import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import { getName } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
-import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import {
   Alert,
   AlertVariant,
@@ -27,7 +27,11 @@ import {
   updateLiveMigrationConfig,
 } from '../utils/utils';
 
-const Network = ({ hyperConverge }) => {
+type NetworkProps = {
+  hyperConverge: HyperConverged;
+};
+
+const Network: FC<NetworkProps> = ({ hyperConverge }) => {
   const { t } = useKubevirtTranslation();
   const cluster = useSettingsCluster();
   const [selectedNetwork, setSelectedNetwork] = useState<string>('');
@@ -44,8 +48,8 @@ const Network = ({ hyperConverge }) => {
     }
   }, [hyperConverge]);
 
-  const onSelect = (_event: MouseEvent<Element>, selectedValue: string) => {
-    updateLiveMigrationConfig(
+  const onSelect = (_event: MouseEvent<Element>, selectedValue: string): void => {
+    void updateLiveMigrationConfig(
       hyperConverge,
       selectedValue !== PRIMARY_NETWORK ? selectedValue : null,
       'network',

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/LiveMigrationSection/utils/utils.ts
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/LiveMigrationSection/utils/utils.ts
@@ -1,8 +1,8 @@
-/* eslint-disable */
 import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import { type V1MigrationConfiguration } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 export type HyperConvergedList = K8sResourceCommon & {
   items: HyperConverged[];
@@ -13,7 +13,7 @@ export const updateLiveMigrationConfig = (
   value: null | number | string,
   name: string,
   cluster?: string,
-) =>
+): ReturnType<typeof kubevirtK8sPatch> =>
   kubevirtK8sPatch({
     cluster,
     data: [
@@ -27,11 +27,12 @@ export const updateLiveMigrationConfig = (
     resource: hyperConverged,
   });
 
-export const getLiveMigrationNetwork = (hyperConverged: HyperConverged) =>
+export const getLiveMigrationNetwork = (hyperConverged: HyperConverged): string | undefined =>
   hyperConverged?.spec?.liveMigrationConfig?.network;
 
-export const getLiveMigrationConfig = (hyperConverge: HyperConverged) =>
-  hyperConverge?.spec?.liveMigrationConfig;
+export const getLiveMigrationConfig = (
+  hyperConverge: HyperConverged,
+): V1MigrationConfiguration | undefined => hyperConverge?.spec?.liveMigrationConfig;
 
 export const MIGRATION_PER_CLUSTER = 'parallelMigrationsPerCluster';
 export const MIGRATION_PER_NODE = 'parallelOutboundMigrationsPerNode';

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/MemoryDensity/MemoryDensity.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/MemoryDensity/MemoryDensity.tsx
@@ -1,18 +1,15 @@
-/* eslint-disable */
-import React, { FC, useState } from 'react';
+import React, { type FC, useState } from 'react';
 
-import ExpandSectionWithCustomToggle from '@kubevirt-utils/components/ExpandSectionWithCustomToggle/ExpandSectionWithCustomToggle';
 import NewBadge from '@kubevirt-utils/components/badges/NewBadge/NewBadge';
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import ExpandSectionWithCustomToggle from '@kubevirt-utils/components/ExpandSectionWithCustomToggle/ExpandSectionWithCustomToggle';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Skeleton, Stack, StackItem } from '@patternfly/react-core';
 import { useSettingsCluster } from '@settings/context/SettingsClusterContext';
 import { CLUSTER_TAB_IDS } from '@settings/search/constants';
 
-import { getGeneralSettingsLabels } from '../consts/consts';
+import { getGeneralSettingsLabels, type HyperConvergeConfigurationWatch } from '../consts/consts';
 import GeneralSettingsError from '../shared/GeneralSettingsError';
-
 import ActiveRatio from './components/ActiveRatio';
 import MemoryRequestRatioHelpContent from './components/MemoryRequestRatioHelpContent';
 import MemoryRequestRatioInput from './components/MemoryRequestRatioInput';
@@ -21,7 +18,7 @@ import { useMemoryRequestRatio } from './hooks/useMemoryRequestRatio';
 import { getCurrentOvercommit } from './utils/utils';
 
 type MemoryDensityProps = {
-  hyperConvergeConfiguration: [hyperConvergeConfig: HyperConverged, loaded: boolean, error: any];
+  hyperConvergeConfiguration: HyperConvergeConfigurationWatch;
 };
 
 const MemoryDensity: FC<MemoryDensityProps> = ({ hyperConvergeConfiguration }) => {
@@ -29,7 +26,7 @@ const MemoryDensity: FC<MemoryDensityProps> = ({ hyperConvergeConfiguration }) =
   const cluster = useSettingsCluster();
   const isAdmin = useIsAdmin();
   const [hyperConverge, hyperLoaded] = hyperConvergeConfiguration;
-  const [error, setError] = useState<any>(null);
+  const [error, setError] = useState<unknown>(null);
 
   const currentOvercommit = getCurrentOvercommit(hyperConverge);
 
@@ -37,7 +34,7 @@ const MemoryDensity: FC<MemoryDensityProps> = ({ hyperConvergeConfiguration }) =
   const { hasChanged, inputValue, isLoading, onChange, onRestoreDefault, onSave } =
     useMemoryRequestRatio({ cluster, currentOvercommit, hyperConverge });
 
-  const handleSave = async () => {
+  const handleSave = async (): Promise<void> => {
     setError(null);
     try {
       await onSave();

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/MemoryDensity/components/KernelSamepageMerging/KernelSamepageMerging.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/MemoryDensity/components/KernelSamepageMerging/KernelSamepageMerging.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import React, { FC, useEffect, useState } from 'react';
+import React, { type FC, useEffect, useState } from 'react';
 
 import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import { type HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { OLSPromptType } from '@lightspeed/utils/prompts';
@@ -42,7 +41,7 @@ const KernelSamepageMerging: FC<KernelSamepageMergingProps> = ({
     }
   }, [ksmConfiguration, hyperLoaded]);
 
-  const onKSMchange = (value: boolean) => {
+  const onKSMchange = (value: boolean): void => {
     setError(null);
     setIsLoading(true);
     kubevirtK8sPatch<HyperConverged>({

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/SSHConfiguration/SSHConfiguration.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/SSHConfiguration/SSHConfiguration.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useCallback, useEffect, useState } from 'react';
+import React, { type FC, useCallback, useEffect, useState } from 'react';
 import { useDebounceCallback } from 'src/views/clusteroverview/utils/hooks/useDebounceCallback';
 
 import { ConfigMapModel } from '@kubevirt-ui-ext/kubevirt-api/console';
@@ -47,7 +46,7 @@ const SSHConfiguration: FC<SSHConfigurationProps> = ({ newBadge }) => {
       const setIsLoading =
         field === LOAD_BALANCER_ENABLED ? setLoadBalancerIsLoading : setNodePortIsLoading;
       setIsLoading(true);
-      kubevirtK8sPatch({
+      void kubevirtK8sPatch({
         cluster,
         data: [
           {
@@ -63,7 +62,7 @@ const SSHConfiguration: FC<SSHConfigurationProps> = ({ newBadge }) => {
     [cluster, featureConfigMap],
   );
 
-  const onTextChange = useDebounceCallback((val: string, field) => {
+  const onTextChange = useDebounceCallback((val: string, field: string) => {
     onChange(val, field);
   }, 700);
 

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/TemplatesAndImagesManagement.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/TemplatesAndImagesManagement.tsx
@@ -1,11 +1,9 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-utils/models';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { Stack, StackItem } from '@patternfly/react-core';
 import { useSettingsCluster } from '@settings/context/SettingsClusterContext';
 import ExpandSection from '@settings/ExpandSection/ExpandSection';
@@ -14,10 +12,10 @@ import AutomaticImagesDownload from '@settings/tabs/ClusterTab/components/Genera
 import BootableVolumeProjectSection from '@settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/BootableVolumeProjectSection/BootableVolumeProjectSection';
 import TemplatesProjectSection from '@settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/TemplatesProjectSection/TemplatesProjectSection';
 
-import { getGeneralSettingsLabels } from '../consts/consts';
+import { getGeneralSettingsLabels, type HyperConvergeConfigurationWatch } from '../consts/consts';
 
 type TemplatesAndImagesManagementProps = {
-  hyperConvergeConfiguration: [hyperConvergeConfig: HyperConverged, loaded: boolean, error: any];
+  hyperConvergeConfiguration: HyperConvergeConfigurationWatch;
   newBadge?: boolean;
 };
 

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/AutomaticImagesDownload/AutomaticImagesDownload.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/AutomaticImagesDownload/AutomaticImagesDownload.tsx
@@ -1,9 +1,7 @@
-/* eslint-disable */
-import React, { FC, useCallback, useState } from 'react';
+import React, { type FC, useCallback, useState } from 'react';
 
 import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useIsAdmin } from '@kubevirt-utils/hooks/useIsAdmin';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName } from '@kubevirt-utils/resources/shared';
@@ -14,10 +12,11 @@ import { useSettingsCluster } from '@settings/context/SettingsClusterContext';
 import ExpandSection from '@settings/ExpandSection/ExpandSection';
 import { CLUSTER_TAB_IDS } from '@settings/search/constants';
 
+import { type HyperConvergeConfigurationWatch } from '../../../consts/consts';
 import { AUTOMATIC_IMAGE_DOWNLOAD_ANNOTATION } from './utils/consts';
 
 type AutomaticImagesDownloadProps = {
-  hyperConvergeConfiguration: [hyperConvergeConfig: HyperConverged, loaded: boolean, error: any];
+  hyperConvergeConfiguration: HyperConvergeConfigurationWatch;
   newBadge: boolean;
 };
 
@@ -33,9 +32,7 @@ const AutomaticImagesDownload: FC<AutomaticImagesDownloadProps> = ({
 
   const [hyperConverged, loaded] = hyperConvergeConfiguration;
   const isEnabledAutomaticImagesDownload =
-    hyperConverged?.spec?.enableCommonBootImageImport !== undefined
-      ? hyperConverged?.spec?.enableCommonBootImageImport
-      : true;
+    hyperConverged?.spec?.enableCommonBootImageImport ?? true;
 
   const bootSources =
     hyperConverged?.spec?.dataImportCronTemplates ||
@@ -44,7 +41,7 @@ const AutomaticImagesDownload: FC<AutomaticImagesDownloadProps> = ({
   const onChangeAutomaticImagesDownload = useCallback(
     (val: boolean) => {
       setIsLoading(true);
-      kubevirtK8sPatch({
+      void kubevirtK8sPatch({
         cluster,
         data: [
           {
@@ -77,7 +74,7 @@ const AutomaticImagesDownload: FC<AutomaticImagesDownloadProps> = ({
             }
           : source,
       );
-      kubevirtK8sPatch({
+      void kubevirtK8sPatch({
         cluster,
         data: [
           {

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/BootableVolumeProjectSection/BootableVolumeProjectSection.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/BootableVolumeProjectSection/BootableVolumeProjectSection.tsx
@@ -1,14 +1,12 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { OPENSHIFT_OS_IMAGES_NS } from '@kubevirt-utils/constants/constants';
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { CLUSTER_TAB_IDS } from '@settings/search/constants';
 
+import { type HyperConvergeConfigurationWatch } from '../../../consts/consts';
 import GeneralSettingsProject from '../../../shared/GeneralSettingsProject';
-
 import {
   getCurrentBootableVolumesNamespaceFromHCO,
   updateHCOBootableVolumesNamespace,
@@ -17,8 +15,8 @@ import {
 import '../../../shared/general-settings.scss';
 
 type BootableVolumeProjectSectionProps = {
-  hyperConvergeConfiguration: [hyperConvergeConfig: HyperConverged, loaded: boolean, error: any];
-  projectsData: [projects: K8sResourceCommon[], loaded: boolean, error: any];
+  hyperConvergeConfiguration: HyperConvergeConfigurationWatch;
+  projectsData: [projects: K8sResourceCommon[], loaded: boolean, error: unknown];
 };
 
 const BootableVolumeProjectSection: FC<BootableVolumeProjectSectionProps> = ({

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/BootableVolumeProjectSection/utils/utils.ts
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/BootableVolumeProjectSection/utils/utils.ts
@@ -1,19 +1,19 @@
-/* eslint-disable */
 import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { OPENSHIFT_OS_IMAGES_NS } from '@kubevirt-utils/constants/constants';
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import { type HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import { getErrorMessage } from '@kubevirt-utils/utils/utils';
 import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
 
 export const getCurrentBootableVolumesNamespaceFromHCO = (hyperConverged: HyperConverged): string =>
-  hyperConverged?.spec?.commonBootImageNamespace || OPENSHIFT_OS_IMAGES_NS;
+  hyperConverged?.spec?.commonBootImageNamespace ?? OPENSHIFT_OS_IMAGES_NS;
 
 export const updateHCOBootableVolumesNamespace = async (
   hyperConverged: HyperConverged,
   newNamespace: null | number | string,
-  handelError: (value: string) => void,
+  handleError: (value: string) => void,
   handleLoading: (value: boolean) => void,
   cluster?: string,
-) => {
+): Promise<void> => {
   const currentTemplatesNamespace = getCurrentBootableVolumesNamespaceFromHCO(hyperConverged);
   if (newNamespace !== currentTemplatesNamespace) {
     handleLoading(true);
@@ -30,8 +30,8 @@ export const updateHCOBootableVolumesNamespace = async (
         model: HyperConvergedModel,
         resource: hyperConverged,
       });
-    } catch (error) {
-      handelError(error?.message || error);
+    } catch (error: unknown) {
+      handleError(getErrorMessage(error));
     } finally {
       handleLoading(false);
     }

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/TemplatesProjectSection/TemplatesProjectSection.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/TemplatesProjectSection/TemplatesProjectSection.tsx
@@ -1,14 +1,12 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { Trans } from 'react-i18next';
 
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { CLUSTER_TAB_IDS } from '@settings/search/constants';
 
+import { type HyperConvergeConfigurationWatch } from '../../../consts/consts';
 import GeneralSettingsProject from '../../../shared/GeneralSettingsProject';
-
 import {
   getCurrentTemplatesNamespaceFromHCO,
   OPENSHIFT,
@@ -18,8 +16,8 @@ import {
 import '../../../shared/general-settings.scss';
 
 type TemplatesProjectSectionProps = {
-  hyperConvergeConfiguration: [hyperConvergeConfig: HyperConverged, loaded: boolean, error: any];
-  projectsData: [projects: K8sResourceCommon[], loaded: boolean, error: any];
+  hyperConvergeConfiguration: HyperConvergeConfigurationWatch;
+  projectsData: [projects: K8sResourceCommon[], loaded: boolean, error: unknown];
 };
 
 const TemplatesProjectSection: FC<TemplatesProjectSectionProps> = ({

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/TemplatesProjectSection/utils/utils.ts
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/components/TemplatesProjectSection/utils/utils.ts
@@ -1,9 +1,9 @@
-/* eslint-disable */
 import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
-import { TemplateModel, V1Template } from '@kubevirt-utils/models';
+import { type HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import { TemplateModel, type V1Template } from '@kubevirt-utils/models';
+import { getErrorMessage } from '@kubevirt-utils/utils/utils';
 import { kubevirtK8sDelete, kubevirtK8sGet, kubevirtK8sPatch } from '@multicluster/k8sRequests';
-import { TemplateList } from '@overview/utils/types';
+import { type TemplateList } from '@overview/utils/types';
 
 const TYPE_LABEL = 'template.kubevirt.io/type';
 const BASE = 'base';
@@ -11,15 +11,15 @@ const BASE = 'base';
 export const OPENSHIFT = 'openshift';
 
 export const getCurrentTemplatesNamespaceFromHCO = (hyperConverged: HyperConverged): string =>
-  hyperConverged?.spec?.commonTemplatesNamespace || OPENSHIFT;
+  hyperConverged?.spec?.commonTemplatesNamespace ?? OPENSHIFT;
 
 export const updateHCOCommonTemplatesNamespace = async (
   hyperConverged: HyperConverged,
   newNamespace: null | number | string,
-  handelError: (value: string) => void,
+  handleError: (value: string) => void,
   handleLoading: (value: boolean) => void,
   cluster?: string,
-) => {
+): Promise<void> => {
   const currentTemplatesNamespace = getCurrentTemplatesNamespaceFromHCO(hyperConverged);
   if (newNamespace !== currentTemplatesNamespace) {
     handleLoading(true);
@@ -56,8 +56,8 @@ export const updateHCOCommonTemplatesNamespace = async (
       );
 
       await Promise.all<Promise<V1Template>[]>(templatesDeletePromisesArray);
-    } catch (error) {
-      handelError(error?.message || error);
+    } catch (error: unknown) {
+      handleError(getErrorMessage(error));
     } finally {
       handleLoading(false);
     }

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/consts/consts.ts
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/consts/consts.ts
@@ -1,9 +1,6 @@
-/* eslint-disable */
-import { ComponentType } from 'react';
+import { type ComponentType } from 'react';
+import { type TFunction } from 'i18next';
 
-import { TFunction } from 'i18next';
-
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import TemplatesAndImagesManagement from '@settings/tabs/ClusterTab/components/GeneralSettings/TemplatesAndImagesManagement/TemplatesAndImagesManagement';
 import VMActionsConfirmation from '@settings/tabs/ClusterTab/components/GeneralSettings/VMActionsConfirmation/VMActionsConfirmation';
 
@@ -11,11 +8,31 @@ import AdvancedCDROMFeatures from '../AdvancedCDROMFeatures/AdvancedCDROMFeature
 import AutomaticallyGrantVirtualizationRoles from '../AutomaticallyGrantVirtualizationRoles/AutomaticallyGrantVirtualizationRoles';
 import HideYamlTab from '../HideYamlTab/HideYamlTab';
 import LiveMigrationSection from '../LiveMigrationSection/LiveMigrationSection';
-import MemoryDensity from '../MemoryDensity/MemoryDensity';
 import KernelSamepageMerging from '../MemoryDensity/components/KernelSamepageMerging/KernelSamepageMerging';
+import MemoryDensity from '../MemoryDensity/MemoryDensity';
 import SSHConfiguration from '../SSHConfiguration/SSHConfiguration';
+import { type GeneralSettingsSectionProps } from './types';
 
-export const getGeneralSettingsLabels = (t: TFunction) => ({
+export type { GeneralSettingsSectionProps, HyperConvergeConfigurationWatch } from './types';
+
+type GeneralSettingsSection = {
+  Component: ComponentType<Partial<GeneralSettingsSectionProps>>;
+  label: string;
+};
+
+type GeneralSettingsLabels = {
+  advancedCDROMFeatures: string;
+  automaticallyGrantVirtualizationRoles: string;
+  kernelSamepageMerging: string;
+  liveMigration: string;
+  memoryRequestRatio: string;
+  sshConfigurations: string;
+  templatesAndImagesManagement: string;
+  virtualMachineActionsConfirmation: string;
+  yamlTabVisibility: string;
+};
+
+export const getGeneralSettingsLabels = (t: TFunction): GeneralSettingsLabels => ({
   advancedCDROMFeatures: t('Advanced CD-ROM features'),
   automaticallyGrantVirtualizationRoles: t('Automatically grant Virtualization roles'),
   kernelSamepageMerging: t('Kernel Samepage Merging (KSM)'),
@@ -26,16 +43,6 @@ export const getGeneralSettingsLabels = (t: TFunction) => ({
   virtualMachineActionsConfirmation: t('VirtualMachine actions confirmation'),
   yamlTabVisibility: t('YAML tab visibility'),
 });
-
-export type GeneralSettingsSectionProps = {
-  hyperConvergeConfiguration: [hyperConvergeConfig: HyperConverged, loaded: boolean, error: Error];
-  newBadge?: boolean;
-};
-
-type GeneralSettingsSection = {
-  Component: ComponentType<Partial<GeneralSettingsSectionProps>>;
-  label: string;
-};
 
 export const getGeneralSettingsSections = (t: TFunction): GeneralSettingsSection[] => {
   const labels = getGeneralSettingsLabels(t);

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/consts/types.ts
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/consts/types.ts
@@ -1,0 +1,12 @@
+import { type HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+
+export type HyperConvergeConfigurationWatch = [
+  hyperConvergeConfig: HyperConverged,
+  loaded: boolean,
+  error: Error,
+];
+
+export type GeneralSettingsSectionProps = {
+  hyperConvergeConfiguration: HyperConvergeConfigurationWatch;
+  newBadge?: boolean;
+};

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/shared/GeneralSettingsError.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/shared/GeneralSettingsError.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Alert, AlertVariant } from '@patternfly/react-core';
@@ -9,12 +8,13 @@ type GeneralSettingsErrorProps = {
   loadingError?: unknown;
 };
 
+const hasMessage = (value: object): value is { message: unknown } => 'message' in value;
+
 const toMessage = (value: unknown): string => {
   if (!value) return '';
   if (typeof value === 'string') return value;
   if (value instanceof Error) return value.message;
-  if (typeof value === 'object' && value !== null && 'message' in value)
-    return String((value as { message: unknown }).message);
+  if (typeof value === 'object' && hasMessage(value)) return String(value.message);
   return String(value);
 };
 

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/shared/GeneralSettingsProject.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/shared/GeneralSettingsProject.tsx
@@ -1,13 +1,13 @@
-/* eslint-disable */
-import React, { FC, ReactNode, useEffect, useState } from 'react';
+import React, { type FC, type ReactNode, useEffect, useState } from 'react';
 
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import { type HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { Content, ContentVariants } from '@patternfly/react-core';
 import { useSettingsCluster } from '@settings/context/SettingsClusterContext';
 import ExpandSection from '@settings/ExpandSection/ExpandSection';
 
+import { type HyperConvergeConfigurationWatch } from '../consts/consts';
 import GeneralSettingsError from '../shared/GeneralSettingsError';
 import GeneralSettingsProjectSelector from '../shared/GeneralSettingsProjectSelector';
 
@@ -16,16 +16,16 @@ import '../shared/general-settings.scss';
 type GeneralSettingsProjectProps = {
   description: ReactNode;
   hcoResourceNamespace: string;
-  hyperConvergeConfiguration: [hyperConvergeConfig: HyperConverged, loaded: boolean, error: any];
+  hyperConvergeConfiguration: HyperConvergeConfigurationWatch;
   namespace: string;
   onChange: (
     hyperConverged: HyperConverged,
     newNamespace: null | number | string,
-    handelError: (value: string) => void,
+    handleError: (value: string) => void,
     handleLoading: (value: boolean) => void,
     cluster?: string,
   ) => void;
-  projectsData: [projects: K8sResourceCommon[], loaded: boolean, error: any];
+  projectsData: [projects: K8sResourceCommon[], loaded: boolean, error: unknown];
   searchItemId?: string;
   toggleText: string;
 };
@@ -55,8 +55,8 @@ const GeneralSettingsProject: FC<GeneralSettingsProjectProps> = ({
     }
   }, [hcoResourceNamespace, hyperConverge, namespace]);
 
-  const onSelect = (value: string) => {
-    setError(null);
+  const onSelect = (value: string): void => {
+    setError(undefined);
     setSelectedProject(value);
     onChange(hyperConverge, value, setError, setLoading, cluster);
   };

--- a/src/views/settings/tabs/ClusterTab/components/GeneralSettings/shared/GeneralSettingsProjectSelector.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GeneralSettings/shared/GeneralSettingsProjectSelector.tsx
@@ -1,11 +1,10 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import InlineFilterSelect from '@kubevirt-utils/components/FilterSelect/InlineFilterSelect';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind, ProjectModel } from '@kubevirt-utils/models';
 import { getName } from '@kubevirt-utils/resources/shared';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { Spinner } from '@patternfly/react-core';
 
 type GeneralSettingsProjectSelectorProps = {
@@ -24,14 +23,13 @@ const GeneralSettingsProjectSelector: FC<GeneralSettingsProjectSelectorProps> = 
 
   return (
     <InlineFilterSelect
-      options={[
-        ...projects
-          ?.map((proj) => ({
-            groupVersionKind: modelToGroupVersionKind(ProjectModel),
-            value: getName(proj),
-          }))
-          .sort((a, b) => a.value.localeCompare(b.value)),
-      ]}
+      options={projects
+        .flatMap((proj) => {
+          const name = getName(proj);
+          if (!name) return [];
+          return [{ groupVersionKind: modelToGroupVersionKind(ProjectModel), value: name }];
+        })
+        .sort((a, b) => a.value.localeCompare(b.value))}
       toggleProps={{
         icon: !loaded && <Spinner size="sm" />,
         isDisabled: !loaded,

--- a/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/components/AutomaticSubscriptionType/utils/utils.ts
+++ b/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/AutomaticSubscriptionRHELGuests/components/AutomaticSubscriptionType/utils/utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
 export enum AutomaticSubscriptionTypeEnum {
@@ -7,7 +6,12 @@ export enum AutomaticSubscriptionTypeEnum {
   NO_SUBSCRIPTION = 'noSubscription',
 }
 
-export const selectItems = [
+export type SubscriptionItem = {
+  title: string;
+  value: AutomaticSubscriptionTypeEnum;
+};
+
+export const selectItems: SubscriptionItem[] = [
   {
     title: t('No subscription'),
     value: AutomaticSubscriptionTypeEnum.NO_SUBSCRIPTION,
@@ -22,5 +26,5 @@ export const selectItems = [
   },
 ];
 
-export const getSubscriptionItem = (value: string) =>
+export const getSubscriptionItem = (value: string): SubscriptionItem | undefined =>
   selectItems.find((item) => item.value === value);

--- a/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/GuestManagementSection.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/GuestManagementSection.tsx
@@ -1,18 +1,17 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Stack, StackItem } from '@patternfly/react-core';
 import ExpandSection from '@settings/ExpandSection/ExpandSection';
 import { CLUSTER_TAB_IDS } from '@settings/search/constants';
 
+import { type HyperConvergeConfigurationWatch } from '../GeneralSettings/consts/types';
 import AutomaticSubscriptionRHELGuests from './AutomaticSubscriptionRHELGuests/AutomaticSubscriptionRHELGuests';
 import GuestSystemLogsAccess from './GuestSystemLogsAccess/GuestSystemLogsAccess';
 import HideCredentials from './HideCredentials/HideCredentials';
 
 type GuestManagementSectionProps = {
-  hyperConvergeConfiguration: [hyperConvergeConfig: HyperConverged, loaded: boolean, error: any];
+  hyperConvergeConfiguration: HyperConvergeConfigurationWatch;
   newBadge?: boolean;
 };
 

--- a/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/GuestSystemLogsAccess/GuestSystemLogsAccess.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/GuestSystemLogsAccess/GuestSystemLogsAccess.tsx
@@ -1,21 +1,22 @@
-/* eslint-disable */
-import React, { FC, useEffect, useState } from 'react';
+import React, { type FC, useEffect, useState } from 'react';
 
 import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
 import { DISABLED_GUEST_SYSTEM_LOGS_ACCESS } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import { type HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { OLSPromptType } from '@lightspeed/utils/prompts';
 import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
 import { Alert, AlertVariant } from '@patternfly/react-core';
 import { useSettingsCluster } from '@settings/context/SettingsClusterContext';
 
+import { type HyperConvergeConfigurationWatch } from '../../GeneralSettings/consts/types';
+
 import './guest-system-logs-access.scss';
 
 type GuestSystemLogsAccessProps = {
-  hyperConvergeConfiguration: [hyperConvergeConfig: HyperConverged, loaded: boolean, error: Error];
+  hyperConvergeConfiguration: HyperConvergeConfigurationWatch;
   newBadge?: boolean;
 };
 
@@ -38,11 +39,11 @@ const GuestSystemLogsAccess: FC<GuestSystemLogsAccessProps> = ({
   const [isChecked, setIsChecked] = useState<boolean>();
 
   useEffect(() => {
-    guestSystemLogsAccessToggle(!!disableSerialConsoleLog);
+    void guestSystemLogsAccessToggle(!!disableSerialConsoleLog);
     setIsChecked(!disableSerialConsoleLog);
   }, [disableSerialConsoleLog, guestSystemLogsAccessToggle]);
 
-  const onChange = async (checked: boolean) => {
+  const onChange = async (checked: boolean): Promise<void> => {
     setError(null);
     setIsLoading(true);
     try {
@@ -58,10 +59,11 @@ const GuestSystemLogsAccess: FC<GuestSystemLogsAccessProps> = ({
         model: HyperConvergedModel,
         resource: hyperConverge,
       });
-      guestSystemLogsAccessToggle(!checked);
+      void guestSystemLogsAccessToggle(!checked);
       setIsChecked(checked);
-    } catch (err) {
-      setError(err.message);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
     } finally {
       setIsLoading(false);
     }

--- a/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/HideCredentials/HideCredentials.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/GuestManagmentSection/HideCredentials/HideCredentials.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
 import { HIDE_CREDENTIALS_NON_PRIVILEGED } from '@kubevirt-utils/hooks/useFeatures/constants';
@@ -21,7 +20,7 @@ const HideCredentials: FC<HideCredentialsProps> = ({ newBadge = false }) => {
     cluster,
   );
 
-  const onChange = async (checked: boolean) => {
+  const onChange = async (checked: boolean): Promise<void> => {
     await toggleFeature(checked);
   };
 

--- a/src/views/settings/tabs/ClusterTab/components/PersistentReservationSection/PersistentReservationSection.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/PersistentReservationSection/PersistentReservationSection.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useState } from 'react';
+import React, { type FC, useState } from 'react';
 
 import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
@@ -8,7 +7,7 @@ import {
   FEATURE_PERSISTENT_RESERVATION,
 } from '@kubevirt-utils/hooks/useFeatures/constants';
 import { useFeatures } from '@kubevirt-utils/hooks/useFeatures/useFeatures';
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import { type HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { OLSPromptType } from '@lightspeed/utils/prompts';
 import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
@@ -35,7 +34,7 @@ const PersistentReservationSection: FC<PersistentReservationSectionProps> = ({
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const { toggleFeature } = useFeatures(FEATURE_HCO_PERSISTENT_RESERVATION, cluster);
 
-  const onChange = async (checked: boolean) => {
+  const onChange = async (checked: boolean): Promise<void> => {
     if (!hyperConverge) return;
     setError(null);
     setIsLoading(true);
@@ -57,8 +56,9 @@ const PersistentReservationSection: FC<PersistentReservationSectionProps> = ({
       });
 
       await toggleFeature(checked);
-    } catch (err) {
-      setError(err.message);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      setError(message);
     } finally {
       setIsLoading(false);
     }

--- a/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/ApplicationAwareQuota/ApplicationAwareQuota.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/ApplicationAwareQuota/ApplicationAwareQuota.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable */
-import React, { FC, useEffect, useMemo, useState } from 'react';
+import React, { type FC, useEffect, useMemo, useState } from 'react';
 import { getQuotaListURL } from 'src/views/quotas/utils/url';
 
 import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import { type HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getAAQCalculationMethod } from '@kubevirt-utils/resources/hyperconverged/selectors';
 import { isAAQEnabled } from '@kubevirt-utils/resources/hyperconverged/utils';
@@ -44,7 +43,7 @@ const ApplicationAwareQuota: FC<ApplicationAwareQuotaProps> = ({
     setIsEnabled(hyperLoaded ? aaqEnabled : false);
   }, [aaqEnabled, cluster, hyperLoaded]);
 
-  const onFeatureChange = (checked: boolean) => {
+  const onFeatureChange = (checked: boolean): void => {
     setIsLoading(true);
     kubevirtK8sPatch<HyperConverged>({
       cluster,

--- a/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/ApplicationAwareQuota/components/EditCalculationMethodButton.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/ApplicationAwareQuota/components/EditCalculationMethodButton.tsx
@@ -1,12 +1,11 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import EditButton from '@kubevirt-utils/components/EditButton/EditButton';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
-import { CalculationMethod } from '@kubevirt-utils/resources/quotas/types';
+import { type HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import { type CalculationMethod } from '@kubevirt-utils/resources/quotas/types';
 
-import { CalculationMethodContentMapper } from '../types';
+import { type CalculationMethodContentMapper } from '../types';
 
 import EditCalculationMethodModal from './EditCalculationMethodModal';
 
@@ -25,7 +24,7 @@ const EditCalculationMethodButton: FC<EditCalculationMethodButtonProps> = ({
 
   const selectedLabel = calculationMethodContentMapper[selectedCalculationMethod]?.label;
 
-  const onClick = () => {
+  const onClick = (): void => {
     createModal(({ isOpen, onClose }) => (
       <EditCalculationMethodModal
         calculationMethodContentMapper={calculationMethodContentMapper}

--- a/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/ApplicationAwareQuota/components/EditCalculationMethodModal.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/ApplicationAwareQuota/components/EditCalculationMethodModal.tsx
@@ -1,17 +1,16 @@
-/* eslint-disable */
-import React, { FC, useState } from 'react';
+import React, { type FC, useState } from 'react';
 
 import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import { type HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { CalculationMethod } from '@kubevirt-utils/resources/quotas/types';
+import { type CalculationMethod } from '@kubevirt-utils/resources/quotas/types';
 import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
 import { FormGroup, Radio } from '@patternfly/react-core';
 import { useSettingsCluster } from '@settings/context/SettingsClusterContext';
 
 import { calculationMethods } from '../constants';
-import { CalculationMethodContentMapper } from '../types';
+import { type CalculationMethodContentMapper } from '../types';
 
 type EditCalculationMethodModalProps = {
   calculationMethodContentMapper: CalculationMethodContentMapper;
@@ -33,7 +32,7 @@ const EditCalculationMethodModal: FC<EditCalculationMethodModalProps> = ({
 
   const [checkedMethod, setCheckedMethod] = useState<CalculationMethod>(initiallySelectedMethod);
 
-  const onSubmit = async () => {
+  const onSubmit = async (): Promise<void> => {
     if (checkedMethod === initiallySelectedMethod) {
       return;
     }

--- a/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/AutoComputeCPULimits.tsx
+++ b/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/AutoComputeCPULimits.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import React, { FC, useEffect, useState } from 'react';
+import React, { type FC, useEffect, useState } from 'react';
 
 import SectionWithSwitch from '@kubevirt-utils/components/SectionWithSwitch/SectionWithSwitch';
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import { type HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Alert, AlertVariant } from '@patternfly/react-core';
 import { useSettingsCluster } from '@settings/context/SettingsClusterContext';
@@ -36,7 +35,7 @@ const AutoComputeCPULimits: FC<AutoComputeCPULimitsProps> = ({
     );
   }, [cluster, featureGates, hcoLoaded]);
 
-  const onFeatureChange = (switchOn: boolean) => {
+  const onFeatureChange = (switchOn: boolean): void => {
     setError(undefined);
     setIsLoading(true);
     updateAutoResourceLimitsFeatureGate(hco, switchOn, cluster)

--- a/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/utils/utils.ts
+++ b/src/views/settings/tabs/ClusterTab/components/ResourceManagementSection/components/AutoComputeCPULimits/utils/utils.ts
@@ -1,7 +1,6 @@
-/* eslint-disable */
 import { HyperConvergedV1Beta1Model as HyperConvergedModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { K8S_OPS } from '@kubevirt-utils/constants/constants';
-import { HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
+import { type HyperConverged } from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
 import { kubevirtK8sPatch } from '@multicluster/k8sRequests';
 
 import { AUTO_RESOURCE_LIMITS_FEATURE_GATE } from './constants';
@@ -10,7 +9,7 @@ export const updateAutoResourceLimitsFeatureGate = (
   hcoCR: HyperConverged,
   switchState: boolean,
   cluster?: string,
-) =>
+): Promise<HyperConverged> =>
   kubevirtK8sPatch<HyperConverged>({
     cluster,
     data: [

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/buildCapabilityRow.tsx
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/buildCapabilityRow.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React from 'react';
 import { type TFunction } from 'i18next';
 

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/useCapabilityFilters.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/useCapabilityFilters.ts
@@ -1,15 +1,13 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
+import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { useDataViewFilters } from '@patternfly/react-data-view';
 
 import {
   type CapabilityFeature,
   type CapabilityFilterValues,
-  CapabilityInstallState,
+  type CapabilityInstallState,
 } from '../../utils/types';
-
-import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { matchesName, matchesStatus } from './utils';
 
 const INITIAL_FILTERS: CapabilityFilterValues = {
@@ -20,7 +18,12 @@ const INITIAL_FILTERS: CapabilityFilterValues = {
 export const useCapabilityFilters = (
   features: CapabilityFeature[],
   getCapabilityInstallState: (feature: CapabilityFeature) => CapabilityInstallState,
-) => {
+): {
+  clearAllFilters: () => void;
+  filteredData: CapabilityFeature[];
+  filters: CapabilityFilterValues;
+  onSetFilters: ReturnType<typeof useDataViewFilters<CapabilityFilterValues>>['onSetFilters'];
+} => {
   const { clearAllFilters, filters, onSetFilters } = useDataViewFilters<CapabilityFilterValues>({
     initialFilters: INITIAL_FILTERS,
   });

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/useCustomSelectionColumns.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/CustomSelectionView/useCustomSelectionColumns.ts
@@ -1,8 +1,8 @@
-/* eslint-disable */
 import { useCallback, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { useDataViewSort } from '@patternfly/react-data-view';
+import { type DataViewTh } from '@patternfly/react-data-view/dist/esm/DataViewTable';
 import { type ThProps } from '@patternfly/react-table';
 
 export const COLUMN_KEYS = {
@@ -14,7 +14,13 @@ export const COLUMN_KEYS = {
 
 const SORTABLE_KEYS = [COLUMN_KEYS.name, COLUMN_KEYS.status];
 
-export const useCustomSelectionColumns = () => {
+type UseCustomSelectionColumnsResult = {
+  columns: DataViewTh[];
+  direction: 'asc' | 'desc' | undefined;
+  sortBy: string | undefined;
+};
+
+export const useCustomSelectionColumns = (): UseCustomSelectionColumnsResult => {
   const { t } = useKubevirtTranslation();
 
   const { direction, onSort, sortBy } = useDataViewSort({

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/components/ReviewRecommendationModal/ReviewRecommendationModal.tsx
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/components/ReviewRecommendationModal/ReviewRecommendationModal.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, Suspense } from 'react';
+import React, { type FC, Suspense } from 'react';
 import { Trans } from 'react-i18next';
 
 import Loading from '@kubevirt-utils/components/Loading/Loading';

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/context/useCapabilitiesActions.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/context/useCapabilitiesActions.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { createContext, useContext } from 'react';
 
 import { type CapabilityFeature, type CapabilitySelectionState } from '../utils/types';
@@ -25,6 +24,7 @@ const defaultActionsValue: CapabilitiesActionsValue = {
 
 const CapabilitiesActionsContext = createContext<CapabilitiesActionsValue>(defaultActionsValue);
 
-export const useCapabilitiesActions = () => useContext(CapabilitiesActionsContext);
+export const useCapabilitiesActions = (): CapabilitiesActionsValue =>
+  useContext(CapabilitiesActionsContext);
 
 export { CapabilitiesActionsContext };

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/context/useCapabilitiesData.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/context/useCapabilitiesData.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { createContext, useContext } from 'react';
 
 import {
@@ -37,6 +36,6 @@ const defaultDataValue: CapabilitiesDataValue = {
 
 const CapabilitiesDataContext = createContext<CapabilitiesDataValue>(defaultDataValue);
 
-export const useCapabilitiesData = () => useContext(CapabilitiesDataContext);
+export const useCapabilitiesData = (): CapabilitiesDataValue => useContext(CapabilitiesDataContext);
 
 export { CapabilitiesDataContext };

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/hooks/useAutopilotStatus.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/hooks/useAutopilotStatus.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import useHyperConvergeConfiguration from '@kubevirt-utils/hooks/useHyperConvergeConfiguration';
@@ -37,7 +36,7 @@ const useAutopilotStatus = (): UseAutopilotStatusResult => {
         statusMap[entry.operatorPackageName] = {
           configStatus:
             result?.loaded && !result?.loadError ? deriveConfigStatus(resource) : undefined,
-          managedCR: resource || undefined,
+          managedCR: resource ?? undefined,
           recommendedYAML: entry.recommendedYAML,
         };
 

--- a/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/types.ts
+++ b/src/views/settings/tabs/RecommendedCapabilitiesTab/utils/types.ts
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import { OLSPromptType } from '@lightspeed/utils/prompts';
+import { type OLSPromptType } from '@lightspeed/utils/prompts';
 import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import {
   type OperatorGroupKind,
@@ -24,7 +23,6 @@ export enum InstallState {
 }
 
 export type VirtFeatureOperatorItem = {
-  [key: string]: any;
   catalogSource?: string;
   catalogSourceNamespace?: string;
   createdAt?: string;

--- a/src/views/storagemigrations/list/StorageMigrationCells.tsx
+++ b/src/views/storagemigrations/list/StorageMigrationCells.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { useNavigate } from 'react-router';
 
 import LazyActionMenu from '@kubevirt-utils/components/LazyActionMenu/LazyActionMenu';
@@ -10,7 +9,7 @@ import {
   NamespaceModel,
   StorageClassModel,
 } from '@kubevirt-utils/models';
-import { MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
+import { type MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
 import { getStorageMigrationPlanSpecNamespaces } from '@kubevirt-utils/resources/migrations/selectors';
 import {
   getMigrationStartTimestamp,
@@ -36,7 +35,7 @@ type CellProps = {
 export const NameCell: FC<CellProps> = ({ row }) => {
   const navigate = useNavigate();
   const clusterParam = useClusterParam();
-  const cluster = getCluster(row) || clusterParam;
+  const cluster = getCluster(row) ?? clusterParam;
   const migPlanName = getName(row);
   const planModel = getStorageMigrationRowModel(row);
 
@@ -63,7 +62,7 @@ export const NameCell: FC<CellProps> = ({ row }) => {
 export const NamespacesCell: FC<CellProps> = ({ row }) => {
   const clusterParam = useClusterParam();
   const isACMPage = useIsACMPage();
-  const cluster = getCluster(row) || clusterParam;
+  const cluster = getCluster(row) ?? clusterParam;
   const namespaces = getStorageMigrationPlanSpecNamespaces(row);
 
   if (isEmpty(namespaces)) {
@@ -98,7 +97,7 @@ export const StorageMigrationCell: FC<CellProps> = ({ row }) => {
 export const TargetStorageClassCell: FC<CellProps> = ({ row }) => {
   const navigate = useNavigate();
   const clusterParam = useClusterParam();
-  const cluster = getCluster(row) || clusterParam;
+  const cluster = getCluster(row) ?? clusterParam;
   const targetStorageClasses = getStorageClassesFromMigPlan(row);
 
   if (isEmpty(targetStorageClasses)) {

--- a/src/views/storagemigrations/list/components/utils.ts
+++ b/src/views/storagemigrations/list/components/utils.ts
@@ -1,7 +1,6 @@
-/* eslint-disable */
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
-  MultiNamespaceVirtualMachineStorageMigrationPlan,
+  type MultiNamespaceVirtualMachineStorageMigrationPlan,
   STORAGE_MIGRATION_PHASE,
 } from '@kubevirt-utils/resources/migrations/constants';
 import {
@@ -37,7 +36,7 @@ export const getStatusMigration = (
 
 export const getMigrationPercentage = (
   storageMigrationPlan: MultiNamespaceVirtualMachineStorageMigrationPlan,
-) => {
+): number => {
   if (isMigrationCompleted(storageMigrationPlan)) return 100;
 
   const totalVolumeCount = getVolumeCountFromMigPlan(storageMigrationPlan);

--- a/src/views/storagemigrations/list/storageMigrationDefinition.tsx
+++ b/src/views/storagemigrations/list/storageMigrationDefinition.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable */
 import React from 'react';
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
-import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
+import { type ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { ACTIONS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
-import { MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
+import { type MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
 import {
   getMigrationStartTimestamp,
   getVolumeCountFromMigPlan,
@@ -92,7 +91,7 @@ export const getStorageMigrationRowId = (
   const uid = getUID(row);
   if (uid) return uid;
 
-  const cluster = getCluster(row) || 'local';
+  const cluster = getCluster(row) ?? 'local';
   const name = getName(row);
 
   if (name) {

--- a/src/views/storagemigrations/list/utils.ts
+++ b/src/views/storagemigrations/list/utils.ts
@@ -1,11 +1,11 @@
-/* eslint-disable */
 import { getStorageMigrationPlanModelForKind } from '@kubevirt-utils/resources/migrations/backends';
-import { MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
+import { type MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
 import { getStorageMigrationPlanSpecNamespaces } from '@kubevirt-utils/resources/migrations/selectors';
 import {
   getMigrationStartTimestamp,
   getVolumeCountFromMigPlan,
 } from '@kubevirt-utils/resources/migrations/utils';
+import { type K8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
 import { getMigrationPercentage } from './components/utils';
 
@@ -26,12 +26,12 @@ export const getStorageClassesFromMigPlan = (
 
 export const getStorageMigrationRowModel = (
   row: MultiNamespaceVirtualMachineStorageMigrationPlan,
-) => getStorageMigrationPlanModelForKind(row?.kind);
+): K8sModel => getStorageMigrationPlanModelForKind(row?.kind);
 
 export const compareMigrationVolumes = (
   a: MultiNamespaceVirtualMachineStorageMigrationPlan,
   b: MultiNamespaceVirtualMachineStorageMigrationPlan,
-) => {
+): number => {
   const aVolumes = getVolumeCountFromMigPlan(a);
   const bVolumes = getVolumeCountFromMigPlan(b);
 
@@ -41,7 +41,7 @@ export const compareMigrationVolumes = (
 export const compareMigrationNamespaces = (
   a: MultiNamespaceVirtualMachineStorageMigrationPlan,
   b: MultiNamespaceVirtualMachineStorageMigrationPlan,
-) => {
+): number => {
   return (
     getStorageMigrationPlanSpecNamespaces(a).length -
     getStorageMigrationPlanSpecNamespaces(b).length
@@ -51,7 +51,7 @@ export const compareMigrationNamespaces = (
 export const compareMigrationStorageClasses = (
   a: MultiNamespaceVirtualMachineStorageMigrationPlan,
   b: MultiNamespaceVirtualMachineStorageMigrationPlan,
-) => {
+): number => {
   const aStorageClasses = getStorageClassesFromMigPlan(a)?.[0] ?? '';
   const bStorageClasses = getStorageClassesFromMigPlan(b)?.[0] ?? '';
 
@@ -61,7 +61,7 @@ export const compareMigrationStorageClasses = (
 export const compareMigrationStarted = (
   a: MultiNamespaceVirtualMachineStorageMigrationPlan,
   b: MultiNamespaceVirtualMachineStorageMigrationPlan,
-) => {
+): number => {
   const aStarted = getMigrationStartTimestamp(a) ?? '';
   const bStarted = getMigrationStartTimestamp(b) ?? '';
   return aStarted.localeCompare(bStarted);
@@ -70,7 +70,7 @@ export const compareMigrationStarted = (
 export const compareMigrationStatus = (
   a: MultiNamespaceVirtualMachineStorageMigrationPlan,
   b: MultiNamespaceVirtualMachineStorageMigrationPlan,
-) => {
+): number => {
   const aPercentage = getMigrationPercentage(a);
   const bPercentage = getMigrationPercentage(b);
   return aPercentage - bPercentage;

--- a/src/views/templates/actions/components/EditBootSourceModal.tsx
+++ b/src/views/templates/actions/components/EditBootSourceModal.tsx
@@ -1,19 +1,18 @@
-/* eslint-disable */
-import React, { FC, useEffect, useRef, useState } from 'react';
+import React, { type FC, useEffect, useRef, useState } from 'react';
 import { Trans } from 'react-i18next';
 
 import {
   modelToGroupVersionKind,
   TemplateModel,
-  V1Template,
+  type V1Template,
 } from '@kubevirt-ui-ext/kubevirt-api/console';
 import {
-  V1beta1DataSource,
-  V1beta1DataVolumeSpec,
+  type V1beta1DataSource,
+  type V1beta1DataVolumeSpec,
 } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { K8sResourceCommon, ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon, ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Alert,
   AlertVariant,
@@ -24,9 +23,9 @@ import {
   Popover,
 } from '@patternfly/react-core';
 
-import { SOURCE_TYPES } from '../../utils/constants';
 import { editBootSource } from '../editBootSource';
 
+import { SOURCE_TYPES } from '../../utils/constants';
 import useBootSourceEditAffectedTemplates from './hooks/useBootSourceEditAffectedTemplates';
 import { SelectSource } from './SelectSource';
 import SelectSourceSkeleton from './SelectSourceSkeleton';
@@ -53,14 +52,14 @@ const EditBootSourceModal: FC<EditBootSourceModalProps> = ({
 
   useEffect(() => {
     setLoading(true);
-    getDataVolumeSpec(dataSource)
+    void getDataVolumeSpec(dataSource)
       .then(setBootSource)
       .finally(() => setLoading(false));
   }, [dataSource]);
 
   const affectedTemplates = useBootSourceEditAffectedTemplates(obj);
 
-  const onSubmit = async () => {
+  const onSubmit = async (): Promise<void> => {
     await editBootSource(dataSource, bootSource);
   };
 
@@ -89,7 +88,7 @@ const EditBootSourceModal: FC<EditBootSourceModalProps> = ({
         </Trans>
       </Alert>
       <Popover
-        bodyContent={(affectedTemplates || []).map((template) => (
+        bodyContent={(affectedTemplates ?? []).map((template) => (
           <ResourceLink
             groupVersionKind={modelToGroupVersionKind(TemplateModel)}
             key={template.metadata.uid}

--- a/src/views/templates/actions/components/SelectSource.tsx
+++ b/src/views/templates/actions/components/SelectSource.tsx
@@ -1,15 +1,14 @@
-/* eslint-disable */
-import React, { FC, ReactNode } from 'react';
+/* eslint-disable max-lines */
+import React, { type FC, type ReactNode } from 'react';
 
-import { V1beta1DataVolumeSpec } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type V1beta1DataVolumeSpec } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import CapacityInput from '@kubevirt-utils/components/CapacityInput/CapacityInput';
 import { DEFAULT_DISK_SIZE } from '@kubevirt-utils/components/DiskModal/utils/constants';
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { FormGroup, TextInput, ValidatedOptions } from '@patternfly/react-core';
 
-import { SOURCE_OPTIONS_IDS, SOURCE_TYPES } from '../../utils/constants';
-
+import { type SOURCE_OPTIONS_IDS, SOURCE_TYPES } from '../../utils/constants';
 import { PersistentVolumeClaimSelect } from './PersistentVolumeClaimSelect/PersistentVolumeClaimSelect';
 import SelectSourceOption from './SelectSourceOption';
 import {
@@ -43,54 +42,62 @@ export const SelectSource: FC<SelectSourceProps> = ({
   const pvcNamespaceSelected = source?.source?.pvc?.namespace;
   const httpURL = source?.source?.http?.url;
   const containerImage = source?.source?.registry?.url;
-  const volumeQuantity = source?.storage?.resources?.requests?.storage || initialVolumeQuantity;
+  const volumeQuantity = source?.storage?.resources?.requests?.storage ?? initialVolumeQuantity;
 
-  const onSourceSelected = (newSourceType: SOURCE_OPTIONS_IDS, newVolumeQuantity?: string) => {
-    const selectedVolumeQuantity = newVolumeQuantity || volumeQuantity;
+  const onSourceSelected = (
+    newSourceType: SOURCE_OPTIONS_IDS,
+    newVolumeQuantity?: string,
+  ): void => {
+    const selectedVolumeQuantity = newVolumeQuantity ?? volumeQuantity;
 
     switch (newSourceType) {
       case SOURCE_TYPES.httpSource:
-        return onSourceChange(
+        onSourceChange(
           getGenericSourceCustomization(
             newSourceType,
             httpURL,
             withSize ? selectedVolumeQuantity : null,
           ),
         );
+        return;
       case SOURCE_TYPES.pvcSource:
-        return onSourceChange(
+        onSourceChange(
           getPVCSource(
             pvcNameSelected,
             pvcNamespaceSelected,
             withSize ? selectedVolumeQuantity : null,
           ),
         );
+        return;
       case SOURCE_TYPES.registrySource:
-        return onSourceChange(
+        onSourceChange(
           getGenericSourceCustomization(
             newSourceType,
-            containerImage || '',
+            containerImage ?? '',
             withSize ? selectedVolumeQuantity : null,
           ),
         );
+        return;
       default:
         return;
     }
   };
 
-  const onContainerChange = (newContainerURL) =>
+  const onContainerChange = (newContainerURL: string): void => {
     onSourceChange(
       getGenericSourceCustomization(
         selectedSourceType,
-        newContainerURL || '',
+        newContainerURL ?? '',
         withSize ? volumeQuantity : null,
       ),
     );
+  };
 
-  const onURLChange = (newUrl) =>
+  const onURLChange = (newUrl: string): void => {
     onSourceChange(
       getGenericSourceCustomization(selectedSourceType, newUrl, withSize ? volumeQuantity : null),
     );
+  };
 
   return (
     <>

--- a/src/views/templates/actions/components/hooks/useBootSourceEditAffectedTemplates.ts
+++ b/src/views/templates/actions/components/hooks/useBootSourceEditAffectedTemplates.ts
@@ -1,10 +1,9 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import {
   modelToGroupVersionKind,
   TemplateModel,
-  V1Template,
+  type V1Template,
 } from '@kubevirt-ui-ext/kubevirt-api/console';
 import {
   getTemplateParameterValue,
@@ -13,7 +12,7 @@ import {
 } from '@kubevirt-utils/resources/template';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
-const useBootSourceEditAffectedTemplates = (obj: V1Template) => {
+const useBootSourceEditAffectedTemplates = (obj: V1Template): V1Template[] => {
   const [allTemplates] = useK8sWatchResource<V1Template[]>({
     groupVersionKind: modelToGroupVersionKind(TemplateModel),
     isList: true,

--- a/src/views/templates/actions/components/utils.ts
+++ b/src/views/templates/actions/components/utils.ts
@@ -1,12 +1,12 @@
-/* eslint-disable */
 import {
-  V1beta1DataSource,
-  V1beta1DataVolumeSpec,
+  type V1beta1DataSource,
+  type V1beta1DataVolumeSpec,
 } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import { DEFAULT_DISK_SIZE } from '@kubevirt-utils/components/DiskModal/utils/constants';
 
-import { SOURCE_OPTIONS_IDS, SOURCE_TYPES } from '../../utils/constants';
 import { getDataSourceDataVolume } from '../editBootSource';
+
+import { type SOURCE_OPTIONS_IDS, SOURCE_TYPES } from '../../utils/constants';
 
 export const getDataVolumeSpec = async (
   dataSource: V1beta1DataSource,
@@ -16,10 +16,12 @@ export const getDataVolumeSpec = async (
 
   const dataVolume = await getDataSourceDataVolume(dataSourcePVCName, dataSourcePVCNamespace);
 
-  return dataVolume?.spec as Promise<V1beta1DataVolumeSpec>;
+  return dataVolume?.spec;
 };
 
-export const getSourceTypeFromDataVolumeSpec = (dataVolumeSpec: V1beta1DataVolumeSpec) => {
+export const getSourceTypeFromDataVolumeSpec = (
+  dataVolumeSpec: V1beta1DataVolumeSpec,
+): SOURCE_OPTIONS_IDS | undefined => {
   if (dataVolumeSpec?.source?.pvc) return SOURCE_TYPES.pvcSource;
 
   if (dataVolumeSpec?.source?.http) return SOURCE_TYPES.httpSource;
@@ -78,6 +80,6 @@ export const getPVCSource = (
 
 const DOCKER_PREFIX = 'docker://';
 
-export const appendDockerPrefix = (image: string) => {
+export const appendDockerPrefix = (image: string): string => {
   return image?.startsWith(DOCKER_PREFIX) ? image : DOCKER_PREFIX.concat(image);
 };

--- a/src/views/templates/components/VirtualMachineTemplateRequest/VirtualMachineTemplateRequestActions.tsx
+++ b/src/views/templates/components/VirtualMachineTemplateRequest/VirtualMachineTemplateRequestActions.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { VirtualMachineTemplateRequestModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1alpha1VirtualMachineTemplateRequest } from '@kubevirt-ui-ext/kubevirt-api/virt-template';
+import { type V1alpha1VirtualMachineTemplateRequest } from '@kubevirt-ui-ext/kubevirt-api/virt-template';
 import ActionsDropdown from '@kubevirt-utils/components/ActionsDropdown/ActionsDropdown';
 import DeleteModal from '@kubevirt-utils/components/DeleteModal/DeleteModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
@@ -26,7 +25,7 @@ const VirtualMachineTemplateRequestActions: FC<VirtualMachineTemplateRequestActi
   const actions = [
     {
       accessReview: asAccessReview(VirtualMachineTemplateRequestModel, request, 'delete'),
-      cta: () =>
+      cta: (): void =>
         createModal(({ isOpen, onClose }) => (
           <DeleteModal
             onDeleteSubmit={() =>

--- a/src/views/templates/components/VirtualMachineTemplateRequest/VirtualMachineTemplateRequestStatusIcon.tsx
+++ b/src/views/templates/components/VirtualMachineTemplateRequest/VirtualMachineTemplateRequestStatusIcon.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1alpha1VirtualMachineTemplateRequest } from '@kubevirt-ui-ext/kubevirt-api/virt-template';
+import { type V1alpha1VirtualMachineTemplateRequest } from '@kubevirt-ui-ext/kubevirt-api/virt-template';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { RedExclamationCircleIcon } from '@openshift-console/dynamic-plugin-sdk';
 import { Tooltip } from '@patternfly/react-core';
@@ -27,7 +26,7 @@ const VirtualMachineTemplateRequestStatusIcon: FC<VirtualMachineTemplateRequestS
 
   if (status === VMTemplateRequestStatus.Failed) {
     return (
-      <Tooltip content={message || t('Unknown error')}>
+      <Tooltip content={message ?? t('Unknown error')}>
         <span>
           <RedExclamationCircleIcon />
           <span className="pf-v6-u-ml-sm">{t('Failed')}</span>

--- a/src/views/templates/details/hooks/useTemplateTabs.ts
+++ b/src/views/templates/details/hooks/useTemplateTabs.ts
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import { useMemo } from 'react';
+import { type FC, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
@@ -11,7 +10,11 @@ import TemplateSchedulingTab from '../tabs/scheduling/TemplateSchedulingTab';
 import TemplateScriptsPage from '../tabs/scripts/TemplateScriptsPage';
 import TemplateYAMLPage from '../tabs/yaml/TemplateYAMLPage';
 
-export const useTemplateTabs = () => {
+export const useTemplateTabs = (): {
+  component: FC;
+  href: string;
+  name: string;
+}[] => {
   const { t } = useKubevirtTranslation();
 
   const tabs = useMemo(


### PR DESCRIPTION
## 📝 Description

Adds eslint typescript rules to the code base part- 8


## 🔗 Links

https://redhat.atlassian.net/browse/CNV-90382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved valid empty or falsy values when selecting clusters, tabs, search options, namespaces, URLs, quantities, and display text.
  * Improved handling of missing project names so invalid options no longer appear in project selectors.
  * Improved error-message handling when updating settings, quotas, templates, and guest access.

* **Improvements**
  * Standardized settings configuration handling across cluster settings sections.
  * Improved consistency and reliability across migration, quota, search, storage migration, template, and settings workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->