### PR TITLE
CNV-90382: add typescript-linters-part-9

### DIFF
--- a/src/utils/resources/secret/utils.ts
+++ b/src/utils/resources/secret/utils.ts
@@ -138,8 +138,7 @@ export const createSSHSecret = (
     ...(dryRun && { queryParams: { dryRun: 'All' } }),
   });
 
-export const deleteSecret = (secret: IoK8sApiCoreV1Secret): false | Promise<K8sResourceCommon> =>
-  secret &&
+export const deleteSecret = (secret: IoK8sApiCoreV1Secret): Promise<K8sResourceCommon> =>
   kubevirtK8sDelete({
     cluster: getCluster(secret),
     model: SecretModel,

--- a/src/views/clusteroverview/OverviewTab/alerts-card/hooks/useSimplifiedAlerts.ts
+++ b/src/views/clusteroverview/OverviewTab/alerts-card/hooks/useSimplifiedAlerts.ts
@@ -1,7 +1,9 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
-import { SimplifiedAlerts } from '@kubevirt-utils/components/AlertsCard/utils/types';
+import {
+  AlertType,
+  type SimplifiedAlerts,
+} from '@kubevirt-utils/components/AlertsCard/utils/types';
 import { createAlertKey } from '@kubevirt-utils/components/AlertsCard/utils/utils';
 import useKubevirtAlerts from '@kubevirt-utils/hooks/useKubevirtAlerts';
 import useManagedClusterConsoleURLs from '@multicluster/hooks/useManagedClusterConsoleURLs';
@@ -9,6 +11,11 @@ import useIsACMPage from '@multicluster/useIsACMPage';
 import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import { getAlertFilterURL, getExternalAlertURL } from '../../status-card/utils/utils';
+
+type AlertSeverity = AlertType | string | undefined;
+
+const isAlertSeverity = (severity: AlertSeverity): severity is AlertType =>
+  severity === AlertType.Critical || severity === AlertType.Warning || severity === AlertType.Info;
 
 type UseSimplifiedAlerts = () => {
   alerts: SimplifiedAlerts;
@@ -22,41 +29,48 @@ const useSimplifiedAlerts: UseSimplifiedAlerts = () => {
   const [hubClusterName] = useHubClusterName();
   const { getConsoleURL, loaded: consoleURLsLoaded } = useManagedClusterConsoleURLs();
 
-  const simplifiedAlerts = useMemo(() => {
-     
-    const data = { critical: [], warning: [], info: [] };
-    return (
-      alerts.reduce((acc, alert) => {
-        const alertCluster = alert?.labels?.cluster;
-        const alertName = alert?.labels?.alertname;
-        const isSpokeClusterAlert = isACMPage && alertCluster && alertCluster !== hubClusterName;
+  const simplifiedAlerts = useMemo((): SimplifiedAlerts => {
+    const data: SimplifiedAlerts = {
+      [AlertType.Critical]: [],
+      [AlertType.Info]: [],
+      [AlertType.Warning]: [],
+    };
 
-        // Get external URL for spoke cluster alerts (opens in new tab)
-        const externalLink = isSpokeClusterAlert
-          ? getExternalAlertURL(alertName, getConsoleURL(alertCluster))
-          : undefined;
-
-        const vmName = alert?.labels?.name || alert?.labels?.vmName;
-        const namespace = alert?.labels?.namespace;
-
-        acc[alert?.labels?.severity] = [
-          ...(acc?.[alert?.labels?.severity] || []),
-          {
-            alertName,
-            cluster: alertCluster,
-            description: alert?.annotations?.description || alert?.annotations?.summary,
-            externalLink,
-            isVMAlert: Boolean(vmName),
-            key: createAlertKey(alert?.activeAt, alert?.labels),
-            link: getAlertFilterURL(alertName),
-            namespace,
-            time: alert?.activeAt,
-            vmName,
-          },
-        ];
+    return alerts.reduce<SimplifiedAlerts>((acc, alert) => {
+      const severity = alert?.labels?.severity;
+      if (!isAlertSeverity(severity)) {
         return acc;
-      }, data) || data
-    );
+      }
+
+      const alertCluster = alert?.labels?.cluster;
+      const alertName = alert?.labels?.alertname;
+      const isSpokeClusterAlert = isACMPage && alertCluster && alertCluster !== hubClusterName;
+
+      // Get external URL for spoke cluster alerts (opens in new tab)
+      const externalLink = isSpokeClusterAlert
+        ? getExternalAlertURL(alertName, getConsoleURL(alertCluster))
+        : undefined;
+
+      const vmName = alert?.labels?.name ?? alert?.labels?.vmName;
+      const namespace = alert?.labels?.namespace;
+
+      acc[severity] = [
+        ...acc[severity],
+        {
+          alertName,
+          cluster: alertCluster,
+          description: alert?.annotations?.description ?? alert?.annotations?.summary,
+          externalLink,
+          isVMAlert: Boolean(vmName),
+          key: createAlertKey(alert?.activeAt, alert?.labels),
+          link: getAlertFilterURL(alertName),
+          namespace,
+          time: alert?.activeAt,
+          vmName,
+        },
+      ];
+      return acc;
+    }, data);
   }, [alerts, isACMPage, hubClusterName, getConsoleURL]);
 
   return { alerts: simplifiedAlerts, error, loaded: loaded && consoleURLsLoaded };

--- a/src/views/templates/actions/components/SelectSource.tsx
+++ b/src/views/templates/actions/components/SelectSource.tsx
@@ -8,7 +8,7 @@ import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { FormGroup, TextInput, ValidatedOptions } from '@patternfly/react-core';
 
-import { type SOURCE_OPTIONS_IDS, SOURCE_TYPES } from '../../utils/constants';
+import { SOURCE_TYPES, type SourceOptionsIds } from '../../utils/constants';
 import { PersistentVolumeClaimSelect } from './PersistentVolumeClaimSelect/PersistentVolumeClaimSelect';
 import SelectSourceOption from './SelectSourceOption';
 import {
@@ -23,7 +23,7 @@ type SelectSourceProps = {
   onSourceChange: (customSource: V1beta1DataVolumeSpec) => void;
   source: V1beta1DataVolumeSpec;
   sourceLabel: ReactNode;
-  sourceOptions: SOURCE_OPTIONS_IDS[];
+  sourceOptions: SourceOptionsIds[];
   withSize?: boolean;
 };
 
@@ -44,10 +44,7 @@ export const SelectSource: FC<SelectSourceProps> = ({
   const containerImage = source?.source?.registry?.url;
   const volumeQuantity = source?.storage?.resources?.requests?.storage ?? initialVolumeQuantity;
 
-  const onSourceSelected = (
-    newSourceType: SOURCE_OPTIONS_IDS,
-    newVolumeQuantity?: string,
-  ): void => {
+  const onSourceSelected = (newSourceType: SourceOptionsIds, newVolumeQuantity?: string): void => {
     const selectedVolumeQuantity = newVolumeQuantity ?? volumeQuantity;
 
     switch (newSourceType) {
@@ -95,7 +92,11 @@ export const SelectSource: FC<SelectSourceProps> = ({
 
   const onURLChange = (newUrl: string): void => {
     onSourceChange(
-      getGenericSourceCustomization(selectedSourceType, newUrl, withSize ? volumeQuantity : null),
+      getGenericSourceCustomization(
+        selectedSourceType,
+        newUrl,
+        withSize ? volumeQuantity : undefined,
+      ),
     );
   };
 
@@ -112,7 +113,7 @@ export const SelectSource: FC<SelectSourceProps> = ({
         <PersistentVolumeClaimSelect
           selectPVC={(newPVCNamespace, newPVCName) =>
             onSourceChange(
-              getPVCSource(newPVCName, newPVCNamespace, withSize ? volumeQuantity : null),
+              getPVCSource(newPVCName, newPVCNamespace, withSize ? volumeQuantity : undefined),
             )
           }
           projectSelected={pvcNamespaceSelected}

--- a/src/views/templates/actions/components/SelectSourceOption.tsx
+++ b/src/views/templates/actions/components/SelectSourceOption.tsx
@@ -8,10 +8,10 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import { FormGroup, SelectOption } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import { type SOURCE_OPTIONS_IDS, SOURCE_TYPE_LABELS, SOURCE_TYPES } from '../../utils/constants';
+import { SOURCE_TYPE_LABELS, SOURCE_TYPES, type SourceOptionsIds } from '../../utils/constants';
 
 const getSourceOption = (
-  source: SOURCE_OPTIONS_IDS,
+  source: SourceOptionsIds,
   ns: string,
   t: TFunction,
 ): JSX.Element | undefined => {
@@ -75,9 +75,9 @@ const getSourceOption = (
 
 type SelectSourceOptionProps = {
   label: ReactNode;
-  onSelectSource: (selection: SOURCE_OPTIONS_IDS) => void;
-  options: SOURCE_OPTIONS_IDS[];
-  selectedSource: SOURCE_OPTIONS_IDS;
+  onSelectSource: (selection: SourceOptionsIds) => void;
+  options: SourceOptionsIds[];
+  selectedSource: SourceOptionsIds;
 };
 
 const SelectSourceOption: FC<SelectSourceOptionProps> = ({

--- a/src/views/templates/actions/components/utils.ts
+++ b/src/views/templates/actions/components/utils.ts
@@ -6,7 +6,7 @@ import { DEFAULT_DISK_SIZE } from '@kubevirt-utils/components/DiskModal/utils/co
 
 import { getDataSourceDataVolume } from '../editBootSource';
 
-import { type SOURCE_OPTIONS_IDS, SOURCE_TYPES } from '../../utils/constants';
+import { SOURCE_TYPES, type SourceOptionsIds } from '../../utils/constants';
 
 export const getDataVolumeSpec = async (
   dataSource: V1beta1DataSource,
@@ -21,16 +21,18 @@ export const getDataVolumeSpec = async (
 
 export const getSourceTypeFromDataVolumeSpec = (
   dataVolumeSpec: V1beta1DataVolumeSpec,
-): SOURCE_OPTIONS_IDS | undefined => {
+): SourceOptionsIds | undefined => {
   if (dataVolumeSpec?.source?.pvc) return SOURCE_TYPES.pvcSource;
 
   if (dataVolumeSpec?.source?.http) return SOURCE_TYPES.httpSource;
 
   if (dataVolumeSpec?.source?.registry) return SOURCE_TYPES.registrySource;
+
+  return undefined;
 };
 
 export const getGenericSourceCustomization = (
-  diskSourceId: SOURCE_OPTIONS_IDS,
+  diskSourceId: SourceOptionsIds,
   url?: string,
   storage?: string,
 ): V1beta1DataVolumeSpec => {

--- a/src/views/templates/details/tabs/details/components/BootMethod/BootMethod.tsx
+++ b/src/views/templates/details/tabs/details/components/BootMethod/BootMethod.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import { getBootloaderTitleFromVM } from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/utils';
@@ -7,7 +6,7 @@ import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   getTemplateVirtualMachineObject,
-  Template,
+  type Template,
   updateTemplate,
 } from '@kubevirt-utils/resources/template';
 
@@ -26,7 +25,7 @@ const BootMethod: FC<BootMethodProps> = ({ editable, template }) => {
     getTemplateVirtualMachineObject(template),
     t,
   );
-  const onEditClick = () =>
+  const onEditClick = (): void =>
     createModal(({ isOpen, onClose }) => (
       <TemplateBootloaderModal
         isOpen={isOpen}

--- a/src/views/templates/details/tabs/details/components/DisplayName.tsx
+++ b/src/views/templates/details/tabs/details/components/DisplayName.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import produce from 'immer';
 import { ANNOTATIONS } from 'src/views/templates/utils/constants';
 
@@ -8,10 +7,10 @@ import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getDisplayName } from '@kubevirt-utils/resources/shared';
-import { Template, updateTemplate } from '@kubevirt-utils/resources/template';
+import { type Template, updateTemplate } from '@kubevirt-utils/resources/template';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
 
-import { TemplateDetailsGridProps } from '../TemplateDetailsPage';
+import { type TemplateDetailsGridProps } from '../TemplateDetailsPage';
 
 import DisplayNameModal from './DisplayNameModal';
 
@@ -20,7 +19,7 @@ const DisplayName: FC<TemplateDetailsGridProps> = ({ editable, template }) => {
   const { t } = useKubevirtTranslation();
   const displayName = getDisplayName(template);
 
-  const updateDisplayName = (updatedDisplayName: string) => {
+  const updateDisplayName = (updatedDisplayName: string): Promise<Template> => {
     const updatedTemplate = produce<Template>(template, (templateDraft: Template) => {
       if (!templateDraft.metadata.annotations) ensurePath(templateDraft, 'metadata.annotations');
 
@@ -35,7 +34,7 @@ const DisplayName: FC<TemplateDetailsGridProps> = ({ editable, template }) => {
     return updateTemplate(updatedTemplate);
   };
 
-  const onEditClick = () =>
+  const onEditClick = (): void =>
     createModal(({ isOpen, onClose }) => (
       <DisplayNameModal
         isOpen={isOpen}
@@ -47,7 +46,7 @@ const DisplayName: FC<TemplateDetailsGridProps> = ({ editable, template }) => {
 
   return (
     <DescriptionItem
-      descriptionData={displayName || <MutedTextSpan text={t('No display name')} />}
+      descriptionData={displayName ?? <MutedTextSpan text={t('No display name')} />}
       descriptionHeader={t('Display name')}
       isEdit={editable}
       onEditClick={onEditClick}

--- a/src/views/templates/details/tabs/details/components/WorkloadProfile.tsx
+++ b/src/views/templates/details/tabs/details/components/WorkloadProfile.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import produce from 'immer';
 import { getWorkloadProfile } from 'src/views/templates/utils/selectors';
 
@@ -10,21 +9,22 @@ import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTransla
 import {
   getTemplateVirtualMachineObject,
   getTemplateWorkload,
+  type Template,
   TEMPLATE_WORKLOAD_LABEL,
   updateTemplate,
-  WORKLOADS,
+  type WORKLOADS,
 } from '@kubevirt-utils/resources/template';
 import { VM_WORKLOAD_ANNOTATION } from '@kubevirt-utils/resources/vm/utils';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
 
-import { TemplateDetailsGridProps } from '../TemplateDetailsPage';
+import { type TemplateDetailsGridProps } from '../TemplateDetailsPage';
 
 const WorkloadProfile: FC<TemplateDetailsGridProps> = ({ editable, template }) => {
   const { createModal } = useModal();
   const { t } = useKubevirtTranslation();
   const workload = getWorkloadProfile(template);
 
-  const updateWorkload = (updatedWorkload: WORKLOADS) => {
+  const updateWorkload = (updatedWorkload: WORKLOADS): Promise<Template> => {
     const updatedTemplate = produce(template, (draftTemplate) => {
       const draftVM = getTemplateVirtualMachineObject(draftTemplate);
       ensurePath(draftVM, ['spec.template.metadata.annotations']);
@@ -40,7 +40,7 @@ const WorkloadProfile: FC<TemplateDetailsGridProps> = ({ editable, template }) =
     return updateTemplate(updatedTemplate);
   };
 
-  const onEditClick = () =>
+  const onEditClick = (): void =>
     createModal(({ isOpen, onClose }) => (
       <WorkloadProfileModal
         initialWorkload={getTemplateWorkload(template) as WORKLOADS}

--- a/src/views/templates/details/tabs/disks/components/DiskRowActions.tsx
+++ b/src/views/templates/details/tabs/disks/components/DiskRowActions.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC, useCallback, useState } from 'react';
+import React, { type FC, useCallback, useState } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ConfirmActionMessage from '@kubevirt-utils/components/ConfirmActionMessage/ConfirmActionMessage';
 import { CONFIRM_ACTIONS } from '@kubevirt-utils/components/ConfirmActionMessage/constants';
 import DiskModal from '@kubevirt-utils/components/DiskModal/DiskModal';
@@ -48,7 +47,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({ diskName, isDisabled, onUpdat
     return onUpdate(vmWithDeletedDisk);
   }, [diskName, onUpdate, vm]);
 
-  const onDeleteModalToggle = () => {
+  const onDeleteModalToggle = (): void => {
     createModal(({ isOpen, onClose }) => (
       <TabModal<V1VirtualMachine>
         headerText={t('Detach disk?')}
@@ -67,7 +66,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({ diskName, isDisabled, onUpdat
     ));
   };
 
-  const onEditModalToggle = () => {
+  const onEditModalToggle = (): void => {
     createModal(({ isOpen, onClose }) => (
       <DiskModal
         editDiskName={diskName}
@@ -79,7 +78,7 @@ const DiskRowActions: FC<DiskRowActionsProps> = ({ diskName, isDisabled, onUpdat
     ));
   };
 
-  const onToggle = () => setIsDropdownOpen((prevIsOpen) => !prevIsOpen);
+  const onToggle = (): void => setIsDropdownOpen((prevIsOpen) => !prevIsOpen);
 
   return (
     <Dropdown

--- a/src/views/templates/details/tabs/disks/utils.ts
+++ b/src/views/templates/details/tabs/disks/utils.ts
@@ -1,8 +1,7 @@
-/* eslint-disable */
 import produce from 'immer';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { getTemplateVirtualMachineObject, Template } from '@kubevirt-utils/resources/template';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { getTemplateVirtualMachineObject, type Template } from '@kubevirt-utils/resources/template';
 
 export const getTemplateVMWithNamespace = (template: Template): undefined | V1VirtualMachine => {
   const vm = getTemplateVirtualMachineObject(template);
@@ -13,6 +12,6 @@ export const getTemplateVMWithNamespace = (template: Template): undefined | V1Vi
 
   return produce(vm, (draftVM) => {
     draftVM.metadata ??= {};
-    draftVM.metadata.namespace ??= template?.metadata?.namespace || 'default';
+    draftVM.metadata.namespace ??= template?.metadata?.namespace ?? 'default';
   });
 };

--- a/src/views/templates/details/tabs/network/components/list/NetworkInterfaceActions.tsx
+++ b/src/views/templates/details/tabs/network/components/list/NetworkInterfaceActions.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useCallback, useState } from 'react';
+import React, { type FC, useCallback, useState } from 'react';
 import produce from 'immer';
 
 import ConfirmActionMessage from '@kubevirt-utils/components/ConfirmActionMessage/ConfirmActionMessage';
@@ -9,10 +8,10 @@ import KebabToggle from '@kubevirt-utils/components/toggles/KebabToggle';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   getTemplateVirtualMachineObject,
-  Template,
+  type Template,
   updateTemplate,
 } from '@kubevirt-utils/resources/template';
-import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
+import { type NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
 import { NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
 import { getContentScrollableElement } from '@kubevirt-utils/utils/utils';
 import { ButtonVariant, Dropdown, DropdownItem, DropdownList } from '@patternfly/react-core';
@@ -45,7 +44,7 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
   const editBtnText = t('Edit');
   const submitBtnText = t('Delete');
 
-  const onEditModalOpen = () => {
+  const onEditModalOpen = (): void => {
     createModal(({ isOpen, onClose }) => (
       <TemplatesEditNetworkInterfaceModal
         isOpen={isOpen}
@@ -69,7 +68,7 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
     return updateTemplate(updatedTemplate);
   }, [nicName, template]);
 
-  const onDeleteModalToggle = () => {
+  const onDeleteModalToggle = (): void => {
     createModal(({ isOpen, onClose }) => (
       <TabModal<Template>
         headerText={label}
@@ -87,7 +86,7 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
     ));
   };
 
-  const onToggle = () => setIsDropdownOpen((prevIsOpen) => !prevIsOpen);
+  const onToggle = (): void => setIsDropdownOpen((prevIsOpen) => !prevIsOpen);
 
   return (
     <Dropdown

--- a/src/views/templates/details/tabs/network/components/modal/TemplatesNetworkInterfaceModal.tsx
+++ b/src/views/templates/details/tabs/network/components/modal/TemplatesNetworkInterfaceModal.tsx
@@ -1,7 +1,7 @@
-/* eslint-disable */
-import React, { FC, useCallback } from 'react';
+import React, { type FC, useCallback } from 'react';
 
 import NetworkInterfaceModal from '@kubevirt-utils/components/NetworkInterfaceModal/NetworkInterfaceModal';
+import { type NetworkInterfaceModalOnSubmit } from '@kubevirt-utils/components/NetworkInterfaceModal/types';
 import {
   createInterface,
   createNetwork,
@@ -11,7 +11,7 @@ import { getNamespace } from '@kubevirt-utils/resources/shared';
 import {
   getTemplateModel,
   getTemplateVirtualMachineObject,
-  Template,
+  type Template,
 } from '@kubevirt-utils/resources/template';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { kubevirtK8sUpdate } from '@multicluster/k8sRequests';
@@ -42,8 +42,8 @@ const TemplatesNetworkInterfaceModal: FC<TemplatesNetworkInterfaceModalProps> = 
       isLegacyPasst,
       networkName,
       nicName,
-    }) =>
-      () => {
+    }: NetworkInterfaceModalOnSubmit) =>
+      (): Promise<Template> => {
         const resultNetwork = createNetwork(nicName, networkName);
         const resultInterface = createInterface({
           interfaceLinkState,
@@ -65,7 +65,7 @@ const TemplatesNetworkInterfaceModal: FC<TemplatesNetworkInterfaceModalProps> = 
           model: getTemplateModel(template),
           name: getName(updatedTemplate),
           ns: getNamespace(updatedTemplate),
-        });
+        }).then(() => updatedTemplate);
       },
     [template],
   );

--- a/src/views/templates/details/tabs/network/utils.ts
+++ b/src/views/templates/details/tabs/network/utils.ts
@@ -1,18 +1,17 @@
-/* eslint-disable */
 import produce from 'immer';
-import { Draft } from 'immer';
+import { type Draft } from 'immer';
 
 import { TemplateModel, VirtualMachineTemplateModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { produceVMNetworks } from '@kubevirt-utils/components/DiskModal/utils/helpers';
 import {
   getTemplateVirtualMachineObject,
   isVirtualMachineTemplate,
   replaceTemplateVM,
-  Template,
+  type Template,
 } from '@kubevirt-utils/resources/template';
 import { getInterface } from '@kubevirt-utils/resources/vm';
-import { NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
+import { type NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
 import { kubevirtConsole } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { kubevirtK8sUpdate } from '@multicluster/k8sRequests';
@@ -20,7 +19,7 @@ import { kubevirtK8sUpdate } from '@multicluster/k8sRequests';
 export const produceTemplateNetwork = (
   template: Template,
   updateNetwork: (vmDraft: Draft<V1VirtualMachine>) => void,
-) => {
+): Template => {
   const vm = getTemplateVirtualMachineObject(template);
   const updatedVM = produceVMNetworks(vm, updateNetwork);
 

--- a/src/views/templates/details/tabs/scheduling/components/AffinityRules.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/AffinityRules.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable */
-import React, { FC } from 'react';
-import { TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
+import React, { type FC } from 'react';
+import { type TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
 import { getAffinity } from 'src/views/templates/utils/selectors';
 
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
@@ -17,7 +16,7 @@ const AffinityRules: FC<TemplateSchedulingGridProps> = ({ editable, onSubmit, te
     rules: getAffinityRules(getAffinity(template))?.length ?? 0,
   });
 
-  const onEditClick = () =>
+  const onEditClick = (): void =>
     createModal(({ isOpen, onClose }) => (
       <AffinityRulesModal
         isOpen={isOpen}

--- a/src/views/templates/details/tabs/scheduling/components/DedicatedResources.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/DedicatedResources.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable */
-import React, { FC } from 'react';
-import { TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
+import React, { type FC } from 'react';
+import { type TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
 import { isDedicatedCPUPlacement } from 'src/views/templates/utils/utils';
 
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
@@ -16,7 +15,7 @@ const DedicatedResources: FC<TemplateSchedulingGridProps> = ({ editable, onSubmi
     ? t('Workload scheduled with dedicated resources (guaranteed policy)')
     : t('No dedicated resources applied');
 
-  const onEditClick = () =>
+  const onEditClick = (): void => {
     createModal(({ isOpen, onClose }) => (
       <DedicatedResourcesModal
         isOpen={isOpen}
@@ -25,6 +24,7 @@ const DedicatedResources: FC<TemplateSchedulingGridProps> = ({ editable, onSubmi
         template={template}
       />
     ));
+  };
 
   return (
     <DescriptionItem

--- a/src/views/templates/details/tabs/scheduling/components/NodeSelector.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/NodeSelector.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable */
-import React, { FC } from 'react';
-import { TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
+import React, { type FC } from 'react';
+import { type TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
 import { getNodeSelector } from 'src/views/templates/utils/selectors';
 
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
@@ -14,7 +13,7 @@ const NodeSelector: FC<TemplateSchedulingGridProps> = ({ editable, onSubmit, tem
   const { t } = useKubevirtTranslation();
   const { createModal } = useModal();
 
-  const onEditClick = () =>
+  const onEditClick = (): void => {
     createModal(({ isOpen, onClose }) => (
       <NodeSelectorModal
         isOpen={isOpen}
@@ -23,6 +22,7 @@ const NodeSelector: FC<TemplateSchedulingGridProps> = ({ editable, onSubmit, tem
         template={template}
       />
     ));
+  };
 
   return (
     <DescriptionItem

--- a/src/views/templates/details/tabs/scheduling/components/NodeSelectorModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/NodeSelectorModal.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 import produce from 'immer';
 import { getNodeSelector } from 'src/views/templates/utils/selectors';
 
 import { modelToGroupVersionKind, NodeModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1Node } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1Node } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import LabelsList from '@kubevirt-utils/components/NodeSelectorModal/components/LabelList';
 import LabelRow from '@kubevirt-utils/components/NodeSelectorModal/components/LabelRow';
 import NodeCheckerAlert from '@kubevirt-utils/components/NodeSelectorModal/components/NodeCheckerAlert';
@@ -14,10 +13,10 @@ import {
   isEqualObject,
   nodeSelectorToIDLabels,
 } from '@kubevirt-utils/components/NodeSelectorModal/utils/helpers';
-import { IDLabel } from '@kubevirt-utils/components/NodeSelectorModal/utils/types';
+import { type IDLabel } from '@kubevirt-utils/components/NodeSelectorModal/utils/types';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { getTemplateVirtualMachineObject, Template } from '@kubevirt-utils/resources/template';
+import { getTemplateVirtualMachineObject, type Template } from '@kubevirt-utils/resources/template';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
@@ -46,7 +45,9 @@ const NodeSelectorModal: FC<NodeSelectorModalProps> = ({ isOpen, onClose, onSubm
 
   const qualifiedNodes = useNodeLabelQualifier(nodes, nodesLoaded, selectorLabels);
 
-  const onSelectorLabelAdd = () => onLabelAdd({ id: null, key: '', value: '' });
+  const onSelectorLabelAdd = (): void => {
+    onLabelAdd({ id: null, key: '', value: '' });
+  };
 
   const updatedTemplate = useMemo(
     () =>

--- a/src/views/templates/details/tabs/scheduling/components/Tolerations.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/Tolerations.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable */
-import React, { FC } from 'react';
-import { TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
+import React, { type FC } from 'react';
+import { type TemplateSchedulingGridProps } from 'src/views/templates/details/tabs/scheduling/components/TemplateSchedulingLeftGrid';
 import { getTolerations } from 'src/views/templates/utils/selectors';
 
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
@@ -16,10 +15,11 @@ const Tolerations: FC<TemplateSchedulingGridProps> = ({ editable, onSubmit, temp
     tolerations: getTolerations(template)?.length ?? 0,
   });
 
-  const onEditClick = () =>
+  const onEditClick = (): void => {
     createModal(({ isOpen, onClose }) => (
       <TolerationsModal isOpen={isOpen} onClose={onClose} onSubmit={onSubmit} template={template} />
     ));
+  };
 
   return (
     <DescriptionItem

--- a/src/views/templates/details/tabs/scheduling/components/TolerationsModal.tsx
+++ b/src/views/templates/details/tabs/scheduling/components/TolerationsModal.tsx
@@ -1,12 +1,11 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 import produce from 'immer';
 import { getTolerations } from 'src/views/templates/utils/selectors';
 
 import { modelToGroupVersionKind, NodeModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1Node } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1Node } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import {
-  K8sIoApiCoreV1Toleration,
+  type K8sIoApiCoreV1Toleration,
   K8sIoApiCoreV1TolerationEffectEnum,
   K8sIoApiCoreV1TolerationOperatorEnum,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
@@ -17,10 +16,10 @@ import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import TolerationEditRow from '@kubevirt-utils/components/TolerationsModal/TolerationEditRow';
 import TolerationListHeaders from '@kubevirt-utils/components/TolerationsModal/TolerationListHeaders';
 import TolerationModalDescriptionText from '@kubevirt-utils/components/TolerationsModal/TolerationModalDescriptionText';
-import { TolerationLabel } from '@kubevirt-utils/components/TolerationsModal/utils/constants';
+import { type TolerationLabel } from '@kubevirt-utils/components/TolerationsModal/utils/constants';
 import { getNodeTaintQualifier } from '@kubevirt-utils/components/TolerationsModal/utils/helpers';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { getTemplateVirtualMachineObject, Template } from '@kubevirt-utils/resources/template';
+import { getTemplateVirtualMachineObject, type Template } from '@kubevirt-utils/resources/template';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
@@ -41,7 +40,7 @@ const TolerationsModal: FC<TolerationsModalProps> = ({ isOpen, onClose, onSubmit
     onEntityChange: onTolerationChange,
     onEntityDelete: onTolerationDelete,
   } = useIDEntities<TolerationLabel>(
-    (getTolerations(template) || []).map((toleration, id) => ({ ...toleration, id })),
+    (getTolerations(template) ?? []).map((toleration, id) => ({ ...toleration, id })),
   );
   const tolerationLabelsEmpty = tolerationsLabels?.length === 0;
   const [nodes, nodesLoaded] = useK8sWatchData<IoK8sApiCoreV1Node[]>({
@@ -51,7 +50,7 @@ const TolerationsModal: FC<TolerationsModalProps> = ({ isOpen, onClose, onSubmit
   });
   const qualifiedNodes = getNodeTaintQualifier(nodes, nodesLoaded, tolerationsLabels);
 
-  const onSelectorLabelAdd = () =>
+  const onSelectorLabelAdd = (): void =>
     onTolerationAdd({
       effect: K8sIoApiCoreV1TolerationEffectEnum.NoSchedule,
       id: null,

--- a/src/views/templates/details/tabs/scripts/components/SSHKey/sshkey-utils.ts
+++ b/src/views/templates/details/tabs/scripts/components/SSHKey/sshkey-utils.ts
@@ -1,15 +1,14 @@
-/* eslint-disable */
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { addSecretToVM } from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
 import {
   getTemplateVirtualMachineObject,
   isVirtualMachineTemplate,
-  Template,
+  type Template,
 } from '@kubevirt-utils/resources/template';
 import { getAccessCredentials } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
-export const updateAccessCredential = (template: Template, secretName: string) => {
+export const updateAccessCredential = (template: Template, secretName: string): void => {
   const vm = getTemplateVirtualMachineObject(template);
   const updatedVM = addSecretToVM(vm, secretName);
 
@@ -23,7 +22,7 @@ export const updateAccessCredential = (template: Template, secretName: string) =
   );
 };
 
-export const removeAccessCredential = (template: Template, secretName: string) => {
+export const removeAccessCredential = (template: Template, secretName: string): void => {
   const vm = getTemplateVirtualMachineObject(template);
   const accessCredentials = getAccessCredentials(vm);
 

--- a/src/views/templates/details/tabs/scripts/components/SysPrepItem/SysPrepItem.tsx
+++ b/src/views/templates/details/tabs/scripts/components/SysPrepItem/SysPrepItem.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { useParams } from 'react-router';
 
 import { ConfigMapModel, modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import WindowsLabel from '@kubevirt-utils/components/Labels/WindowsLabel';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
@@ -12,7 +11,7 @@ import { SysprepDescription } from '@kubevirt-utils/components/SysprepModal/Sysp
 import { SysprepModal } from '@kubevirt-utils/components/SysprepModal/SysprepModal';
 import { DEFAULT_NAMESPACE } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { getTemplateVirtualMachineObject, Template } from '@kubevirt-utils/resources/template';
+import { getTemplateVirtualMachineObject, type Template } from '@kubevirt-utils/resources/template';
 import { getVolumes } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
@@ -21,7 +20,6 @@ import { Button, ButtonVariant, Flex, FlexItem, Title } from '@patternfly/react-
 import { PencilAltIcon } from '@patternfly/react-icons';
 
 import useEditTemplateAccessReview from '../../../../hooks/useIsTemplateEditable';
-
 import {
   deleteTemplateSysprepObject,
   getTemplateSysprepObject,
@@ -61,20 +59,23 @@ const SysPrepItem: FC<SysPrepItemProps> = ({ template }) => {
     );
 
   const { [AUTOUNATTEND]: autoUnattend, [UNATTEND]: unattend } =
-    externalSysprepConfig?.data || sysPrepObject?.data || {};
+    externalSysprepConfig?.data ?? sysPrepObject?.data ?? {};
 
-  const onSysprepSelected = async (newSysprepName: string) => {
+  const onSysprepSelected = async (newSysprepName: string): Promise<void> => {
     const templateNoSysprepObj = deleteTemplateSysprepObject(template, currentVMSysprepName);
     return updateTemplateWithSysprep(templateNoSysprepObj, newSysprepName, currentVMSysprepName);
   };
 
-  const onSysprepCreation = (newUnattended: string, newAutoUnattend: string) => {
+  const onSysprepCreation = async (
+    newUnattended: string,
+    newAutoUnattend: string,
+  ): Promise<void> => {
     const newSysPrepObject = updateSysprepObject(sysPrepObject, newUnattended, newAutoUnattend);
     const templateWithSysPrep = newSysPrepObject
       ? replaceTemplateSysprepObject(template, newSysPrepObject, currentVMSysprepName)
       : deleteTemplateSysprepObject(template, currentVMSysprepName);
 
-    return updateTemplateWithSysprep(
+    await updateTemplateWithSysprep(
       templateWithSysPrep,
       newSysPrepObject?.metadata?.name,
       externalSysprepSelected,
@@ -97,7 +98,7 @@ const SysPrepItem: FC<SysPrepItemProps> = ({ template }) => {
                   <SysprepModal
                     {...modalProps}
                     autoUnattend={autoUnattend}
-                    namespace={vm?.metadata?.namespace || DEFAULT_NAMESPACE}
+                    namespace={vm?.metadata?.namespace ?? DEFAULT_NAMESPACE}
                     onSysprepCreation={onSysprepCreation}
                     onSysprepSelected={onSysprepSelected}
                     sysprepSelected={externalSysprepSelected}

--- a/src/views/templates/list/cells/TemplateClusterCell.tsx
+++ b/src/views/templates/list/cells/TemplateClusterCell.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { TemplateOrRequest } from '@kubevirt-utils/resources/template';
+import { type TemplateOrRequest } from '@kubevirt-utils/resources/template';
 import { ManagedClusterModel } from '@multicluster/constants';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
@@ -14,7 +13,7 @@ type TemplateClusterCellProps = {
 
 const TemplateClusterCell: FC<TemplateClusterCellProps> = ({ row }) => {
   const [hubClusterName] = useHubClusterName();
-  const cluster = getCluster(row) || hubClusterName;
+  const cluster = getCluster(row) ?? hubClusterName;
 
   return (
     <ResourceLink groupVersionKind={modelToGroupVersionKind(ManagedClusterModel)} name={cluster} />

--- a/src/views/templates/list/cells/TemplateNameCell.tsx
+++ b/src/views/templates/list/cells/TemplateNameCell.tsx
@@ -1,12 +1,11 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import {
   isDeprecatedTemplate,
   isVirtualMachineTemplateRequest,
-  TemplateOrRequest,
+  type TemplateOrRequest,
 } from '@kubevirt-utils/resources/template';
 import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
 import { getCluster } from '@multicluster/helpers/selectors';
@@ -26,7 +25,7 @@ const TemplateNameCell: FC<TemplateNameCellProps> = ({ row }) => {
 
   const name = getName(row);
   const namespace = getNamespace(row);
-  const cluster = getCluster(row) || clusterParam;
+  const cluster = getCluster(row) ?? clusterParam;
 
   const isVMTR = isVirtualMachineTemplateRequest(row);
 

--- a/src/views/templates/list/cells/TemplateNamespaceCell.tsx
+++ b/src/views/templates/list/cells/TemplateNamespaceCell.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { modelToGroupVersionKind, NamespaceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
-import { TemplateOrRequest } from '@kubevirt-utils/resources/template';
+import { type TemplateOrRequest } from '@kubevirt-utils/resources/template';
 import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useClusterParam from '@multicluster/hooks/useClusterParam';
@@ -14,7 +13,7 @@ type TemplateNamespaceCellProps = {
 
 const TemplateNamespaceCell: FC<TemplateNamespaceCellProps> = ({ row }) => {
   const clusterParam = useClusterParam();
-  const cluster = getCluster(row) || clusterParam;
+  const cluster = getCluster(row) ?? clusterParam;
   const namespace = getNamespace(row);
 
   return (

--- a/src/views/templates/list/components/VirtualMachineTemplatesCreateButton/VirtualMachineTemplatesCreateButton.tsx
+++ b/src/views/templates/list/components/VirtualMachineTemplatesCreateButton/VirtualMachineTemplatesCreateButton.tsx
@@ -48,7 +48,7 @@ const VirtualMachineTemplatesCreateButton: FC = () => {
   const onSelect = useCallback(
     (_event: MouseEvent, value: string) => {
       setIsOpen(false);
-      if (value === CreateTemplateItems.yaml) {
+      if (value === CreateTemplateItems.Yaml) {
         return navigate(
           isACMPage && cluster
             ? `${getFleetTemplatesURL(cluster, namespace)}/~new`
@@ -56,14 +56,14 @@ const VirtualMachineTemplatesCreateButton: FC = () => {
         );
       }
 
-      if (value === CreateTemplateItems.fromVM) {
+      if (value === CreateTemplateItems.FromVM) {
         navigate(
           getVMListPath(currentNamespace, cluster, `${VM_LIST_TAB_PARAM}=${VM_LIST_TAB_VMS}`),
         );
         return addCreateFromVMToast();
       }
 
-      if (value === CreateTemplateItems.fromTemplate) {
+      if (value === CreateTemplateItems.FromTemplate) {
         return createModal?.(({ isOpen: isModalOpen, onClose }) => (
           <CloneTemplateModal isOpen={isModalOpen} onClose={onClose} />
         ));
@@ -104,20 +104,20 @@ const VirtualMachineTemplatesCreateButton: FC = () => {
         <DropdownList>
           <DropdownItem
             description={t('Clone and customize a template.')}
-            key={CreateTemplateItems.fromTemplate}
-            value={CreateTemplateItems.fromTemplate}
+            key={CreateTemplateItems.FromTemplate}
+            value={CreateTemplateItems.FromTemplate}
           >
             {t('From an existing template')}
           </DropdownItem>
           <DropdownItem
             description={t('Save an existing VM as a template.')}
             isExternalLink
-            key={CreateTemplateItems.fromVM}
-            value={CreateTemplateItems.fromVM}
+            key={CreateTemplateItems.FromVM}
+            value={CreateTemplateItems.FromVM}
           >
             {t('From a virtual machine')}
           </DropdownItem>
-          <DropdownItem key={CreateTemplateItems.yaml} value={CreateTemplateItems.yaml}>
+          <DropdownItem key={CreateTemplateItems.Yaml} value={CreateTemplateItems.Yaml}>
             {t('With YAML')}
           </DropdownItem>
         </DropdownList>

--- a/src/views/templates/list/components/VirtualMachineTemplatesCreateButton/constants.ts
+++ b/src/views/templates/list/components/VirtualMachineTemplatesCreateButton/constants.ts
@@ -1,6 +1,5 @@
-/* eslint-disable */
 export enum CreateTemplateItems {
-  fromTemplate = 'fromTemplate',
-  fromVM = 'fromVM',
-  yaml = 'yaml',
+  FromTemplate = 'fromTemplate',
+  FromVM = 'fromVM',
+  Yaml = 'yaml',
 }

--- a/src/views/templates/list/hooks/useAllTemplateResources.ts
+++ b/src/views/templates/list/hooks/useAllTemplateResources.ts
@@ -1,17 +1,15 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import useIsVMTemplateFeatureEnabled from '@kubevirt-utils/hooks/useVMTemplateFeatureFlag/useIsVMTemplateFeatureEnabled';
 import {
   sortTemplates,
-  Template,
-  TemplateOrRequest,
+  type Template,
+  type TemplateOrRequest,
 } from '@kubevirt-utils/resources/template/utils';
-import { Selector } from '@openshift-console/dynamic-plugin-sdk';
+import { type Selector } from '@openshift-console/dynamic-plugin-sdk';
 
 import { VMTemplateRequestStatus } from '../../components/VirtualMachineTemplateRequest/constants';
 import { getVMTemplateRequestStatus } from '../../components/VirtualMachineTemplateRequest/utils';
-
 import { useOpenShiftTemplates } from './useOpenShiftTemplates';
 import useVirtualMachineTemplateRequests from './useVirtualMachineTemplateRequests';
 import useVirtualMachineTemplates from './useVirtualMachineTemplates';
@@ -23,7 +21,7 @@ type UseAllTemplateResources = (props: {
 }) => {
   allTemplates: Template[];
   allTemplatesWithRequests: TemplateOrRequest[];
-  error: any;
+  error: unknown;
   loaded: boolean;
 };
 
@@ -74,7 +72,7 @@ const useAllTemplateResources: UseAllTemplateResources = ({
   return {
     allTemplates,
     allTemplatesWithRequests,
-    error: vmTemplatesEnabled ? templatesError || vmtError || vmtrError : templatesError,
+    error: vmTemplatesEnabled ? (templatesError ?? vmtError ?? vmtrError) : templatesError,
     loaded:
       !vmTemplatesFeatureLoading &&
       (vmTemplatesEnabled ? templatesLoaded && vmtLoaded && vmtrLoaded : templatesLoaded),

--- a/src/views/templates/list/hooks/useOpenShiftTemplates.ts
+++ b/src/views/templates/list/hooks/useOpenShiftTemplates.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import { type V1Template } from '@kubevirt-ui-ext/kubevirt-api/console';
@@ -20,7 +19,7 @@ type UseOpenShiftTemplates = (props: {
   namespace?: string;
   selector?: Selector;
 }) => {
-  error: any;
+  error: unknown;
   loaded: boolean;
   templates: V1Template[];
 };
@@ -68,9 +67,9 @@ export const useOpenShiftTemplates: UseOpenShiftTemplates = ({
     namespace,
     searchQueries: templateMulticlusterFilters,
     selector: {
-      ...(selector || {}),
+      ...(selector ?? {}),
       matchExpressions: [
-        ...(selector?.matchExpressions || []),
+        ...(selector?.matchExpressions ?? []),
         {
           key: TEMPLATE_TYPE_LABEL,
           operator: Operator.In,

--- a/src/views/templates/list/hooks/useVirtualMachineTemplateRequests.ts
+++ b/src/views/templates/list/hooks/useVirtualMachineTemplateRequests.ts
@@ -1,6 +1,5 @@
-/* eslint-disable */
 import { VirtualMachineTemplateRequestModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1alpha1VirtualMachineTemplateRequest } from '@kubevirt-ui-ext/kubevirt-api/virt-template';
+import { type V1alpha1VirtualMachineTemplateRequest } from '@kubevirt-ui-ext/kubevirt-api/virt-template';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
 import useListClusters from '@kubevirt-utils/hooks/useListClusters';
 import isResourceNotFoundError from '@kubevirt-utils/utils/isResourceNotFoundError';
@@ -10,7 +9,7 @@ type UseVirtualMachineTemplateRequests = (
   namespace?: string,
   enabled?: boolean,
 ) => {
-  error: any;
+  error: unknown;
   loaded: boolean;
   vmTemplateRequests: V1alpha1VirtualMachineTemplateRequest[];
 };

--- a/src/views/templates/list/hooks/useVirtualMachineTemplates.ts
+++ b/src/views/templates/list/hooks/useVirtualMachineTemplates.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import { VirtualMachineTemplateModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
@@ -14,7 +13,7 @@ type UseVirtualMachineTemplates = (
   enabled?: boolean,
   clusterOverride?: string,
 ) => {
-  error: any;
+  error: unknown;
   loaded: boolean;
   vmTemplates: V1beta1VirtualMachineTemplate[];
 };

--- a/src/views/templates/utils/constants.ts
+++ b/src/views/templates/utils/constants.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 export const ANNOTATIONS = {
   displayName: 'openshift.io/display-name',
   providerDisplayName: 'openshift.io/provider-display-name',
@@ -26,7 +25,7 @@ export const SOURCE_TYPE_LABELS = {
   [SOURCE_TYPES.registrySource]: 'Registry (ContainerDisk)',
 };
 
-export type SOURCE_OPTIONS_IDS =
+export type SourceOptionsIds =
   | typeof SOURCE_TYPES.httpSource
   | typeof SOURCE_TYPES.pvcSource
   | typeof SOURCE_TYPES.registrySource

--- a/src/views/templates/utils/selectors.ts
+++ b/src/views/templates/utils/selectors.ts
@@ -1,27 +1,30 @@
-/* eslint-disable */
+import {
+  type K8sIoApiCoreV1Affinity,
+  type K8sIoApiCoreV1Toleration,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getAnnotation } from '@kubevirt-utils/resources/shared';
 import { getLabel } from '@kubevirt-utils/resources/shared';
 import {
   getTemplateVirtualMachineObject,
-  Template,
+  type Template,
   WORKLOADS_LABELS,
 } from '@kubevirt-utils/resources/template';
 import { VM_WORKLOAD_ANNOTATION } from '@kubevirt-utils/resources/vm/utils';
 
 import { ANNOTATIONS, LABELS } from './constants';
 
-export const getAffinity = (template: Template) =>
-  getTemplateVirtualMachineObject(template)?.spec?.template?.spec?.affinity || {};
+export const getAffinity = (template: Template): K8sIoApiCoreV1Affinity =>
+  getTemplateVirtualMachineObject(template)?.spec?.template?.spec?.affinity ?? {};
 
 export const getEvictionStrategy = (template: Template): string =>
   getTemplateVirtualMachineObject(template)?.spec?.template?.spec?.evictionStrategy;
 
-export const getNodeSelector = (template: Template) =>
+export const getNodeSelector = (template: Template): Record<string, string> | undefined =>
   getTemplateVirtualMachineObject(template)?.spec?.template?.spec?.nodeSelector;
 
 export const getTemplateProviderName = (template: Template): string =>
-  getAnnotation(template, ANNOTATIONS.providerName, null) ||
-  getLabel(template, LABELS.provider, null) ||
+  getAnnotation(template, ANNOTATIONS.providerName, null) ??
+  getLabel(template, LABELS.provider, null) ??
   getAnnotation(template, ANNOTATIONS.providerDisplayName, null);
 
 export const getTemplateWorkload = (template: Template): string =>
@@ -29,12 +32,12 @@ export const getTemplateWorkload = (template: Template): string =>
     VM_WORKLOAD_ANNOTATION
   ];
 
-export const getTolerations = (template: Template) =>
+export const getTolerations = (template: Template): K8sIoApiCoreV1Toleration[] | undefined =>
   getTemplateVirtualMachineObject(template)?.spec?.template?.spec?.tolerations;
 
 // t('Other')
 export const getWorkloadProfile = (template: Template): string =>
-  WORKLOADS_LABELS[getTemplateWorkload(template)] || 'Other';
+  WORKLOADS_LABELS[getTemplateWorkload(template)] ?? 'Other';
 
 export const getVMTemplateBaseName = (template: Template): { name: string; namespace: string } => {
   const name = getLabel(template, LABELS.name);

--- a/src/views/topology/components/vm/VMDetailsPanel/TopologyVMDetailsPanel.tsx
+++ b/src/views/topology/components/vm/VMDetailsPanel/TopologyVMDetailsPanel.tsx
@@ -1,11 +1,10 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import useInstanceTypeExpandSpec from '@kubevirt-utils/resources/vm/hooks/useInstanceTypeExpandSpec';
 import { Grid, GridItem } from '@patternfly/react-core';
 import { observer } from '@patternfly/react-topology';
-import { VMNode } from '@topology/utils/types/types';
+import { type VMNode, type VMNodeData } from '@topology/utils/types/types';
 
 import VMDetailsPanelLeftColumn from './components/VMDetailsPanelLeftColumn/VMDetailsPanelLeftColumn';
 import VMDetailsPanelRightColumn from './components/VMDetailsPanelRightColumn/VMDetailsPanelRightColumn';
@@ -17,7 +16,7 @@ type TopologyVMDetailsPanelProps = {
 const TopologyVMDetailsPanel: FC<TopologyVMDetailsPanelProps> = observer(({ vmNode }) => {
   const vmData = vmNode.getData();
   const vm = vmData.resource as V1VirtualMachine;
-  const { vmi } = vmData?.data;
+  const vmi = (vmData.data as VMNodeData | undefined)?.vmi;
   const [instanceTypeExpandedSpec] = useInstanceTypeExpandSpec(vm);
   return (
     <div className="overview__sidebar-pane-body resource-overview__body">

--- a/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelLeftColumn/components/VMDescriptionDetailsItem.tsx
+++ b/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelLeftColumn/components/VMDescriptionDetailsItem.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import { DescriptionModal } from '@kubevirt-utils/components/DescriptionModal/DescriptionModal';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
@@ -25,7 +24,7 @@ const VMDescriptionDetailsItem: FC<VMDescriptionDetailsItemProps> = ({ vm }) => 
   return (
     <DescriptionItem
       descriptionData={
-        getAnnotation(vm, DESCRIPTION_ANNOTATION) || <MutedTextSpan text={t('None')} />
+        getAnnotation(vm, DESCRIPTION_ANNOTATION) ?? <MutedTextSpan text={t('None')} />
       }
       onEditClick={() =>
         createModal(({ isOpen, onClose }) => (

--- a/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelLeftColumn/components/VMTemplateDetailsItem/VMTemplateDetailsItem.tsx
+++ b/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelLeftColumn/components/VMTemplateDetailsItem/VMTemplateDetailsItem.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { TemplateModel, V1Template } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { TemplateModel, type V1Template } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -14,7 +13,6 @@ import {
 import {
   getGroupVersionKindForModel,
   useK8sWatchResource,
-  WatchK8sResource,
 } from '@openshift-console/dynamic-plugin-sdk';
 
 import VMTemplateLink from './VMTemplateLink';
@@ -31,17 +29,22 @@ const VMTemplateDetailsItem: FC<VMDetailsItemTemplateProps> = ({ vm }) => {
   const templateName = getLabel(vm, LABEL_USED_TEMPLATE_NAME);
   const templateNamespace = getLabel(vm, LABEL_USED_TEMPLATE_NAMESPACE);
 
-  const templatesResource: WatchK8sResource = {
-    groupVersionKind: getGroupVersionKindForModel(TemplateModel),
-    isList: false,
-    name: templateName,
-    namespace: templateNamespace,
-  };
-  const [template, loadedTemplates, errorTemplates] =
-    useK8sWatchResource<V1Template>(templatesResource);
+  const [template, loadedTemplates, errorTemplates] = useK8sWatchResource<V1Template>(
+    templateName && templateNamespace
+      ? {
+          groupVersionKind: getGroupVersionKindForModel(TemplateModel),
+          isList: false,
+          name: templateName,
+          namespace: templateNamespace,
+        }
+      : null,
+  ) as [V1Template | undefined, boolean, Error | undefined];
 
   const notAvailable =
-    !templateName || !templateNamespace || (loadedTemplates && !template) || errorTemplates;
+    !templateName ||
+    !templateNamespace ||
+    (loadedTemplates && !template) ||
+    Boolean(errorTemplates);
 
   return (
     <DescriptionItem

--- a/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/components/HardwareDevices/VMGPUDevicesDetailsItem.tsx
+++ b/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/components/HardwareDevices/VMGPUDevicesDetailsItem.tsx
@@ -1,7 +1,9 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import HardwareDevicesModal from '@kubevirt-utils/components/HardwareDevices/modal/HardwareDevicesModal';
 import { HARDWARE_DEVICE_TYPE } from '@kubevirt-utils/components/HardwareDevices/utils/constants';
@@ -23,7 +25,7 @@ const VMGPUDevicesDetailsItem: FC<VMGPUDevicesDetailsItemProps> = ({ vm, vmi }) 
   const gpus = getGPUDevices(vm);
   const gpusCount = getGPUDevices(vm)?.length || [].length;
 
-  const onEditGPU = () => {
+  const onEditGPU = (): void => {
     createModal(({ isOpen, onClose }) => (
       <HardwareDevicesModal
         btnText={t('Add GPU device')}

--- a/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/components/HardwareDevices/VMHostDevicesDetailsItem.tsx
+++ b/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/components/HardwareDevices/VMHostDevicesDetailsItem.tsx
@@ -1,7 +1,9 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import HardwareDevicesModal from '@kubevirt-utils/components/HardwareDevices/modal/HardwareDevicesModal';
 import { HARDWARE_DEVICE_TYPE } from '@kubevirt-utils/components/HardwareDevices/utils/constants';
@@ -24,7 +26,7 @@ const VMHostDevicesDetailsItem: FC<VMHostDevicesDetailsItemProps> = ({ vm, vmi }
   const hostDevices = getHostDevices(vm);
   const hostDevicesCount = getHostDevices(vm)?.length || [].length;
 
-  const onEditHostDevices = () => {
+  const onEditHostDevices = (): void => {
     createModal(({ isOpen, onClose }) => (
       <HardwareDevicesModal
         onSubmit={(updatedVM) =>

--- a/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/components/VMTimezoneDetailsItem.tsx
+++ b/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/components/VMTimezoneDetailsItem.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
@@ -20,7 +19,7 @@ const VMTimezoneDetailsItem: FC<VMTimezoneDetailsItemProps> = ({ vmi }) => {
   return (
     <DescriptionItem
       className="topology-vm-details-panel__item"
-      descriptionData={guestAgentData?.timezone?.split(',')[0] || NO_DATA_DASH}
+      descriptionData={guestAgentData?.timezone?.split(',')[0] ?? NO_DATA_DASH}
       descriptionHeader={t('Time zone')}
     />
   );

--- a/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/components/VMWorkloadProfileDetailsItem.tsx
+++ b/src/views/topology/components/vm/VMDetailsPanel/components/VMDetailsPanelRightColumn/components/VMWorkloadProfileDetailsItem.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
@@ -31,7 +30,7 @@ const VMWorkloadProfileDetailsItem: FC<VMWorkloadProfileDetailsItemProps> = ({ v
       <DescriptionItem
         descriptionData={
           vmWorkload ? (
-            (() => {
+            ((): string => {
               const workloadKey = WORKLOADS_LABELS[vmWorkload];
               return workloadKey ? t(workloadKey) : vmWorkload;
             })()

--- a/src/views/topology/hooks/usePodsForVM.ts
+++ b/src/views/topology/hooks/usePodsForVM.ts
@@ -1,24 +1,38 @@
-/* eslint-disable */
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { PodModel, ReplicationControllerModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineInstanceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1Pod } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type IoK8sApiCoreV1Pod } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import {
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import useDeepCompareMemoize from '@kubevirt-utils/hooks/useDeepCompareMemoize/useDeepCompareMemoize';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getVMIPod } from '@kubevirt-utils/resources/vmi';
 import {
-  ExtPodKind,
+  type ExtPodKind,
   getGroupVersionKindForModel,
-  K8sResourceCommon,
-  K8sResourceKind,
-  PodRCData,
+  type K8sResourceCommon,
+  type K8sResourceKind,
+  type PodRCData,
   useK8sWatchResources,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useDebounceCallback } from '@overview/utils/hooks/useDebounceCallback';
 
 import { getReplicationControllersForResource } from '../utils/resource-utils';
+
+type WatchedResourceResult<T extends K8sResourceCommon = K8sResourceCommon> = {
+  data: T[];
+  loadError?: string;
+  loaded: boolean;
+};
+
+type UsePodsForVMWatchedResources = {
+  pods: WatchedResourceResult;
+  replicationControllers: WatchedResourceResult;
+  virtualmachineinstances: WatchedResourceResult<V1VirtualMachineInstance>;
+};
 
 type UsePodsForVM = (vm: V1VirtualMachine) => {
   loaded: boolean;
@@ -60,7 +74,7 @@ const usePodsForVM: UsePodsForVM = (vm) => {
   const resources = useK8sWatchResources<{ [key: string]: K8sResourceCommon[] }>(watchedResources);
 
   const updateResults = useCallback(
-    (updatedResources) => {
+    (updatedResources: UsePodsForVMWatchedResources): void => {
       const errorKey = Object.keys(updatedResources).find((key) => updatedResources[key].loadError);
       if (errorKey) {
         setLoadError(updatedResources[errorKey].loadError);
@@ -70,19 +84,17 @@ const usePodsForVM: UsePodsForVM = (vm) => {
         Object.keys(updatedResources).length > 0 &&
         Object.keys(updatedResources).every((key) => updatedResources[key].loaded)
       ) {
-        const vmis = updatedResources.virtualmachineinstances.data;
-        const vmi = vmis.find(
-          (instance) => instance.metadata.name === vmName,
-        ) as V1VirtualMachineInstance;
+        const vmis = updatedResources.virtualmachineinstances?.data ?? [];
+        const vmi = vmis.find((instance) => instance.metadata?.name === vmName);
         const { visibleReplicationControllers } = getReplicationControllersForResource(
           vmRef.current,
           updatedResources,
         );
         const [current, previous] = visibleReplicationControllers;
-        const launcherPod = getVMIPod(
-          vmi,
-          updatedResources.pods.data as IoK8sApiCoreV1Pod[],
-        ) as ExtPodKind;
+        const podsData = updatedResources.pods?.data ?? [];
+        const launcherPod = vmi
+          ? (getVMIPod(vmi, podsData as IoK8sApiCoreV1Pod[]) as ExtPodKind)
+          : undefined;
         const podRCData: PodRCData = {
           current,
           isRollingOut: false,
@@ -96,7 +108,7 @@ const usePodsForVM: UsePodsForVM = (vm) => {
       }
     },
     // Don't update on a resource change, we want the debounce callback to be consistent
-     
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- vm is read from the current render when the debounced callback runs
     [vmName],
   );
 

--- a/src/views/topology/utils/kubevirt-component-factory.ts
+++ b/src/views/topology/utils/kubevirt-component-factory.ts
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import { ComponentType } from 'react';
+import { type ComponentType } from 'react';
 
 import {
   contextMenuActions,
@@ -9,8 +8,8 @@ import {
   withEditReviewAccess,
 } from '@openshift-console/dynamic-plugin-sdk-internal';
 import {
-  GraphElement,
-  NodeComponentProps,
+  type GraphElement,
+  type NodeComponentProps,
   nodeDragSourceSpec,
   nodeDropTargetSpec,
   withDndDrop,
@@ -20,7 +19,6 @@ import {
 
 import CreateConnector from '../components/CreateConnector';
 import VMNode from '../components/nodes/VMNode/VMNode';
-
 import { VIRTUAL_MACHINE_TYPE } from './constants';
 
 export const getKubevirtComponentFactory = (
@@ -33,8 +31,8 @@ export const getKubevirtComponentFactory = (
         CreateConnector,
       )(
         withDndDrop<
-          any,
-          any,
+          unknown,
+          unknown,
           { canDrop?: boolean; droppable?: boolean; hover?: boolean },
           NodeComponentProps
         >(nodeDropTargetSpec())(

--- a/src/views/topology/utils/selectors/selectors.ts
+++ b/src/views/topology/utils/selectors/selectors.ts
@@ -1,11 +1,10 @@
-/* eslint-disable */
-import { IoK8sApiCoreV1Pod } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type IoK8sApiCoreV1Pod } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getStatusPhase } from '@kubevirt-utils/resources/shared';
 
 import { VMIPhase } from '../constants';
 
 export const getNodeName = (pod: IoK8sApiCoreV1Pod): string => pod?.spec?.nodeName;
 
-export const isVMIReady = (vmi: V1VirtualMachineInstance) =>
+export const isVMIReady = (vmi: V1VirtualMachineInstance): boolean =>
   getStatusPhase(vmi) === VMIPhase.Running;

--- a/src/views/topology/utils/topology-utils.ts
+++ b/src/views/topology/utils/topology-utils.ts
@@ -1,15 +1,14 @@
-/* eslint-disable */
-import { K8sResourceKind } from '@openshift-console/dynamic-plugin-sdk';
-import { TopologyDataObject } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/topology-types';
-import { GraphElement } from '@patternfly/react-topology';
+import { type K8sResourceKind } from '@openshift-console/dynamic-plugin-sdk';
+import { type TopologyDataObject } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/topology-types';
+import { type GraphElement } from '@patternfly/react-topology';
 
-import OdcBaseNode from '../components/ODCBaseNode';
+import type OdcBaseNode from '../components/ODCBaseNode';
 
 export const getTopologyResourceObject = (topologyObject: TopologyDataObject): K8sResourceKind => {
   if (!topologyObject) {
     return null;
   }
-  return topologyObject.resource || topologyObject.resources?.obj;
+  return topologyObject.resource ?? topologyObject.resources?.obj;
 };
 
 export const getResource = <T = K8sResourceKind>(node: GraphElement): T => {

--- a/src/views/topology/utils/utils.ts
+++ b/src/views/topology/utils/utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { NODE_HEIGHT, NODE_PADDING, NODE_WIDTH, VIRTUAL_MACHINE_TYPE } from './constants';
 
 export const WorkloadModelProps = {
@@ -11,4 +10,4 @@ export const WorkloadModelProps = {
   width: NODE_WIDTH,
 };
 
-export const isVMType = (type: string) => type === VIRTUAL_MACHINE_TYPE;
+export const isVMType = (type: string): boolean => type === VIRTUAL_MACHINE_TYPE;

--- a/src/views/virtualmachines/actions/components/DeleteAllConfirmationModal/DeleteAllVMsConfirmationModal.tsx
+++ b/src/views/virtualmachines/actions/components/DeleteAllConfirmationModal/DeleteAllVMsConfirmationModal.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import React, { FC, useState } from 'react';
+import React, { type FC, useState } from 'react';
 import { Trans } from 'react-i18next';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { TELEMETRY_VM_ACTION } from '@kubevirt-utils/extensions/telemetry';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName } from '@kubevirt-utils/resources/shared';
@@ -51,14 +50,15 @@ const DeleteAllVMsConfirmationModal: FC<DeleteAllVMsConfirmationModalProps> = ({
   const numVMs = vms.length;
   const isConfirmed = confirmationValue === numVMs.toString();
 
-  const actionOnVms = () => runActionOnVMs(vms, deleteVM, TELEMETRY_VM_ACTION.DELETE);
+  const actionOnVms = (): Promise<void> =>
+    runActionOnVMs(vms, deleteVM, TELEMETRY_VM_ACTION.DELETE);
 
-  const handleSearchVirtualMachines = (value: string) => {
+  const handleSearchVirtualMachines = (value: string): void => {
     setSearchVirtualMachines(value);
     setShowAll(false);
   };
 
-  const handleClose = () => {
+  const handleClose = (): void => {
     setShowAll(false);
     setConfirmationValue('');
     setSearchVirtualMachines('');
@@ -66,7 +66,7 @@ const DeleteAllVMsConfirmationModal: FC<DeleteAllVMsConfirmationModalProps> = ({
     onClose();
   };
 
-  const submitHandler = async () => {
+  const submitHandler = async (): Promise<void> => {
     if (isSubmitting || !isConfirmed) return;
     setIsSubmitting(true);
     setError(undefined);

--- a/src/views/virtualmachines/actions/components/DeleteVMModal/DeleteVMModal.tsx
+++ b/src/views/virtualmachines/actions/components/DeleteVMModal/DeleteVMModal.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import React, { FC, useMemo, useState } from 'react';
+import React, { type FC, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ConfirmActionMessage from '@kubevirt-utils/components/ConfirmActionMessage/ConfirmActionMessage';
 import { GracePeriodInput } from '@kubevirt-utils/components/GracePeriodInput/GracePeriodInput';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
@@ -18,10 +17,10 @@ import { useHubClusterName } from '@stolostron/multicluster-sdk';
 import { deselectVM, isVMSelected } from '@virtualmachines/list/selectedVMs';
 
 import DeleteOwnedResourcesMessage from './components/DeleteOwnedResourcesMessage';
+import { DEFAULT_GRACE_PERIOD } from './constants';
 import useDeleteVMResources from './hooks/useDeleteVMResources';
 import useResourceSelection from './hooks/useResourceSelection';
 import { deleteVMWithResources } from './utils/deleteVM';
-import { DEFAULT_GRACE_PERIOD } from './constants';
 
 type DeleteVMModalProps = {
   isOpen: boolean;
@@ -44,7 +43,7 @@ const DeleteVMModal: FC<DeleteVMModalProps> = ({ isOpen, onClose, vm }) => {
   const shareableVolumes = useMemo(() => getShareableVolumes(vm), [vm]);
   const { shouldSaveResource, toggleResource } = useResourceSelection(shareableVolumes);
 
-  const onDelete = async (updatedVM: V1VirtualMachine) => {
+  const onDelete = async (updatedVM: V1VirtualMachine): Promise<void> => {
     await deleteVMWithResources({
       gracePeriodOptions: gracePeriodCheckbox
         ? { apiVersion: 'v1', gracePeriodSeconds, kind: 'DeleteOptions' }

--- a/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useResourceSelection.ts
+++ b/src/views/virtualmachines/actions/components/DeleteVMModal/hooks/useResourceSelection.ts
@@ -1,12 +1,16 @@
-/* eslint-disable */
 import { useCallback, useState } from 'react';
 
-import { V1Volume } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { type V1Volume } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 import { getResourceKey, isResourceSavedByDefault } from '../utils/helpers';
 
-const useResourceSelection = (sharableVolumes: V1Volume[]) => {
+type UseResourceSelectionReturn = {
+  shouldSaveResource: (resource: K8sResourceCommon) => boolean;
+  toggleResource: (resource: K8sResourceCommon) => void;
+};
+
+const useResourceSelection = (sharableVolumes: V1Volume[]): UseResourceSelectionReturn => {
   const [userOverrides, setUserOverrides] = useState<Record<string, boolean>>({});
 
   const shouldSaveResource = useCallback(

--- a/src/views/virtualmachines/actions/components/DeleteVMModal/utils/helpers.ts
+++ b/src/views/virtualmachines/actions/components/DeleteVMModal/utils/helpers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import {
   modelToGroupVersionKind,
   PersistentVolumeClaimModel,
@@ -6,24 +5,32 @@ import {
 import { DataVolumeModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineSnapshotModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
-import { IoK8sApiCoreV1Secret } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type IoK8sApiCoreV1Secret } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import {
-  V1beta1VirtualMachineSnapshot,
-  V1VirtualMachine,
-  V1Volume,
+  type V1beta1VirtualMachineSnapshot,
+  type V1VirtualMachine,
+  type V1Volume,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { deleteSecret } from '@kubevirt-utils/resources/secret/utils';
 import { compareOwnerReferences, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getDataVolumeTemplates } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { k8sPatch, K8sResourceCommon, OwnerReference } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  type K8sGroupVersionKind,
+  k8sPatch,
+  type K8sResourceCommon,
+  type OwnerReference,
+} from '@openshift-console/dynamic-plugin-sdk';
 
-export const getResourceKey = (resource: K8sResourceCommon) =>
+export const getResourceKey = (resource: K8sResourceCommon): string =>
   `${resource.kind}/${getNamespace(resource)}/${getName(resource)}`;
 
-export const isResourceShared = (sharableVolumes: V1Volume[], resource: K8sResourceCommon) =>
+export const isResourceShared = (
+  sharableVolumes: V1Volume[],
+  resource: K8sResourceCommon,
+): boolean =>
   sharableVolumes.some(
     (volume) =>
       volume?.dataVolume?.name === getName(resource) ||
@@ -41,7 +48,7 @@ export const isResourceSavedByDefault = (
 export const findPVCOwner = (
   pvc: IoK8sApiCoreV1PersistentVolumeClaim,
   resources: K8sResourceCommon[],
-) =>
+): K8sResourceCommon | undefined =>
   resources.find((resource) =>
     pvc?.metadata?.ownerReferences?.find((owner) => owner.uid === resource.metadata.uid),
   );
@@ -49,8 +56,8 @@ export const findPVCOwner = (
 export const updateVolumeResources = (
   resources: (IoK8sApiCoreV1PersistentVolumeClaim | V1beta1DataVolume)[],
   vmOwnerRef: OwnerReference,
-) =>
-  (resources || []).map((resource) =>
+): Promise<K8sResourceCommon>[] =>
+  (resources ?? []).map((resource) =>
     k8sPatch({
       data: [
         {
@@ -72,8 +79,8 @@ export const updateVolumeResources = (
 export const updateSnapshotResources = (
   resources: V1beta1VirtualMachineSnapshot[],
   vmOwnerRef: OwnerReference,
-) =>
-  (resources || []).map((resource) =>
+): Promise<K8sResourceCommon>[] =>
+  (resources ?? []).map((resource) =>
     k8sPatch({
       data: [
         {
@@ -89,13 +96,13 @@ export const updateSnapshotResources = (
     }),
   );
 
-export const deleteSecrets = (secrets: IoK8sApiCoreV1Secret[]) =>
-  (secrets || []).map((secret) => deleteSecret(secret));
+export const deleteSecrets = (secrets: IoK8sApiCoreV1Secret[]): Promise<K8sResourceCommon>[] =>
+  (secrets ?? []).map((secret) => deleteSecret(secret));
 
 export const detachDataVolumeTemplates = (
   vm: V1VirtualMachine,
   dataVolumesToSave: V1beta1DataVolume[],
-) => {
+): Promise<K8sResourceCommon> | undefined => {
   const dataVolumeTemplates = getDataVolumeTemplates(vm);
 
   const indexes = dataVolumesToSave
@@ -121,5 +128,5 @@ const MODEL_BY_KIND: Record<string, typeof DataVolumeModel> = {
   [VirtualMachineSnapshotModel.kind]: VirtualMachineSnapshotModel,
 };
 
-export const getResourceGroupVersionKind = (resource: K8sResourceCommon) =>
-  modelToGroupVersionKind(MODEL_BY_KIND[resource.kind] || DataVolumeModel);
+export const getResourceGroupVersionKind = (resource: K8sResourceCommon): K8sGroupVersionKind =>
+  modelToGroupVersionKind(MODEL_BY_KIND[resource.kind] ?? DataVolumeModel);

--- a/src/views/virtualmachines/actions/components/VMActionsIconBar/components/ActionIconButton.tsx
+++ b/src/views/virtualmachines/actions/components/VMActionsIconBar/components/ActionIconButton.tsx
@@ -1,23 +1,23 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import classNames from 'classnames';
 
 import { Button, ButtonVariant, SplitItem, Tooltip } from '@patternfly/react-core';
 import { useFleetAccessReview } from '@stolostron/multicluster-sdk';
-import { VMActionIconDetails } from '@virtualmachines/actions/components/VMActionsIconBar/utils/types';
+import { type VMActionIconDetails } from '@virtualmachines/actions/components/VMActionsIconBar/utils/types';
 
 import '../VMActionsIconBar.scss';
 
 const ActionIconButton: FC<VMActionIconDetails> = ({
   action,
-  Icon,
+  icon: iconComponent,
   iconClassname,
   isDisabled,
   isHidden,
 }) => {
   const [actionAllowed] = useFleetAccessReview(action?.accessReview);
+  const IconElement = iconComponent;
 
-  const handleClick = () => {
+  const handleClick = (): void => {
     if (typeof action?.cta === 'function') {
       action?.cta();
     }
@@ -34,7 +34,7 @@ const ActionIconButton: FC<VMActionIconDetails> = ({
             onClick={handleClick}
             variant={ButtonVariant.link}
           >
-            <Icon className={classNames(iconClassname, 'vm-actions-icon-bar__icon')} />
+            <IconElement className={classNames(iconClassname, 'vm-actions-icon-bar__icon')} />
           </Button>
         </Tooltip>
       </SplitItem>

--- a/src/views/virtualmachines/actions/components/VMActionsIconBar/utils/types.ts
+++ b/src/views/virtualmachines/actions/components/VMActionsIconBar/utils/types.ts
@@ -1,12 +1,11 @@
-/* eslint-disable */
-import { ComponentClass } from 'react';
+import { type ComponentClass } from 'react';
 
-import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
-import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
+import { type ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
+import { type SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
 
 export type VMActionIconDetails = {
   action: ActionDropdownItemType;
-  Icon: ComponentClass<SVGIconProps, any>;
+  icon: ComponentClass<SVGIconProps, unknown>;
   iconClassname?: string;
   isDisabled?: boolean;
   isHidden?: boolean;

--- a/src/views/virtualmachines/actions/components/VMActionsIconBar/utils/utils.ts
+++ b/src/views/virtualmachines/actions/components/VMActionsIconBar/utils/utils.ts
@@ -25,29 +25,29 @@ export const getVMActionIconsDetails = (
   return [
     {
       action: stopAction,
-      Icon: SquareIcon,
+      icon: SquareIcon,
       isDisabled: stopAction?.disabled,
     },
     {
       action: restartAction,
-      Icon: RedoIcon,
+      icon: RedoIcon,
       isDisabled: restartAction?.disabled,
     },
     {
       action: pauseAction,
-      Icon: PauseIcon,
+      icon: PauseIcon,
       isDisabled: pauseAction?.disabled,
       isHidden: isPaused(vm),
     },
     {
       action: VirtualMachineActionFactory.unpause(vm),
-      Icon: EjectIcon,
+      icon: EjectIcon,
       iconClassname: 'vm-actions-icon-bar__icon--unpause',
       isHidden: !isPaused(vm),
     },
     {
       action: startAction,
-      Icon: PlayIcon,
+      icon: PlayIcon,
       isDisabled: startAction?.disabled,
     },
   ];

--- a/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/ComputeMigrationModal.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/ComputeMigrationModal.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC, useState } from 'react';
+import React, { type FC, useState } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { TELEMETRY_VM_ACTION } from '@kubevirt-utils/extensions/telemetry/utils/property-constants';
 import { logVMActionPerformed } from '@kubevirt-utils/extensions/telemetry/vm-actions';
@@ -30,7 +29,7 @@ const ComputeMigrationModal: FC<ComputeMigrationModalProps> = ({ isOpen, onClose
 
   const [selectedNode, setSelectedNode] = useState<string>('');
 
-  const handleNodeSelection = (changedNode: string) => {
+  const handleNodeSelection = (changedNode: string): void => {
     setSelectedNode(changedNode);
   };
 

--- a/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesData.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesData.ts
@@ -1,15 +1,15 @@
-/* eslint-disable */
-import { IoK8sApiCoreV1Node } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type IoK8sApiCoreV1Node } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import useWorkerNodes from '@kubevirt-utils/resources/node/hooks/useWorkerNodes';
 import { getNodeArchitecture } from '@kubevirt-utils/resources/node/utils/selectors';
-import { isNodeSchedulable, nodeStatus } from '@kubevirt-utils/resources/node/utils/utils';
+import { NodeStatus } from '@kubevirt-utils/resources/node/utils/types';
+import { isNodeReady, isNodeSchedulable } from '@kubevirt-utils/resources/node/utils/utils';
 import { getName } from '@kubevirt-utils/resources/shared';
 import useNode from '@kubevirt-utils/resources/vm/hooks/useNode';
 import { getArchitecture } from '@kubevirt-utils/resources/vm/utils/selectors';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useNodesMetrics from '@virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesMetrics/useNodesMetrics';
-import { NodeData } from '@virtualmachines/actions/components/VirtualMachineComputeMigration/utils/types';
+import { type NodeData } from '@virtualmachines/actions/components/VirtualMachineComputeMigration/utils/types';
 
 type UseNodesData = (vm: V1VirtualMachine) => {
   nodes: IoK8sApiCoreV1Node[];
@@ -32,24 +32,42 @@ const useNodesData: UseNodesData = (vm) => {
     return getNodeArchitecture(node) === vmArch;
   });
 
-  const nodesData = (filteredNodes || [])?.reduce((acc, node) => {
+  const nodesData = (filteredNodes ?? []).reduce<NodeData[]>((acc, node) => {
     const nodeName = getName(node);
-    const nodeMetrics = metricsData?.[nodeName];
-    const { totalCPU, totalMemory, usedCPU, usedMemory } = nodeMetrics || {};
+    const nodeMetrics = nodeName ? metricsData[nodeName] : undefined;
+    const totalCPU = nodeMetrics?.totalCPU;
+    const totalMemory = nodeMetrics?.totalMemory;
+    const usedCPU = nodeMetrics?.usedCPU;
+    const usedMemory = nodeMetrics?.usedMemory;
 
-    acc.push({
-      cpuUtilization: usedCPU && totalCPU ? usedCPU / totalCPU : 0,
-      memoryUtilization: usedMemory && totalMemory ? usedMemory / totalMemory : 0,
+    const nodeData: NodeData = {
       metadata: {
         name: getName(node),
       },
       name: nodeName,
-      status: nodeStatus(node),
-      totalCPU,
-      totalMemory,
-      usedCPU,
-      usedMemory,
-    });
+      status: isNodeReady(node) ? NodeStatus.READY : NodeStatus.NOT_READY,
+    };
+
+    if (usedCPU && totalCPU) {
+      nodeData.cpuUtilization = String(usedCPU / totalCPU);
+    }
+    if (usedMemory && totalMemory) {
+      nodeData.memoryUtilization = String(usedMemory / totalMemory);
+    }
+    if (totalCPU != null) {
+      nodeData.totalCPU = totalCPU;
+    }
+    if (totalMemory != null) {
+      nodeData.totalMemory = totalMemory;
+    }
+    if (usedCPU != null) {
+      nodeData.usedCPU = String(usedCPU);
+    }
+    if (usedMemory != null) {
+      nodeData.usedMemory = usedMemory;
+    }
+
+    acc.push(nodeData);
     return acc;
   }, []);
 

--- a/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesMetrics/useNodesMetrics.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesMetrics/useNodesMetrics.ts
@@ -1,7 +1,6 @@
-/* eslint-disable */
 import { PrometheusEndpoint } from '@openshift-console/dynamic-plugin-sdk';
 import { useFleetPrometheusPoll } from '@stolostron/multicluster-sdk';
-import { MetricsDataByNode } from '@virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesMetrics/utils/types';
+import { type MetricsDataByNode } from '@virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesMetrics/utils/types';
 import { getDataByNode } from '@virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesMetrics/utils/utils';
 
 type UseNodesMetrics = (cluster?: string) => {
@@ -41,11 +40,11 @@ const useNodesMetrics: UseNodesMetrics = (cluster) => {
 
   const metricsLoaded = usedMemoryLoaded && totalMemoryLoaded && usedCPULoaded && totalCPULoaded;
 
-  const metricsData = getDataByNode({
-    totalCPU: totalCPUData || [],
-    totalMemory: totalMemoryData || [],
-    usedCPU: usedCPUData || [],
-    usedMemory: usedMemoryData || [],
+  const metricsData: MetricsDataByNode = getDataByNode({
+    totalCPU: totalCPUData ?? [],
+    totalMemory: totalMemoryData ?? [],
+    usedCPU: usedCPUData ?? [],
+    usedMemory: usedMemoryData ?? [],
   });
 
   return { metricsData, metricsLoaded };

--- a/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesMetrics/utils/types.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesMetrics/utils/types.ts
@@ -1,8 +1,8 @@
 export type NodeMetricsData = {
-  totalCPU: number;
-  totalMemory: number;
-  usedCPU: number;
-  usedMemory: number;
+  totalCPU?: number;
+  totalMemory?: number;
+  usedCPU?: number;
+  usedMemory?: number;
 };
 
 export type MetricsDataByNode = { [nodeName: string]: NodeMetricsData };

--- a/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesMetrics/utils/utils.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineComputeMigration/utils/hooks/useNodesMetrics/utils/utils.ts
@@ -1,21 +1,34 @@
 import { type PrometheusResult } from '@openshift-console/dynamic-plugin-sdk';
 
-import { type MetricsDataByNode } from './types';
+import { type MetricsDataByNode, type NodeMetricsData } from './types';
 
-const getValuesByNode = (data: PrometheusResult[]): Record<string, string | undefined> => {
-  return data?.reduce<Record<string, string | undefined>>((acc, dataItem) => {
+const isNodeMetricKey = (key: string): key is keyof NodeMetricsData =>
+  key === 'totalCPU' || key === 'totalMemory' || key === 'usedCPU' || key === 'usedMemory';
+
+const parseMetricValue = (value?: string): number | undefined => {
+  if (value == null) return undefined;
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+const getValuesByNode = (data: PrometheusResult[]): Record<string, number | undefined> => {
+  return data?.reduce<Record<string, number | undefined>>((acc, dataItem) => {
     const instance = dataItem?.metric?.instance;
-    if (instance) acc[instance] = dataItem?.value?.[1];
+    if (instance) acc[instance] = parseMetricValue(dataItem?.value?.[1]);
     return acc;
   }, {});
 };
 
 export const getDataByNode = (allData: { [key: string]: PrometheusResult[] }): MetricsDataByNode =>
-  Object.entries(allData)?.reduce<MetricsDataByNode>((acc, [metricName, dataItem]) => {
+  Object.entries(allData).reduce<MetricsDataByNode>((acc, [metricName, dataItem]) => {
+    if (!isNodeMetricKey(metricName)) {
+      return acc;
+    }
+
     const valuesByNode = getValuesByNode(dataItem);
     for (const [nodeName, value] of Object.entries(valuesByNode)) {
-      acc[nodeName] = acc?.[nodeName] ?? ({} as MetricsDataByNode[string]);
-      acc[nodeName] = { ...acc[nodeName], [metricName]: value };
+      const existingMetrics = acc[nodeName] ?? {};
+      acc[nodeName] = { ...existingMetrics, [metricName]: value };
     }
     return acc;
-  }, {} as MetricsDataByNode);
+  }, {});

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/backends/mtc/useMTCPlanPolling.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/backends/mtc/useMTCPlanPolling.ts
@@ -1,12 +1,11 @@
-/* eslint-disable */
 import { useCallback, useEffect, useState } from 'react';
 
 import { MigMigrationModel, MigPlanModel } from '@kubevirt-utils/models';
 import {
-  MigMigration,
-  MigPlan,
+  type MigMigration,
+  type MigPlan,
   MTC_MIGRATION_NAMESPACE,
-  MultiNamespaceVirtualMachineStorageMigrationPlan,
+  type MultiNamespaceVirtualMachineStorageMigrationPlan,
   STORAGE_MIGRATION_PHASE,
 } from '@kubevirt-utils/resources/migrations/constants';
 import {
@@ -32,7 +31,7 @@ const useMTCPlanPolling = (
   plan: MultiNamespaceVirtualMachineStorageMigrationPlan | null,
 ): [MultiNamespaceVirtualMachineStorageMigrationPlan | null, boolean, Error | undefined] => {
   const [data, setData] = useState<MultiNamespaceVirtualMachineStorageMigrationPlan | null>(() =>
-    plan ? mergeMTCMigMigrationStatusIntoPlan(plan, undefined, undefined) : null,
+    plan ? mergeMTCMigMigrationStatusIntoPlan(plan, undefined) : null,
   );
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<Error | undefined>();
@@ -85,13 +84,13 @@ const useMTCPlanPolling = (
   useEffect(() => {
     if (!plan) return;
 
-    setData(mergeMTCMigMigrationStatusIntoPlan(plan, undefined, undefined));
+    setData(mergeMTCMigMigrationStatusIntoPlan(plan, undefined));
 
     let stopped = false;
     let timerId: ReturnType<typeof setTimeout>;
     let nextDelayMs = MIGRATION_PLAN_POLL_INTERVAL_MS;
 
-    const poll = async () => {
+    const poll = async (): Promise<void> => {
       const result = await fetchProgress(stopped);
       if (stopped) return;
 
@@ -114,9 +113,9 @@ const useMTCPlanPolling = (
       timerId = setTimeout(poll, nextDelayMs);
     };
 
-    poll();
+    void poll();
 
-    return () => {
+    return (): void => {
       stopped = true;
       clearTimeout(timerId);
     };

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/backends/singleNs/useSingleNsPlanPolling.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/backends/singleNs/useSingleNsPlanPolling.ts
@@ -1,11 +1,10 @@
-/* eslint-disable */
 import { useCallback, useEffect, useState } from 'react';
 
 import { VirtualMachineStorageMigrationPlanModel } from '@kubevirt-utils/models';
 import {
-  MultiNamespaceVirtualMachineStorageMigrationPlan,
+  type MultiNamespaceVirtualMachineStorageMigrationPlan,
   STORAGE_MIGRATION_PHASE,
-  VirtualMachineStorageMigrationPlan,
+  type VirtualMachineStorageMigrationPlan,
 } from '@kubevirt-utils/resources/migrations/constants';
 import { normalizeSingleNsPlan } from '@kubevirt-utils/resources/migrations/singleNs/overview';
 import { isMigrationCompleted } from '@kubevirt-utils/resources/migrations/utils';
@@ -74,7 +73,7 @@ const useSingleNsPlanPolling = (
     let timerId: ReturnType<typeof setTimeout>;
     let nextDelayMs = MIGRATION_PLAN_POLL_INTERVAL_MS;
 
-    const poll = async () => {
+    const poll = async (): Promise<void> => {
       const result = await fetchPlan(stopped);
       if (stopped) return;
 
@@ -97,9 +96,9 @@ const useSingleNsPlanPolling = (
       timerId = setTimeout(poll, nextDelayMs);
     };
 
-    poll();
+    void poll();
 
-    return () => {
+    return (): void => {
       stopped = true;
       clearTimeout(timerId);
     };

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/components/MigrationProgressDisplay.tsx
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/components/MigrationProgressDisplay.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { ComponentType, FC } from 'react';
+import React, { type ComponentType, type FC } from 'react';
 import { Link } from 'react-router';
 
 import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
@@ -14,7 +13,7 @@ import {
   EmptyStateActions,
   EmptyStateBody,
   EmptyStateFooter,
-  EmptyStateStatus,
+  type EmptyStateStatus,
   EmptyStateVariant,
   Spinner,
 } from '@patternfly/react-core';
@@ -43,7 +42,7 @@ const MigrationProgressDisplay: FC<MigrationProgressDisplayProps> = ({
   isExternal,
   migrationCompleted,
   migrationHeading,
-  migrationIcon: MigrationIcon,
+  migrationIcon,
   migrationStatus,
   onCancelMigration,
   onClose,
@@ -53,7 +52,7 @@ const MigrationProgressDisplay: FC<MigrationProgressDisplayProps> = ({
   return (
     <EmptyState
       headingLevel="h3"
-      icon={MigrationIcon}
+      icon={migrationIcon}
       status={migrationStatus}
       titleText={migrationHeading}
       variant={EmptyStateVariant.lg}

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/hooks/useMigrationState.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/hooks/useMigrationState.ts
@@ -1,15 +1,14 @@
-/* eslint-disable */
 import { useCallback, useMemo, useState } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getStorageMigrationBackend } from '@kubevirt-utils/resources/migrations/backends';
 import {
+  type MultiNamespaceVirtualMachineStorageMigrationPlan,
   type StorageMigrationAPI,
-  MultiNamespaceVirtualMachineStorageMigrationPlan,
 } from '@kubevirt-utils/resources/migrations/constants';
 import { getCluster } from '@multicluster/helpers/selectors';
 
-import { SelectedMigration } from '../utils/constants';
+import { type SelectedMigration } from '../utils/constants';
 
 type UseMigrationState = (
   selectedMigrations: SelectedMigration[],
@@ -45,7 +44,7 @@ const useMigrationState: UseMigrationState = (
   const migrate = useMemo(
     () =>
       backend?.migrateVMs ??
-      (async () => {
+      (async (): Promise<never> => {
         throw new Error(t('Storage migration is not available on this cluster.'));
       }),
     [backend, t],

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/hooks/useStorageMigrationPlanCancel.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/hooks/useStorageMigrationPlanCancel.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useCallback, useState } from 'react';
 
 import { getCluster } from '@multicluster/helpers/selectors';
@@ -20,7 +19,10 @@ const useStorageMigrationPlanCancel = ({
   onClose,
   planModel,
   storageMigrationPlan,
-}: UseStorageMigrationPlanCancelArgs) => {
+}: UseStorageMigrationPlanCancelArgs): {
+  cancelError: Error | null;
+  onCancelMigration: () => Promise<void>;
+} => {
   const [cancelError, setCancelError] = useState<Error | null>(null);
 
   const onCancelMigration = useCallback(async () => {

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/hooks/useStorageMigrationProgressMetrics.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/hooks/useStorageMigrationProgressMetrics.ts
@@ -1,11 +1,24 @@
-/* eslint-disable */
-import { useMemo } from 'react';
+import { type ComponentType, useMemo } from 'react';
 import type { TFunction } from 'i18next';
 
-import type { MultiNamespaceVirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
+import type {
+  MigrationStatus,
+  MultiNamespaceVirtualMachineStorageMigrationPlan,
+} from '@kubevirt-utils/resources/migrations/constants';
 import { isMigrationCompleted } from '@kubevirt-utils/resources/migrations/utils';
+import { type EmptyStateStatus } from '@patternfly/react-core';
+import type { SVGIconProps } from '@patternfly/react-icons/dist/esm/createIcon';
 
 import { getFailedMigrations, getMigrationStateConfig } from '../utils/utils';
+
+export type StorageMigrationProgressMetrics = {
+  failedMigrations: MigrationStatus[];
+  hasFailed: boolean;
+  migrationCompleted: boolean;
+  migrationHeading: string;
+  migrationIcon: ComponentType<SVGIconProps>;
+  migrationStatus: EmptyStateStatus;
+};
 
 /**
  * Derives completion, failure list, and presentation config from a watched or polled plan.
@@ -13,7 +26,7 @@ import { getFailedMigrations, getMigrationStateConfig } from '../utils/utils';
 const useStorageMigrationProgressMetrics = (
   watchStorageMigrationPlan: MultiNamespaceVirtualMachineStorageMigrationPlan | null | undefined,
   t: TFunction,
-) =>
+): StorageMigrationProgressMetrics =>
   useMemo(() => {
     const migrationCompleted = isMigrationCompleted(watchStorageMigrationPlan);
     const failedMigrations = getFailedMigrations(watchStorageMigrationPlan);

--- a/src/views/virtualmachines/actions/components/VirtualMachineMigration/utils/diskData.ts
+++ b/src/views/virtualmachines/actions/components/VirtualMachineMigration/utils/diskData.ts
@@ -1,6 +1,5 @@
-/* eslint-disable */
-import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachine, V1Volume } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1VirtualMachine, type V1Volume } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getDisks, getVolumes } from '@kubevirt-utils/resources/vm';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
@@ -8,7 +7,7 @@ import { getPrintableDiskDrive } from '@kubevirt-utils/resources/vm/utils/disk/s
 import { convertToBaseValue, humanizeBinaryBytes } from '@kubevirt-utils/utils/humanize.js';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 
-import { SelectedMigration } from './constants';
+import { type SelectedMigration } from './constants';
 import { getVolumePVC } from './utils';
 
 export type MigrationDisksTableData = {
@@ -52,7 +51,7 @@ const getVMDiskdata = (
 export const getTableDiskData = (
   vms: V1VirtualMachine[],
   pvcs: IoK8sApiCoreV1PersistentVolumeClaim[],
-) => {
+): MigrationDisksTableData[] => {
   if (isEmpty(vms)) {
     return [];
   }

--- a/src/views/virtualmachines/actions/hooks/storageMigrationApi/useClusterStorageMigrationAPI.ts
+++ b/src/views/virtualmachines/actions/hooks/storageMigrationApi/useClusterStorageMigrationAPI.ts
@@ -1,5 +1,5 @@
-/* eslint-disable */
 import { useKubevirtClusterServiceVersion } from '@kubevirt-utils/hooks/useKubevirtClusterServiceVersion';
+import { type StorageMigrationAPI } from '@kubevirt-utils/resources/migrations/constants';
 import useIsACMPage from '@multicluster/useIsACMPage';
 
 import useClusterStorageMigrationApiProbe from './useClusterStorageMigrationApiProbe';
@@ -11,7 +11,7 @@ import useClusterStorageMigrationApiProbe from './useClusterStorageMigrationApiP
  * The overview widget calls `useClusterStorageMigrationApiProbe` with shared CSV context
  * to avoid duplicate Subscription/CSV watches next to OpenShift Virtualization.
  */
-const useClusterStorageMigrationAPI = (cluster?: string) => {
+const useClusterStorageMigrationAPI = (cluster?: string): StorageMigrationAPI => {
   const isACMPage = useIsACMPage();
   const csv = useKubevirtClusterServiceVersion(isACMPage ? cluster : undefined);
   return useClusterStorageMigrationApiProbe(cluster, csv);

--- a/src/views/virtualmachines/actions/hooks/storageMigrationApi/useClusterStorageMigrationApiProbe.ts
+++ b/src/views/virtualmachines/actions/hooks/storageMigrationApi/useClusterStorageMigrationApiProbe.ts
@@ -1,21 +1,20 @@
-/* eslint-disable */
 import { useEffect, useRef, useState } from 'react';
 
 import type { useKubevirtClusterServiceVersion } from '@kubevirt-utils/hooks/useKubevirtClusterServiceVersion';
 import {
-  type StorageMigrationAPI,
   STORAGE_MIGRATION_API,
+  type StorageMigrationAPI,
 } from '@kubevirt-utils/resources/migrations/constants';
 import useIsACMPage from '@multicluster/useIsACMPage';
 import { useHubClusterName } from '@stolostron/multicluster-sdk';
 
 import {
-  type StorageMigrationProbeFallbackPhase,
   csvLoadedIndicatesMultiNsStorageMigrationApi,
   csvVersionMeetsMultiNsAssumeThreshold,
   STORAGE_MIGRATION_CSV_WAIT_AFTER_MULTI_NS_404_MS,
   STORAGE_MIGRATION_PROBE_PHASE_IDLE,
   STORAGE_MIGRATION_PROBE_PHASE_WAITING_CSV_AFTER_MULTI_NS_404,
+  type StorageMigrationProbeFallbackPhase,
 } from './constants';
 import {
   onMultiNamespaceStorageMigration404,
@@ -45,7 +44,11 @@ const useClusterStorageMigrationApiProbe = (
   const phaseRef = useRef<StorageMigrationProbeFallbackPhase>(STORAGE_MIGRATION_PROBE_PHASE_IDLE);
   const resolvedRef = useRef<{ api: StorageMigrationAPI; cluster?: string } | null>(null);
 
-  const [, hubClusterLoaded, hubClusterError] = useHubClusterName();
+  const [, hubClusterLoaded, hubClusterError] = useHubClusterName() as [
+    string | undefined,
+    boolean,
+    Error | undefined,
+  ];
   const { installedCSV, loaded: csvLoaded } = csv;
   const csvVersion = installedCSV?.spec?.version;
 
@@ -89,14 +92,14 @@ const useClusterStorageMigrationApiProbe = (
     let canceled = false;
     let csvWaitTimer: ReturnType<typeof setTimeout> | undefined;
 
-    const clearCsvWaitTimer = () => {
+    const clearCsvWaitTimer = (): void => {
       if (csvWaitTimer !== undefined) {
         clearTimeout(csvWaitTimer);
         csvWaitTimer = undefined;
       }
     };
 
-    const finish = (api: StorageMigrationAPI) => {
+    const finish = (api: StorageMigrationAPI): void => {
       if (canceled) return;
       phaseRef.current = STORAGE_MIGRATION_PROBE_PHASE_IDLE;
       clearCsvWaitTimer();
@@ -104,7 +107,7 @@ const useClusterStorageMigrationApiProbe = (
       setResult(api);
     };
 
-    const canceledFn = () => canceled;
+    const canceledFn = (): boolean => canceled;
 
     if (
       phaseRef.current === STORAGE_MIGRATION_PROBE_PHASE_WAITING_CSV_AFTER_MULTI_NS_404 &&
@@ -117,7 +120,7 @@ const useClusterStorageMigrationApiProbe = (
       } else {
         probeMtcThenSingleNsOrNone(cluster, canceledFn, finish);
       }
-      return () => {
+      return (): void => {
         canceled = true;
         clearCsvWaitTimer();
       };
@@ -127,7 +130,7 @@ const useClusterStorageMigrationApiProbe = (
       phaseRef.current === STORAGE_MIGRATION_PROBE_PHASE_WAITING_CSV_AFTER_MULTI_NS_404 &&
       !csvLoaded
     ) {
-      return () => {
+      return (): void => {
         canceled = true;
         clearCsvWaitTimer();
       };
@@ -137,7 +140,7 @@ const useClusterStorageMigrationApiProbe = (
     // resolve immediately without a LIST probe when CSV is already loaded.
     if (csvLoadedIndicatesMultiNsStorageMigrationApi(csvLoaded, csvVersion)) {
       finish(STORAGE_MIGRATION_API.MULTI_NS);
-      return () => {
+      return (): void => {
         canceled = true;
       };
     }
@@ -159,7 +162,7 @@ const useClusterStorageMigrationApiProbe = (
       }),
     );
 
-    return () => {
+    return (): void => {
       canceled = true;
       clearCsvWaitTimer();
     };

--- a/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
+++ b/src/views/virtualmachines/actions/hooks/useVirtualMachineActionsProvider.ts
@@ -1,11 +1,10 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import {
-  V1VirtualMachine,
-  V1VirtualMachineInstanceMigration,
+  type V1VirtualMachine,
+  type V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
+import { type ActionDropdownItemType } from '@kubevirt-utils/components/ActionsDropdown/constants';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { getConsoleVirtctlCommand } from '@kubevirt-utils/components/SSHAccess/utils';
 import { CONFIRM_VM_ACTIONS, TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
@@ -20,9 +19,9 @@ import useACMExtensionActions from '@multicluster/hooks/useACMExtensionActions/u
 import useClusterParam from '@multicluster/hooks/useClusterParam';
 import { useK8sModel } from '@openshift-console/dynamic-plugin-sdk';
 
-import { printableVMStatus } from '../../utils';
 import { createVirtualMachineActionFactory } from '../VirtualMachineActionFactory';
 
+import { printableVMStatus } from '../../utils';
 import useClusterStorageMigrationAPI from './storageMigrationApi/useClusterStorageMigrationAPI';
 import useActiveVMStorageMigrationPlan from './useActiveVMStorageMigrationPlan';
 import useIsMTVInstalled from './useIsMTVInstalled';
@@ -30,7 +29,7 @@ import useIsMTVInstalled from './useIsMTVInstalled';
 type UseVirtualMachineActionsProvider = (
   vm: V1VirtualMachine,
   vmim?: V1VirtualMachineInstanceMigration,
-) => [ActionDropdownItemType[], boolean, any];
+) => [ActionDropdownItemType[], boolean];
 
 const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (vm, vmim) => {
   const { t } = useKubevirtTranslation();
@@ -78,15 +77,14 @@ const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (vm, 
     const isComputeMigration =
       !isStorageMigration && (printableStatus === Migrating || !!currentMigrationExist);
 
-    const startOrStop = ((printableStatusMachine) => {
-      const map = {
-        default: VirtualMachineActionFactory.stop(vm, createModal, confirmVMActionsEnabled),
-        Stopped: VirtualMachineActionFactory.start(vm),
-        Stopping: VirtualMachineActionFactory.forceStop(vm),
-        Terminating: VirtualMachineActionFactory.forceStop(vm),
-      };
-      return map[printableStatusMachine] || map.default;
-    })(printableStatus);
+    const startOrStopMap: Record<string, ActionDropdownItemType> = {
+      default: VirtualMachineActionFactory.stop(vm, createModal, confirmVMActionsEnabled),
+      Stopped: VirtualMachineActionFactory.start(vm),
+      Stopping: VirtualMachineActionFactory.forceStop(vm),
+      Terminating: VirtualMachineActionFactory.forceStop(vm),
+    };
+    const startOrStop: ActionDropdownItemType =
+      startOrStopMap[printableStatus ?? 'default'] ?? startOrStopMap.default;
 
     const migrateCompute = VirtualMachineActionFactory.migrateCompute(vm, createModal);
 
@@ -153,7 +151,7 @@ const useVirtualMachineActionsProvider: UseVirtualMachineActionsProvider = (vm, 
     VirtualMachineActionFactory,
   ]);
 
-  return useMemo(() => [actions, !inFlight, undefined], [actions, inFlight]);
+  return useMemo(() => [actions, !inFlight], [actions, inFlight]);
 };
 
 export default useVirtualMachineActionsProvider;

--- a/src/views/virtualmachines/actions/hooks/utils.ts
+++ b/src/views/virtualmachines/actions/hooks/utils.ts
@@ -1,11 +1,10 @@
-/* eslint-disable */
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { VirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type VirtualMachineStorageMigrationPlan } from '@kubevirt-utils/resources/migrations/constants';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { vmimStatuses } from '@kubevirt-utils/resources/vmim/statuses';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { printableVMStatus } from '@virtualmachines/utils';
-import { getVMIMFromMapper, VMIMMapper } from '@virtualmachines/utils/mappers';
+import { getVMIMFromMapper, type VMIMMapper } from '@virtualmachines/utils/mappers';
 
 export const sortMigPlansByCreationTimestamp = (
   a: VirtualMachineStorageMigrationPlan,
@@ -23,7 +22,7 @@ export const getVMMigPlans = (
   return migPlans?.filter((migPlan) => isVMMigPlan(migPlan, getName(vm)));
 };
 
-export const someVMIsMigrating = (vms: V1VirtualMachine[], vmimMapper: VMIMMapper) =>
+export const someVMIsMigrating = (vms: V1VirtualMachine[], vmimMapper: VMIMMapper): boolean =>
   vms?.some((vm) => {
     if (vm?.status?.printableStatus === printableVMStatus.Migrating) {
       return true;

--- a/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
+++ b/src/views/virtualmachines/details/VirtualMachineNavPage.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 import { useParams } from 'react-router';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { tourGuideVM } from '@kubevirt-utils/components/GuidedTour/utils/constants';
 import { runningTourSignal } from '@kubevirt-utils/components/GuidedTour/utils/guidedTourSignals';
 import HorizontalNavbar from '@kubevirt-utils/components/HorizontalNavbar/HorizontalNavbar';
@@ -61,7 +60,7 @@ const VirtualMachineNavPage: FC = () => {
       <SidebarEditorProvider telemetryResourceType={TELEMETRY_RESOURCE_TYPE.VM}>
         <div className="VirtualMachineNavPage">
           <DocumentTitle>
-            {getResourceDetailsTitle(getName(vmToShow) || name, 'VirtualMachine')}
+            {getResourceDetailsTitle(getName(vmToShow) ?? name, 'VirtualMachine')}
           </DocumentTitle>
 
           <VirtualMachineNavPageTitle

--- a/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/RestartPendingChanges.tsx
+++ b/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/RestartPendingChanges.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachineCondition } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachineCondition } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import PendingChangesBreadcrumb from '@kubevirt-utils/components/PendingChanges/PendingChangesBreadcrumb/PendingChangesBreadcrumb';
 import { getPendingChangesByTab } from '@kubevirt-utils/components/PendingChanges/utils/helpers';
-import { PendingChange } from '@kubevirt-utils/components/PendingChanges/utils/types';
+import { type PendingChange } from '@kubevirt-utils/components/PendingChanges/utils/types';
 import { VirtualMachineDetailsTab } from '@kubevirt-utils/constants/tabs-constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { List } from '@patternfly/react-core';
@@ -35,7 +34,7 @@ const RestartPendingChanges: FC<RestartPendingChangesProps> = ({
   return (
     <span>
       <p>
-        {restartRequiredCondition?.message ||
+        {restartRequiredCondition?.message ??
           t('RestartRequired condition has been set on this VirtualMachine.')}
       </p>
       {hasPendingChanges && (

--- a/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/utils/utils.ts
+++ b/src/views/virtualmachines/details/VirtualMachinePendingChangesAlert/utils/utils.ts
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
-import { V1VirtualMachineCondition } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachineCondition } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 
 export const getPendingChangesAlertTitle = (
   t: TFunction,
@@ -24,7 +23,7 @@ export const getMigrationRequiredConditionMessage = (
   condition?: V1VirtualMachineCondition,
 ): string => {
   const baseMessage =
-    condition?.message ||
+    condition?.message ??
     t(
       'Pending configuration changes require migrating or restarting the VirtualMachine to take effect.',
     );

--- a/src/views/virtualmachines/details/hooks/useVirtualMachineTabs.ts
+++ b/src/views/virtualmachines/details/hooks/useVirtualMachineTabs.ts
@@ -1,7 +1,7 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type NavPageKubevirt } from '@kubevirt-utils/components/HorizontalNavbar/utils/utils';
 import { VirtualMachineDetailsTab } from '@kubevirt-utils/constants/tabs-constants';
 import useHideYamlTab, { filterYamlTabs } from '@kubevirt-utils/hooks/useHideYamlTab';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -17,7 +17,7 @@ import SnapshotListPage from '../tabs/snapshots/SnapshotListPage';
 import VirtualMachineYAMLPage from '../tabs/yaml/VirtualMachineYAMLPage';
 import { getTabHrefAndName } from '../utils/utils';
 
-export const useVirtualMachineTabs = (vm: V1VirtualMachine) => {
+export const useVirtualMachineTabs = (vm: V1VirtualMachine): NavPageKubevirt[] => {
   const { t } = useKubevirtTranslation();
   const { hideYamlTab } = useHideYamlTab();
 

--- a/src/views/virtualmachines/details/tabs/configuration/VirtualMachineConfigurationTab.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/VirtualMachineConfigurationTab.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { createElement, type FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { useLocation } from 'react-router';
 
@@ -10,12 +9,11 @@ import { getName } from '@kubevirt-utils/resources/shared';
 import useVMI from '@kubevirt-utils/resources/vm/hooks/useVMI';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { PageSection, Tab, Tabs, TabTitleText } from '@patternfly/react-core';
-import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
+import { type NavPageComponentProps } from '@virtualmachines/details/utils/types';
 import { isRunning } from '@virtualmachines/utils';
 
 import ConfigurationSearch from '../../../../../utils/components/ConfigurationSearch/ConfigurationSearch';
 import { getNamespace } from '../../../../cdi-upload-provider/utils/selectors';
-
 import { createConfigurationSearchURL } from './search/utils/utils';
 import { getSearchItems } from './utils/search';
 import { getInnerTabFromPath, getTabs, includesConfigurationPath } from './utils/utils';
@@ -64,7 +62,7 @@ const VirtualMachineConfigurationTab: FC<NavPageComponentProps> = ({
       />
       <div className="VirtualMachineConfigurationTab__body">
         <Tabs activeKey={activeTabKey} className="VirtualMachineConfigurationTab__tabs" isVertical>
-          {tabs.map(({ Component, name, title }) => (
+          {tabs.map(({ Component: tabComponent, name, title }) => (
             <Tab
               className="VirtualMachineConfigurationTab__content"
               data-test={`vm-configuration-${name}`}
@@ -73,14 +71,13 @@ const VirtualMachineConfigurationTab: FC<NavPageComponentProps> = ({
               onClick={() => redirectTab(name)}
               title={<TabTitleText>{title}</TabTitleText>}
             >
-              {activeTabKey === name && (
-                <Component
-                  allInstanceTypes={allInstanceTypes}
-                  instanceTypeVM={instanceTypeExpandedSpec}
-                  vm={vm}
-                  vmi={vmi}
-                />
-              )}
+              {activeTabKey === name &&
+                createElement(tabComponent, {
+                  allInstanceTypes,
+                  instanceTypeVM: instanceTypeExpandedSpec,
+                  vm,
+                  vmi,
+                })}
             </Tab>
           ))}
         </Tabs>

--- a/src/views/virtualmachines/details/tabs/configuration/details/components/DeletionProtection/DeletionProtectionModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/components/DeletionProtection/DeletionProtectionModal.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import {
@@ -36,7 +35,7 @@ const DeletionProtectionModal: FC<DeletionProtectionModalProps> = ({
   const vmName = getName(vm);
   const vmNamespace = getNamespace(vm);
 
-  const submitHandler = () => {
+  const submitHandler = (): void => {
     onConfirm(enableDeletionProtection);
   };
 

--- a/src/views/virtualmachines/details/tabs/configuration/details/components/DeletionProtection/utils/utils.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/details/components/DeletionProtection/utils/utils.ts
@@ -1,15 +1,14 @@
-/* eslint-disable */
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { t } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getLabel, getLabels } from '@kubevirt-utils/resources/shared';
 import { updateLabels } from '@virtualmachines/details/tabs/configuration/details/utils/utils';
 
 import { VM_DELETION_PROTECTION_LABEL } from './constants';
 
-export const isDeletionProtectionEnabled = (vm: V1VirtualMachine) =>
+export const isDeletionProtectionEnabled = (vm: V1VirtualMachine): boolean =>
   getLabel(vm, VM_DELETION_PROTECTION_LABEL, 'false') === 'true';
 
-export const getDeletionProtectionPrintableStatus = (vm: V1VirtualMachine) => {
+export const getDeletionProtectionPrintableStatus = (vm: V1VirtualMachine): string => {
   const deletionProtectionEnabled = isDeletionProtectionEnabled(vm);
   return deletionProtectionEnabled ? t('Enabled') : t('Disabled');
 };
@@ -17,7 +16,7 @@ export const getDeletionProtectionPrintableStatus = (vm: V1VirtualMachine) => {
 export const setDeletionProtectionForVM = (
   vm: V1VirtualMachine,
   enableDeletionProtection: boolean,
-) => {
+): Promise<V1VirtualMachine> => {
   const vmLabels = getLabels(vm, {});
   vmLabels[VM_DELETION_PROTECTION_LABEL] = enableDeletionProtection.toString();
   return updateLabels(vm, vmLabels);

--- a/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionHardware.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/details/components/DetailsSectionHardware.tsx
@@ -1,8 +1,10 @@
-/* eslint-disable */
-import React, { FC, useEffect } from 'react';
+import React, { type FC, useEffect } from 'react';
 import { useLocation } from 'react-router';
 
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getClusterOnlyArchitecture } from '@kubevirt-utils/components/FirmwareBootloaderModal/utils/utils';
 import HardwareDevicesTable from '@kubevirt-utils/components/HardwareDevices/HardwareDevicesTable';
 import HardwareDeviceTitle from '@kubevirt-utils/components/HardwareDevices/HardwareDeviceTitle';
@@ -42,7 +44,7 @@ const DetailsSectionHardware: FC<DetailsSectionHardwareProps> = ({
   const [clusterWorkloadArchitectures] = useHcoWorkloadArchitectures(getCluster(vm));
   const clusterOnlyArchitecture = getClusterOnlyArchitecture(clusterWorkloadArchitectures);
   const [isExpanded, setIsExpanded] = useToggle('hardware-devices');
-  const onSubmit = onSubmitProp || updateHardwareDevices;
+  const onSubmit = onSubmitProp ?? updateHardwareDevices;
   const hostDevices = getHostDevices(vm);
   const gpus = getGPUDevices(vm);
   const vmHasS390xArchitecture = hasS390xArchitecture(vm);
@@ -52,7 +54,7 @@ const DetailsSectionHardware: FC<DetailsSectionHardwareProps> = ({
     expandURLHash(getSearchItemsIds(getDetailsTabHardwareIds(vm)), location?.hash, setIsExpanded);
   }, [location?.hash, vm, setIsExpanded]);
 
-  const onEditHostDevices = () => {
+  const onEditHostDevices = (): void => {
     createModal(({ isOpen, onClose }) => (
       <HardwareDevicesModal
         btnText={t('Add host device')}
@@ -68,7 +70,7 @@ const DetailsSectionHardware: FC<DetailsSectionHardwareProps> = ({
     ));
   };
 
-  const onEditGPU = () => {
+  const onEditGPU = (): void => {
     createModal(({ isOpen, onClose }) => (
       <HardwareDevicesModal
         onSubmit={async (updatedVM) => {

--- a/src/views/virtualmachines/details/tabs/configuration/initialrun/components/InitialRunTabSysprep.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/initialrun/components/InitialRunTabSysprep.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { ConfigMapModel, modelToGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import WindowsLabel from '@kubevirt-utils/components/Labels/WindowsLabel';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
@@ -17,7 +16,7 @@ import { SysprepDescription } from '@kubevirt-utils/components/SysprepModal/Sysp
 import { SysprepModal } from '@kubevirt-utils/components/SysprepModal/SysprepModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getVolumes } from '@kubevirt-utils/resources/vm';
-import { PatchCustomizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
+import { type PatchCustomizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
@@ -49,9 +48,9 @@ const InitialRunTabSysprep: FC<InitialRunTabSysprepProps> = ({ canUpdateVM, onSu
       },
     );
 
-  const { [AUTOUNATTEND]: autoUnattend, [UNATTEND]: unattend } = externalSysprepConfig?.data || {};
+  const { [AUTOUNATTEND]: autoUnattend, [UNATTEND]: unattend } = externalSysprepConfig?.data ?? {};
 
-  const onSysprepSelected = (name: string) =>
+  const onSysprepSelected = (name: string): Promise<void> =>
     patchVMWithExistingSysprepConfigMap(name, vm, onSubmit);
 
   const onSysprepCreation = async (unattended: string, autounattend: string): Promise<void> =>

--- a/src/views/virtualmachines/details/tabs/configuration/initialrun/utils/utils.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/initialrun/utils/utils.ts
@@ -1,7 +1,6 @@
-/* eslint-disable */
 import { ConfigMapModel, VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type IoK8sApiCoreV1ConfigMap } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { SYSPREP } from '@kubevirt-utils/components/SysprepModal/consts';
 import {
   AUTOUNATTEND,
@@ -12,7 +11,7 @@ import {
 } from '@kubevirt-utils/components/SysprepModal/sysprep-utils';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getDisks, getVolumes } from '@kubevirt-utils/resources/vm';
-import { PatchCustomizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
+import { type PatchCustomizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { kubevirtK8sCreate, kubevirtK8sPatch } from '@multicluster/k8sRequests';
@@ -29,14 +28,14 @@ export const patchVMWithExistingSysprepConfigMap = async (
     ? onSubmit([
         {
           data: [
-            ...(vmDisks || []).filter((disk) => disk?.name !== SYSPREP),
+            ...(vmDisks ?? []).filter((disk) => disk?.name !== SYSPREP),
             ...(!isEmpty(name) ? [sysprepDisk()] : []),
           ],
           path: `spec.template.spec.domain.devices.disks`,
         },
         {
           data: [
-            ...(vmVolumes || []).filter((vol) => vol?.name !== SYSPREP),
+            ...(vmVolumes ?? []).filter((vol) => vol?.name !== SYSPREP),
             ...(!isEmpty(name) ? [sysprepVolume(name)] : []),
           ],
           path: `spec.template.spec.volumes`,
@@ -125,12 +124,12 @@ export const createSysprepConfigMap = async (
           {
             op: 'replace',
             path: `/spec/template/spec/domain/devices/disks`,
-            value: [...(vmDisks || []), sysprepDisk()],
+            value: [...(vmDisks ?? []), sysprepDisk()],
           },
           {
             op: 'replace',
             path: `/spec/template/spec/volumes`,
-            value: [...(vmVolumes || []), sysprepVolume(configMap.metadata.name)],
+            value: [...(vmVolumes ?? []), sysprepVolume(configMap.metadata.name)],
           },
         ],
         model: VirtualMachineModel,

--- a/src/views/virtualmachines/details/tabs/configuration/network/components/modal/VirtualMachinesNetworkInterfaceModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/network/components/modal/VirtualMachinesNetworkInterfaceModal.tsx
@@ -1,16 +1,16 @@
-/* eslint-disable */
-import React, { FC, useCallback } from 'react';
+import React, { type FC, useCallback } from 'react';
 import produce from 'immer';
 import { VirtualMachineModel } from 'src/views/dashboard-extensions/utils';
 
 import {
-  V1Disk,
-  V1Interface,
-  V1Network,
-  V1VirtualMachine,
-  V1VirtualMachineInstance,
+  type V1Disk,
+  type V1Interface,
+  type V1Network,
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import NetworkInterfaceModal from '@kubevirt-utils/components/NetworkInterfaceModal/NetworkInterfaceModal';
+import { type NetworkInterfaceModalOnSubmit } from '@kubevirt-utils/components/NetworkInterfaceModal/types';
 import {
   createInterface,
   createNetwork,
@@ -22,6 +22,7 @@ import {
   addNetwork,
   patchVM,
 } from '@kubevirt-utils/resources/vm/utils/network/patch';
+import { ensurePath } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { kubevirtK8sUpdate } from '@multicluster/k8sRequests';
 
@@ -55,7 +56,9 @@ const VirtualMachinesNetworkInterfaceModal: FC<VirtualMachinesNetworkInterfaceMo
       isLegacyPasst,
       networkName,
       nicName,
-    }) =>
+    }: NetworkInterfaceModalOnSubmit): (() =>
+      | Promise<V1VirtualMachine | string | void>
+      | undefined) =>
       () => {
         const existingInterface = getInterface(vm, nicName);
         const existingNetwork = getNetworks(vm)?.find(({ name }) => name === nicName);
@@ -77,8 +80,8 @@ const VirtualMachinesNetworkInterfaceModal: FC<VirtualMachinesNetworkInterfaceMo
         if (isBootSource) resultInterface.bootOrder = nicBootOrder;
 
         if (onAddNetworkInterface) {
-          const updatedNetworks: V1Network[] = [...(getNetworks(vm) || []), resultNetwork];
-          const updatedInterfaces: V1Interface[] = [...(getInterfaces(vm) || []), resultInterface];
+          const updatedNetworks: V1Network[] = [...(getNetworks(vm) ?? []), resultNetwork];
+          const updatedInterfaces: V1Interface[] = [...(getInterfaces(vm) ?? []), resultInterface];
           return onAddNetworkInterface(
             updatedNetworks,
             updatedInterfaces,
@@ -88,9 +91,12 @@ const VirtualMachinesNetworkInterfaceModal: FC<VirtualMachinesNetworkInterfaceMo
 
         if (isBootSource && needsDiskUpdate) {
           const newVM = produce(vm, (draftVM) => {
-            draftVM.spec!.template!.spec!.domain!.devices!.disks = disksWithOrder;
-            getNetworks(draftVM)!.push(resultNetwork);
-            getInterfaces(draftVM)!.push(resultInterface);
+            ensurePath(draftVM, ['spec.template.spec.domain.devices.disks']);
+            draftVM.spec.template.spec.domain.devices.disks = disksWithOrder;
+            ensurePath(draftVM, ['spec.template.spec.networks']);
+            draftVM.spec.template.spec.networks.push(resultNetwork);
+            ensurePath(draftVM, ['spec.template.spec.domain.devices.interfaces']);
+            draftVM.spec.template.spec.domain.devices.interfaces.push(resultInterface);
           });
           return kubevirtK8sUpdate({
             cluster: getCluster(vm),

--- a/src/views/virtualmachines/details/tabs/configuration/network/utils/utils.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/network/utils/utils.ts
@@ -1,12 +1,11 @@
-/* eslint-disable */
 import produce from 'immer';
 
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import {
-  V1Network,
-  V1VirtualMachine,
-  V1VirtualMachineInstance,
-  V1VirtualMachineInstanceNetworkInterface,
+  type V1Network,
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+  type V1VirtualMachineInstanceNetworkInterface,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getInterface, getInterfaces } from '@kubevirt-utils/resources/vm';
 import { DEFAULT_NETWORK_INTERFACE } from '@kubevirt-utils/resources/vm/utils/constants';
@@ -30,12 +29,12 @@ export const isActiveOnGuest = (
   vmi: V1VirtualMachineInstance,
   nicName: string,
   isVMRunning?: boolean,
-) =>
+): boolean =>
   (isVMRunning ? getVMIStatusInterfaces(vmi) : getVMIInterfaces(vmi))?.some(
     (iface) => iface?.name === nicName,
   );
 
-export const isAbsent = (vm: V1VirtualMachine, nicName: string) =>
+export const isAbsent = (vm: V1VirtualMachine, nicName: string): boolean =>
   getInterfaces(vm)?.find((iface) => iface?.name === nicName)?.state === ABSENT;
 
 export const isPendingNICAdd = (
@@ -53,14 +52,14 @@ export const isPendingNICAdd = (
   );
 };
 
-export const interfaceNotFound = (vm: V1VirtualMachine, nicName: string) =>
+export const interfaceNotFound = (vm: V1VirtualMachine, nicName: string): boolean =>
   !Boolean(getInterfaces(vm)?.find((iface) => iface?.name === nicName));
 
 //special case - when u add ephemeral nic from vm console terminal
 export const isInterfaceEphemeral = (
   network: V1Network,
   ifaceVMIStatus: V1VirtualMachineInstanceNetworkInterface,
-) => {
+): boolean => {
   const ifaceVMI = !network && ifaceVMIStatus && ifaceVMIStatus?.infoSource === 'guest-agent';
 
   return ifaceVMI;
@@ -89,7 +88,7 @@ export const isPendingNICRemoval = (
 
 export { getConfigInterfaceState, getConfigInterfaceStateFromVM, isSRIOVNetworkByVM };
 
-export const isSRIOVInterface = <T extends { sriov?: object }>(iface: T) => !!iface?.sriov;
+export const isSRIOVInterface = <T extends { sriov?: object }>(iface: T): boolean => !!iface?.sriov;
 
 export const getRuntimeInterfaceState = (simpleIfaceState: string): NetworkInterfaceState => {
   return isNetworkInterfaceState(simpleIfaceState) ? simpleIfaceState : NetworkInterfaceState.NONE;
@@ -115,5 +114,5 @@ export const setNetworkInterfaceState = (
   }).catch((error) => kubevirtConsole.error(error));
 };
 
-export const isLinkStateEditable = (state: NetworkInterfaceState) =>
+export const isLinkStateEditable = (state: NetworkInterfaceState): boolean =>
   state === NetworkInterfaceState.DOWN || state === NetworkInterfaceState.UP;

--- a/src/views/virtualmachines/details/tabs/configuration/scheduling/components/DeschedulerPopover.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/scheduling/components/DeschedulerPopover.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type FC } from 'react';
 import { Trans } from 'react-i18next';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
-const DeschedulerPopover = () => {
+const DeschedulerPopover: FC = () => {
   const { t } = useKubevirtTranslation();
 
   return (

--- a/src/views/virtualmachines/details/tabs/configuration/ssh/components/DynamicSSHKeyInjectionDescription.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/ssh/components/DynamicSSHKeyInjectionDescription.tsx
@@ -1,12 +1,17 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type FC } from 'react';
 
 import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
 import { documentationURL } from '@kubevirt-utils/constants/documentation';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { StackItem } from '@patternfly/react-core';
 
-const DynamicSSHKeyInjectionDescription = ({ isDynamicSSHInjectionEnabled }) => {
+type DynamicSSHKeyInjectionDescriptionProps = {
+  isDynamicSSHInjectionEnabled: boolean;
+};
+
+const DynamicSSHKeyInjectionDescription: FC<DynamicSSHKeyInjectionDescriptionProps> = ({
+  isDynamicSSHInjectionEnabled,
+}) => {
   const { t } = useKubevirtTranslation();
 
   if (isDynamicSSHInjectionEnabled) return <>{t('Store the key in a project secret.')}</>;

--- a/src/views/virtualmachines/details/tabs/configuration/ssh/components/SSHTabAuthorizedSSHKey.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/ssh/components/SSHTabAuthorizedSSHKey.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 import { VirtualMachineModel } from 'src/views/dashboard-extensions/utils';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
@@ -15,12 +14,11 @@ import { asAccessReview, getName, getNamespace } from '@kubevirt-utils/resources
 import { getVMSSHSecretName } from '@kubevirt-utils/resources/vm';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { kubevirtK8sUpdate } from '@multicluster/k8sRequests';
-import { K8sVerb } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sVerb } from '@openshift-console/dynamic-plugin-sdk';
 import { Stack } from '@patternfly/react-core';
 import { useFleetAccessReview } from '@stolostron/multicluster-sdk';
 
 import { useDynamicSSHInjection } from '../hooks/useDynamicSSHInjection';
-
 import DynamicSSHKeyInjectionDescription from './DynamicSSHKeyInjectionDescription';
 
 type SSHTabAuthorizedSSHKeyProps = {
@@ -48,7 +46,7 @@ const SSHTabAuthorizedSSHKey: FC<SSHTabAuthorizedSSHKeyProps> = ({
   const isEditable =
     ((canUpdateVM && isDynamicSSHInjectionEnabled) || isCustomizeInstanceType) && loaded;
 
-  const onSubmit = (updatedVM: V1VirtualMachine) =>
+  const onSubmit = (updatedVM: V1VirtualMachine): Promise<V1VirtualMachine> =>
     onUpdateVM
       ? onUpdateVM(updatedVM)
       : kubevirtK8sUpdate({

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/hooks/useFilesystemListColumns.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/hooks/useFilesystemListColumns.ts
@@ -1,8 +1,14 @@
-/* eslint-disable */
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { sortable } from '@patternfly/react-table';
 
-const useFilesystemTableColumns = () => {
+type FilesystemTableColumn = {
+  id: string;
+  sort: string;
+  title: string;
+  transforms: (typeof sortable)[];
+};
+
+const useFilesystemTableColumns = (): FilesystemTableColumn[] => {
   const { t } = useKubevirtTranslation();
 
   const columns = [

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/hooks/useMountIsoUploadForDisk.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/hooks/useMountIsoUploadForDisk.ts
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { UPLOAD_PROGRESS_STATUS } from '@kubevirt-utils/hooks/useUploadProgressToast/constants';
 import { getVmCdromUploadKeyFromVm } from '@kubevirt-utils/hooks/useUploadProgressToast/keys/uploadKeys';
 import { useUploadProgressStore } from '@kubevirt-utils/hooks/useUploadProgressToast/uploadProgressStore';
@@ -40,7 +39,7 @@ export const useMountIsoUploadForDisk = (
 
   const isUploadInProgress = upload?.status === UPLOAD_PROGRESS_STATUS.UPLOADING;
 
-  const cancelUpload = () => cancelMountIsoUpload(vm, diskName);
+  const cancelUpload = (): Promise<boolean> => cancelMountIsoUpload(vm, diskName);
 
   return { cancelUpload, isUploadInProgress };
 };

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/EjectCDROMModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/EjectCDROMModal.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { Trans } from 'react-i18next';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { ejectISOFromCDROM } from '@kubevirt-utils/components/DiskModal/utils/helpers';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -30,7 +29,7 @@ const EjectCDROMModal: FC<EjectCDROMModalProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
 
-  const handleEject = () => {
+  const handleEject = async (): Promise<V1VirtualMachine> => {
     const currentVM = getCustomizeWizardVM() ?? vm;
     const updatedVM = ejectISOFromCDROM(currentVM, cdromName);
 


### PR DESCRIPTION
## 📝 Description

Adds eslint typescript rules to the code base part- 9


## 🔗 Links

https://redhat.atlassian.net/browse/CNV-90382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Alerts with unsupported or missing severity values are now safely excluded from alert groupings.
  * Template details in topology views now watch resources from the VM’s associated cluster and avoid invalid watches when identifying information is unavailable.
  * VM migration metrics now handle incomplete or invalid data more reliably, displaying utilization only when sufficient values are available.
  * Empty display names and annotations are preserved instead of being replaced by fallback text.
* **Refactor**
  * Improved consistency and reliability across template, VM, migration, and topology workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->