### PR TITLE
CNV-90382: add typescript-linters-part-10

### DIFF
--- a/src/utils/components/SnapshotModal/BulkSnapshotModal.tsx
+++ b/src/utils/components/SnapshotModal/BulkSnapshotModal.tsx
@@ -15,7 +15,7 @@ import { addRandomSuffix } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { kubevirtK8sCreate } from '@multicluster/k8sRequests';
 import { FormGroup, List, ListItem, Stack, StackItem, TextArea } from '@patternfly/react-core';
-import { deadlineUnits } from '@virtualmachines/details/tabs/snapshots/utils/consts';
+import { DeadlineUnits } from '@virtualmachines/details/tabs/snapshots/utils/consts';
 import { getVolumeSnapshotStatusesPartitionPerVM } from '@virtualmachines/details/tabs/snapshots/utils/helpers';
 
 import TabModal from '../TabModal/TabModal';
@@ -47,7 +47,7 @@ const BulkSnapshotModal: FC<BulkSnapshotModalProps> = ({ isOpen, onClose, vms })
 
   const [description, setDescription] = useState<string>(undefined);
   const [deadline, setDeadline] = useState<string>(undefined);
-  const [deadlineUnit, setDeadlineUnit] = useState<deadlineUnits>(deadlineUnits.Seconds);
+  const [deadlineUnit, setDeadlineUnit] = useState<DeadlineUnits>(DeadlineUnits.Seconds);
 
   const [isSubmitDisabled, setIsSubmitDisabled] = useState<boolean>(false);
 

--- a/src/utils/components/SnapshotModal/SnapshotFormFields/SnapshotDeadlineFormField.tsx
+++ b/src/utils/components/SnapshotModal/SnapshotFormFields/SnapshotDeadlineFormField.tsx
@@ -18,14 +18,14 @@ import {
   ValidatedOptions,
 } from '@patternfly/react-core';
 
-import { deadlineUnits } from '../../../../views/virtualmachines/details/tabs/snapshots/utils/consts';
+import { DeadlineUnits } from '../../../../views/virtualmachines/details/tabs/snapshots/utils/consts';
 import { validateSnapshotDeadline } from '../../../../views/virtualmachines/details/tabs/snapshots/utils/helpers';
 
 type SnapshotDeadlineFormFieldProps = {
   deadline: string;
-  deadlineUnit: string;
+  deadlineUnit: DeadlineUnits;
   setDeadline: Dispatch<SetStateAction<string>>;
-  setDeadlineUnit: Dispatch<SetStateAction<string>>;
+  setDeadlineUnit: Dispatch<SetStateAction<DeadlineUnits>>;
   setIsError: Dispatch<SetStateAction<boolean>>;
 };
 
@@ -49,7 +49,7 @@ const SnapshotDeadlineFormField: FC<SnapshotDeadlineFormFieldProps> = ({
 
   const handleDeadlineUnitChange = (
     _event: FormEvent<HTMLSelectElement>,
-    value: deadlineUnits,
+    value: DeadlineUnits,
   ): void => {
     setDeadlineUnit(value);
   };
@@ -71,7 +71,7 @@ const SnapshotDeadlineFormField: FC<SnapshotDeadlineFormFieldProps> = ({
         </GridItem>
         <GridItem span={4}>
           <FormSelect id="deadline-unit" onChange={handleDeadlineUnitChange} value={deadlineUnit}>
-            {Object.entries(deadlineUnits).map(([key, value]) => (
+            {Object.entries(DeadlineUnits).map(([key, value]) => (
               <FormSelectOption key={key} label={`${key} (${value})`} value={value} />
             ))}
           </FormSelect>

--- a/src/utils/components/SnapshotModal/SnapshotFormFields/tests/SnapshotDeadlineFormField.test.tsx
+++ b/src/utils/components/SnapshotModal/SnapshotFormFields/tests/SnapshotDeadlineFormField.test.tsx
@@ -1,27 +1,27 @@
 import React from 'react';
 
 import { fireEvent, render, screen } from '@testing-library/react';
-import { deadlineUnits } from '@virtualmachines/details/tabs/snapshots/utils/consts';
+import { DeadlineUnits } from '@virtualmachines/details/tabs/snapshots/utils/consts';
 
 import SnapshotDeadlineFormField from '../SnapshotDeadlineFormField';
 
 const defaultProps = {
   deadline: '',
-  deadlineUnit: deadlineUnits.Seconds,
+  deadlineUnit: DeadlineUnits.Seconds,
   setDeadline: jest.fn(),
   setDeadlineUnit: jest.fn(),
   setIsError: jest.fn(),
 };
 
 describe('SnapshotDeadlineFormField', () => {
-  it('should render deadline unit options from deadlineUnits enum only', () => {
+  it('should render deadline unit options from DeadlineUnits enum only', () => {
     render(<SnapshotDeadlineFormField {...defaultProps} />);
 
     const select = screen.getByRole('combobox');
     expect(select).toBeInTheDocument();
 
     const options = screen.getAllByRole('option');
-    const expectedCount = Object.keys(deadlineUnits).length;
+    const expectedCount = Object.keys(DeadlineUnits).length;
     expect(options).toHaveLength(expectedCount);
     expect(expectedCount).toBe(3);
   });
@@ -36,7 +36,7 @@ describe('SnapshotDeadlineFormField', () => {
     expect(optionLabels.some((label) => label.includes('ms'))).toBe(false);
   });
 
-  it.each(Object.entries(deadlineUnits))(
+  it.each(Object.entries(DeadlineUnits))(
     'should expose %s (%s) as a deadline unit option',
     (labelPart, valuePart) => {
       render(<SnapshotDeadlineFormField {...defaultProps} />);

--- a/src/utils/components/SnapshotModal/SnapshotModal.tsx
+++ b/src/utils/components/SnapshotModal/SnapshotModal.tsx
@@ -30,7 +30,7 @@ import {
   TextInput,
   ValidatedOptions,
 } from '@patternfly/react-core';
-import { deadlineUnits } from '@virtualmachines/details/tabs/snapshots/utils/consts';
+import { DeadlineUnits } from '@virtualmachines/details/tabs/snapshots/utils/consts';
 import { getVolumeSnapshotStatusesPartition } from '@virtualmachines/details/tabs/snapshots/utils/helpers';
 import { printableVMStatus } from '@virtualmachines/utils';
 
@@ -54,7 +54,7 @@ const SnapshotModal: FC<SnapshotModalProps> = ({ isOpen, onClose, vm }) => {
   const isSnapshotNameValid = isDNS1123Label(snapshotName);
   const [description, setDescription] = useState<string>(undefined);
   const [deadline, setDeadline] = useState<string>(undefined);
-  const [deadlineUnit, setDeadlineUnit] = useState<deadlineUnits>(deadlineUnits.Seconds);
+  const [deadlineUnit, setDeadlineUnit] = useState<DeadlineUnits>(DeadlineUnits.Seconds);
 
   const volumeSnapshotStatuses = getVolumeSnapshotStatuses(vm);
   const { supportedVolumes, unsupportedVolumes } =

--- a/src/utils/components/SnapshotModal/utils/utils.ts
+++ b/src/utils/components/SnapshotModal/utils/utils.ts
@@ -6,7 +6,7 @@ import {
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { buildOwnerReference, getName } from '@kubevirt-utils/resources/shared';
 import { MAX_K8S_NAME_LENGTH } from '@kubevirt-utils/utils/constants';
-import { type deadlineUnits } from '@virtualmachines/details/tabs/snapshots/utils/consts';
+import { type DeadlineUnits } from '@virtualmachines/details/tabs/snapshots/utils/consts';
 import { getEmptyVMSnapshotResource } from '@virtualmachines/details/tabs/snapshots/utils/helpers';
 
 const DEFAULT_SUFFIX_LENGTH = 'snapshot-yyyyMMdd-kkmmss'.length as 24;
@@ -43,7 +43,7 @@ export const generateSnapshot = (
   snapshotName: string,
   description: string,
   deadline: string,
-  deadlineUnit: deadlineUnits,
+  deadlineUnit: DeadlineUnits,
 ): V1beta1VirtualMachineSnapshot => {
   const snapshot = getEmptyVMSnapshotResource(vm);
   const ownerReference = buildOwnerReference(vm, { blockOwnerDeletion: false });

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/MakePersistentModal.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/MakePersistentModal.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import {
-  V1VirtualMachine,
-  V1VirtualMachineInstance,
-  V1Volume,
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+  type V1Volume,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ConfirmActionMessage from '@kubevirt-utils/components/ConfirmActionMessage/ConfirmActionMessage';
 import { CONFIRM_ACTIONS } from '@kubevirt-utils/components/ConfirmActionMessage/constants';
@@ -14,7 +13,6 @@ import { getVMIVolumes } from '@kubevirt-utils/resources/vmi';
 import { Stack, StackItem } from '@patternfly/react-core';
 
 import { updateDisks } from '../../../details/utils/utils';
-
 import { persistVolume } from './utils';
 
 type MakePersistentModalProps = {
@@ -34,7 +32,7 @@ const MakePersistentModal: FC<MakePersistentModalProps> = ({
 }) => {
   const { t } = useKubevirtTranslation();
 
-  const makePersistent = async () => {
+  const makePersistent = async (): Promise<V1VirtualMachine> => {
     const volumeToPersist = getVMIVolumes(vmi)?.find(
       (vmiVolume) => vmiVolume.name === volume?.name,
     );

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useISOOptions.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useISOOptions.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import usePVCs from '@kubevirt-utils/hooks/usePVCs';
@@ -10,7 +9,12 @@ type ISOOption = {
   value: string;
 };
 
-export const useISOOptions = (namespace: string) => {
+type UseISOOptionsReturn = {
+  isoOptions: ISOOption[];
+  pvcsLoaded: boolean;
+};
+
+export const useISOOptions = (namespace: string): UseISOOptionsReturn => {
   const [pvcs, pvcsLoaded] = usePVCs(namespace);
 
   const isoOptions: ISOOption[] = useMemo(() => {

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useMountCDROMForm.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/modal/hooks/useMountCDROMForm.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useCallback, useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
 
@@ -108,7 +107,7 @@ export const useMountCDROMForm = (options?: UseMountCDROMFormOptions): UseMountC
     clearUploadFilenameFields();
   }, [handleClearUpload, clearUploadFilenameFields]);
 
-  const isFormValid = Boolean(selectedISO || uploadFile?.filename);
+  const isFormValid = selectedISO !== '' || Boolean(uploadFile?.filename);
 
   return {
     handleClearUpload,

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRow.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskRow.tsx
@@ -1,23 +1,21 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 
 import { DataVolumeModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
-  CONTAINER_EPHERMAL,
-  OTHER,
-} from '@kubevirt-utils/components/DiskModal/components/utils/constants';
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind, PersistentVolumeClaimModel } from '@kubevirt-utils/models';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getDisks } from '@kubevirt-utils/resources/vm';
-import { NameWithPercentages } from '@kubevirt-utils/resources/vm/hooks/types';
-import { DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
+import { type NameWithPercentages } from '@kubevirt-utils/resources/vm/hooks/types';
+import { type DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 import { isCDROMDisk } from '@kubevirt-utils/resources/vm/utils/disk/selectors';
 import { readableSizeUnit } from '@kubevirt-utils/utils/units';
 import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
 import { getCluster } from '@multicluster/helpers/selectors';
-import { RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
+import { type RowProps, TableData } from '@openshift-console/dynamic-plugin-sdk';
 import {
   Label,
   Popover,
@@ -30,15 +28,10 @@ import {
 import DiskRowActions from './DiskRowActions';
 import { HotplugLabel } from './HotplugLabel';
 import ISOBadge from './ISOBadge';
+import { getTranslatedSource } from './utils/helpers';
 
 import '../tables.scss';
 import './disklist.scss';
-
-const getTranslatedSource = (source: string, t: (key: string) => string): string => {
-  if (source === OTHER) return t(OTHER);
-  if (source === CONTAINER_EPHERMAL) return t(CONTAINER_EPHERMAL);
-  return source;
-};
 
 const DiskRow: FC<
   RowProps<
@@ -76,7 +69,7 @@ const DiskRow: FC<
   const provisioningPercentage = provisioningPercentages?.[source];
 
   const { displayName } = useMemo(() => {
-    const disks = getDisks(vm) || [];
+    const disks = getDisks(vm) ?? [];
     const foundDisk = disks.find((disk) => disk.name === name);
     const cdrom = foundDisk && isCDROMDisk(foundDisk);
     const cdromName = t('CD-ROM');
@@ -132,7 +125,7 @@ const DiskRow: FC<
             )}
             cluster={getCluster(vm)}
             name={source}
-            namespace={namespace || getNamespace(vm)}
+            namespace={namespace ?? getNamespace(vm)}
           />
         )}
 

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/ISOBadge.tsx
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/ISOBadge.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getDisks } from '@kubevirt-utils/resources/vm';
 import { isCDROMDisk } from '@kubevirt-utils/resources/vm/utils/disk/selectors';
@@ -15,7 +14,7 @@ type ISOBadgeProps = {
 const ISOBadge: FC<ISOBadgeProps> = ({ diskName, vm }) => {
   const { t } = useKubevirtTranslation();
 
-  const disks = getDisks(vm) || [];
+  const disks = getDisks(vm) ?? [];
   const disk = disks.find((vmDisk) => vmDisk.name === diskName);
 
   if (!disk || !isCDROMDisk(disk)) {

--- a/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/utils/helpers.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/storage/components/tables/disk/utils/helpers.ts
@@ -1,11 +1,15 @@
-/* eslint-disable */
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type TFunction } from 'i18next';
+
+import {
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
   CONTAINER_EPHERMAL,
   OTHER,
 } from '@kubevirt-utils/components/DiskModal/components/utils/constants';
 import { getVolumes } from '@kubevirt-utils/resources/vm';
-import { DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
+import { type DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 
 export const isHotplugVolume = (
   vm: V1VirtualMachine,
@@ -15,10 +19,16 @@ export const isHotplugVolume = (
   const volumeStatus = vmi?.status?.volumeStatus?.find((volStatus) => volStatus.name === diskName);
   const vmVolume = getVolumes(vm)?.find((vol) => vol?.name === diskName);
   const hotplugStatus =
-    volumeStatus?.hotplugVolume ||
-    vmVolume?.dataVolume?.hotpluggable ||
-    vmVolume?.persistentVolumeClaim?.hotpluggable;
+    volumeStatus?.hotplugVolume != null ||
+    vmVolume?.dataVolume?.hotpluggable === true ||
+    vmVolume?.persistentVolumeClaim?.hotpluggable === true;
   return !!hotplugStatus;
+};
+
+export const getTranslatedSource = (source: string, t: TFunction): string => {
+  if (source === OTHER) return t(OTHER);
+  if (source === CONTAINER_EPHERMAL) return t(CONTAINER_EPHERMAL);
+  return source;
 };
 
 export const isPVCSource = (obj: DiskRowDataLayout): boolean =>

--- a/src/views/virtualmachines/details/tabs/configuration/utils/utils.ts
+++ b/src/views/virtualmachines/details/tabs/configuration/utils/utils.ts
@@ -1,8 +1,8 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type ComponentType } from 'react';
+import { type TFunction } from 'i18next';
 
 import { VirtualMachineDetailsTab } from '@kubevirt-utils/constants/tabs-constants';
-import { getTabNameAndTitle } from '@virtualmachines/details/utils/utils';
+import { getTabNameAndTitle, type TabNameAndTitle } from '@virtualmachines/details/utils/utils';
 
 import DetailsTab from '../details/DetailsTab';
 import InitialRunTab from '../initialrun/InitialRunTab';
@@ -12,7 +12,11 @@ import VirtualMachineSchedulingPage from '../scheduling/SchedulingTab';
 import SSHTab from '../ssh/SSHTab';
 import StorageTab from '../storage/StorageTab';
 
-export const getTabs = (t: TFunction) => [
+type TabConfig = TabNameAndTitle & {
+  Component: ComponentType<Record<string, unknown>>;
+};
+
+export const getTabs = (t: TFunction): TabConfig[] => [
   {
     Component: DetailsTab,
     ...getTabNameAndTitle(VirtualMachineDetailsTab.Details, t),
@@ -49,7 +53,7 @@ const getInnerTabs = (t: TFunction): { [key: string]: string } =>
     return acc;
   }, {});
 
-export const getInnerTabFromPath = (path: string, t: TFunction) =>
+export const getInnerTabFromPath = (path: string, t: TFunction): string | undefined =>
   getInnerTabs(t)[path.slice(path.lastIndexOf('/') + 1)];
 
 export const includesConfigurationPath = (path: string, append: string): string => {

--- a/src/views/virtualmachines/details/tabs/diagnostic/components/DiagnosticsIssuesToolbar/DiagnosticsIssuesToolbar.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/components/DiagnosticsIssuesToolbar/DiagnosticsIssuesToolbar.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable */
-import React, { FC, Ref, useState } from 'react';
-import { TFunction } from 'i18next';
+import React, { type FC, type MouseEvent, type ReactElement, type Ref, useState } from 'react';
+import { type TFunction } from 'i18next';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
@@ -8,7 +7,7 @@ import {
   Flex,
   FlexItem,
   MenuToggle,
-  MenuToggleElement,
+  type MenuToggleElement,
   SearchInput,
   Select,
   SelectGroup,
@@ -21,7 +20,7 @@ import { DataViewToolbar } from '@patternfly/react-data-view';
 import { FilterIcon } from '@patternfly/react-icons';
 
 import { DIAGNOSTIC_CATEGORIES, DIAGNOSTIC_CONDITIONS } from '../../utils/constants';
-import { DiagnosticFilterCounts, DiagnosticFilters } from '../../utils/types';
+import { type DiagnosticFilterCounts, type DiagnosticFilters } from '../../utils/types';
 
 import './diagnostics-issues-toolbar.scss';
 
@@ -45,7 +44,7 @@ const renderFilterOptions = (
   selectedSet: Set<string>,
   counts: Record<string, number>,
   t: TFunction,
-) =>
+): ReactElement[] =>
   options.map((option) => (
     <SelectOption hasCheckbox isSelected={selectedSet.has(option)} key={option} value={option}>
       <Flex
@@ -72,7 +71,7 @@ const DiagnosticsIssuesToolbar: FC<DiagnosticsIssuesToolbarProps> = ({
 
   const activeFilterCount = filters.categories.size + filters.conditions.size;
 
-  const handleSelect = (_event: React.MouseEvent, value: string) => {
+  const handleSelect = (_event: MouseEvent, value: string): void => {
     if ((DIAGNOSTIC_CATEGORIES as string[]).includes(value)) {
       onFiltersChange({ ...filters, categories: toggleSetItem(filters.categories, value) });
     } else {
@@ -80,12 +79,12 @@ const DiagnosticsIssuesToolbar: FC<DiagnosticsIssuesToolbarProps> = ({
     }
   };
 
-  const clearAll = () => {
+  const clearAll = (): void => {
     onFiltersChange({ categories: new Set(), conditions: new Set() });
     onSearchChange('');
   };
 
-  const filterToggle = (toggleRef: Ref<MenuToggleElement>) => (
+  const filterToggle = (toggleRef: Ref<MenuToggleElement>): ReactElement => (
     <MenuToggle
       badge={activeFilterCount > 0 ? <Badge isRead>{activeFilterCount}</Badge> : undefined}
       icon={<FilterIcon />}

--- a/src/views/virtualmachines/details/tabs/diagnostic/components/DiagnosticsOverviewCards/DiagnosticsOverviewCards.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/components/DiagnosticsOverviewCards/DiagnosticsOverviewCards.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { ComponentType, FC } from 'react';
+import React, { type ComponentType, type FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
@@ -19,7 +18,7 @@ import {
   InfoCircleIcon,
 } from '@patternfly/react-icons';
 
-import { DiagnosticSeverity, DiagnosticSeverityCounts } from '../../utils/types';
+import { type DiagnosticSeverity, type DiagnosticSeverityCounts } from '../../utils/types';
 
 import './diagnostics-overview-cards.scss';
 
@@ -82,36 +81,36 @@ const DiagnosticsOverviewCards: FC<DiagnosticsOverviewCardsProps> = ({
 
   return (
     <Flex className="diagnostics-overview-cards">
-      {cards.map(({ colorClass, count, icon: CardIcon, label, severity, status }) => {
-        const isSelected = activeSeverity === severity;
+      {cards.map((card) => {
+        const isSelected = activeSeverity === card.severity;
 
         return (
-          <FlexItem flex={{ default: 'flex_1' }} key={label}>
+          <FlexItem flex={{ default: 'flex_1' }} key={card.label}>
             <Card
-              className={`diagnostics-overview-cards__card ${colorClass} ${
+              className={`diagnostics-overview-cards__card ${card.colorClass} ${
                 isSelected ? 'diagnostics-overview-cards__card--selected' : ''
               }`}
-              aria-label={t('{{label}}, {{count}}', { count, label })}
+              aria-label={t('{{label}}, {{count}}', { count: card.count, label: card.label })}
               aria-pressed={isSelected}
-              data-test={`diagnostics-card-${severity ?? 'all'}`}
+              data-test={`diagnostics-card-${card.severity ?? 'all'}`}
               isClickable
               isCompact
               isSelected={isSelected}
-              onClick={() => onSeverityChange(severity)}
+              onClick={() => onSeverityChange(card.severity)}
               role="button"
             >
               <CardTitle>
                 <Split hasGutter>
                   <SplitItem>
-                    <Icon status={status}>
-                      <CardIcon />
+                    <Icon status={card.status}>
+                      <card.icon />
                     </Icon>
                   </SplitItem>
-                  <SplitItem>{label}</SplitItem>
+                  <SplitItem>{card.label}</SplitItem>
                 </Split>
               </CardTitle>
               <CardBody>
-                <span className="diagnostics-overview-cards__count">{count}</span>
+                <span className="diagnostics-overview-cards__count">{card.count}</span>
               </CardBody>
             </Card>
           </FlexItem>

--- a/src/views/virtualmachines/details/tabs/diagnostic/hooks/useDiagnosticConditionsTableColumns.ts
+++ b/src/views/virtualmachines/details/tabs/diagnostic/hooks/useDiagnosticConditionsTableColumns.ts
@@ -3,12 +3,12 @@ import useKubevirtUserSettingsTableColumns from '@kubevirt-utils/hooks/useKubevi
 import type { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 
 import type { DiagnosticColumn, DiagnosticSort } from '../utils/types';
-
-import useDiagnosticSort from './useDiagnosticSort';
+import useDiagnosticSort, { type GetSorting } from './useDiagnosticSort';
 
 type UseDiagnosticConditionsTableColumnsResult = {
   activeColumns: TableColumn<DiagnosticColumn>[];
   columns: TableColumn<DiagnosticColumn>[];
+  getSorting: GetSorting;
   loaded: boolean;
   sorting: DiagnosticSort;
 };
@@ -50,7 +50,7 @@ const useDiagnosticConditionsTableColumns = (): UseDiagnosticConditionsTableColu
     columns,
   });
 
-  return { activeColumns, columns, loaded, sorting: sort };
+  return { activeColumns, columns, getSorting, loaded, sorting: sort };
 };
 
 export default useDiagnosticConditionsTableColumns;

--- a/src/views/virtualmachines/details/tabs/diagnostic/hooks/useDiagnosticDataVolumeStatusTableColumns.ts
+++ b/src/views/virtualmachines/details/tabs/diagnostic/hooks/useDiagnosticDataVolumeStatusTableColumns.ts
@@ -4,12 +4,12 @@ import useKubevirtUserSettingsTableColumns from '@kubevirt-utils/hooks/useKubevi
 import type { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 
 import type { DiagnosticColumn, DiagnosticSort } from '../utils/types';
-
-import useDiagnosticSort from './useDiagnosticSort';
+import useDiagnosticSort, { type GetSorting } from './useDiagnosticSort';
 
 type UseDiagnosticDataVolumeStatusTableColumnsResult = {
   activeColumns: TableColumn<DiagnosticColumn>[];
   columns: TableColumn<DiagnosticColumn>[];
+  getSorting: GetSorting;
   sorting: DiagnosticSort;
 };
 
@@ -46,7 +46,7 @@ const useDiagnosticDataVolumeStatusTableColumns =
       columns,
     });
 
-    return { activeColumns, columns, sorting: sort };
+    return { activeColumns, columns, getSorting, sorting: sort };
   };
 
 export default useDiagnosticDataVolumeStatusTableColumns;

--- a/src/views/virtualmachines/details/tabs/diagnostic/hooks/useDiagnosticSort.ts
+++ b/src/views/virtualmachines/details/tabs/diagnostic/hooks/useDiagnosticSort.ts
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 
 import { type ThProps } from '@patternfly/react-table';
 
-type GetSorting = (column: string, columnIndex: number) => ThProps['sort'];
+export type GetSorting = (column: string, columnIndex: number) => ThProps['sort'];
 
 type UseDiagnosticSort = () => {
   getSorting: GetSorting;

--- a/src/views/virtualmachines/details/tabs/diagnostic/hooks/useDiagnosticVolumeStatusTableColumns.ts
+++ b/src/views/virtualmachines/details/tabs/diagnostic/hooks/useDiagnosticVolumeStatusTableColumns.ts
@@ -3,12 +3,12 @@ import useKubevirtUserSettingsTableColumns from '@kubevirt-utils/hooks/useKubevi
 import type { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
 
 import type { DiagnosticColumn, DiagnosticSort } from '../utils/types';
-
-import useDiagnosticSort from './useDiagnosticSort';
+import useDiagnosticSort, { type GetSorting } from './useDiagnosticSort';
 
 type UseDiagnosticVolumeStatusTableColumnsResult = {
   activeColumns: TableColumn<DiagnosticColumn>[];
   columns: TableColumn<DiagnosticColumn>[];
+  getSorting: GetSorting;
   sorting: DiagnosticSort;
 };
 
@@ -44,7 +44,7 @@ const useDiagnosticVolumeStatusTableColumns = (): UseDiagnosticVolumeStatusTable
     columns,
   });
 
-  return { activeColumns, columns, sorting: sort };
+  return { activeColumns, columns, getSorting, sorting: sort };
 };
 
 export default useDiagnosticVolumeStatusTableColumns;

--- a/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabConditions.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabConditions.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import Timestamp from '@kubevirt-utils/components/Timestamp/Timestamp';
@@ -12,9 +11,8 @@ import { Bullseye, Label } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import useDiagnosticConditionsTableColumns from '../hooks/useDiagnosticConditionsTableColumns';
-import { VirtualizationStatusCondition } from '../utils/types';
+import { type VirtualizationStatusCondition } from '../utils/types';
 import { getConditionLabel } from '../utils/utils';
-
 import VirtualMachineDiagnosticTabTableTitle from './components/VirtualMachineDiagnosticTabTableTitle';
 
 type VirtualMachineDiagnosticTabConditionsProps = {
@@ -25,7 +23,7 @@ const VirtualMachineDiagnosticTabConditions: FC<VirtualMachineDiagnosticTabCondi
   conditions,
 }) => {
   const { t } = useKubevirtTranslation();
-  const { activeColumns, loaded, sorting } = useDiagnosticConditionsTableColumns();
+  const { activeColumns, getSorting, loaded, sorting } = useDiagnosticConditionsTableColumns();
 
   const sortedData = useMemo(
     () => columnSorting(conditions, sorting?.direction, undefined, sorting?.column),
@@ -57,8 +55,8 @@ const VirtualMachineDiagnosticTabConditions: FC<VirtualMachineDiagnosticTabCondi
       <Table aria-label={t('Status conditions')}>
         <Thead>
           <Tr>
-            {activeColumns?.map(({ cell: { sort }, title }, index) => (
-              <Th key={title} modifier="nowrap" sort={sort(index)}>
+            {activeColumns?.map(({ id, title }, index) => (
+              <Th key={title} modifier="nowrap" sort={getSorting(id, index)}>
                 {title}
               </Th>
             ))}

--- a/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabDataVolumeStatus.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabDataVolumeStatus.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useNamespaceParam from '@kubevirt-utils/hooks/useNamespaceParam';
@@ -13,9 +12,8 @@ import { Label } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import useDiagnosticDataVolumeStatusTableColumns from '../hooks/useDiagnosticDataVolumeStatusTableColumns';
-import { VirtualizationDataVolumeStatus } from '../utils/types';
+import { type VirtualizationDataVolumeStatus } from '../utils/types';
 import { getPhaseLabel } from '../utils/utils';
-
 import VirtualMachineDiagnosticTabTableTitle from './components/VirtualMachineDiagnosticTabTableTitle';
 
 type VirtualMachineDiagnosticTabDataVolumeStatusProps = {
@@ -27,7 +25,7 @@ const VirtualMachineDiagnosticTabDataVolumeStatus: FC<
 > = ({ dataVolumesStatuses }) => {
   const { t } = useKubevirtTranslation();
   const namespace = useNamespaceParam();
-  const { activeColumns, sorting } = useDiagnosticDataVolumeStatusTableColumns();
+  const { activeColumns, getSorting, sorting } = useDiagnosticDataVolumeStatusTableColumns();
 
   const sortedData = useMemo(
     () => columnSorting(dataVolumesStatuses, sorting?.direction, undefined, sorting?.column),
@@ -49,8 +47,8 @@ const VirtualMachineDiagnosticTabDataVolumeStatus: FC<
       <Table aria-label={t('DataVolume status')}>
         <Thead>
           <Tr>
-            {activeColumns?.map(({ cell: { sort }, title }, index) => (
-              <Th key={title} sort={sort(index)}>
+            {activeColumns?.map(({ id, title }, index) => (
+              <Th key={title} sort={getSorting(id, index)}>
                 {title}
               </Th>
             ))}

--- a/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabVolumeStatus.tsx
+++ b/src/views/virtualmachines/details/tabs/diagnostic/tables/VirtualMachineDiagnosticTabVolumeStatus.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
@@ -10,9 +9,8 @@ import { Label } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
 import useDiagnosticVolumeStatusTableColumns from '../hooks/useDiagnosticVolumeStatusTableColumns';
-import { VirtualizationVolumeSnapshotStatus } from '../utils/types';
+import { type VirtualizationVolumeSnapshotStatus } from '../utils/types';
 import { getEnabledLabel } from '../utils/utils';
-
 import VirtualMachineDiagnosticTabTableTitle from './components/VirtualMachineDiagnosticTabTableTitle';
 
 type VirtualMachineDiagnosticTabVolumeStatusProps = {
@@ -23,7 +21,7 @@ const VirtualMachineDiagnosticTabVolumeStatus: FC<VirtualMachineDiagnosticTabVol
   volumeSnapshotStatuses,
 }) => {
   const { t } = useKubevirtTranslation();
-  const { activeColumns, sorting } = useDiagnosticVolumeStatusTableColumns();
+  const { activeColumns, getSorting, sorting } = useDiagnosticVolumeStatusTableColumns();
 
   const sortedData = useMemo(
     () => columnSorting(volumeSnapshotStatuses, sorting?.direction, undefined, sorting?.column),
@@ -47,8 +45,8 @@ const VirtualMachineDiagnosticTabVolumeStatus: FC<VirtualMachineDiagnosticTabVol
       <Table aria-label={t('Volume snapshot status')}>
         <Thead>
           <Tr>
-            {activeColumns?.map(({ cell: { sort }, title }, index) => (
-              <Th key={title} sort={sort(index)}>
+            {activeColumns?.map(({ id, title }, index) => (
+              <Th key={title} sort={getSorting(id, index)}>
                 {title}
               </Th>
             ))}

--- a/src/views/virtualmachines/details/tabs/diagnostic/utils/types.ts
+++ b/src/views/virtualmachines/details/tabs/diagnostic/utils/types.ts
@@ -1,27 +1,26 @@
-/* eslint-disable */
 import {
-  V1VirtualMachineCondition,
-  V1VolumeSnapshotStatus,
+  type V1VirtualMachineCondition,
+  type V1VolumeSnapshotStatus,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { ThProps } from '@patternfly/react-table';
+import { type ThProps } from '@patternfly/react-table';
 
 export type DiagnosticSeverity = 'critical' | 'healthy' | 'warning';
 
-export interface VirtualizationVolumeSnapshotStatus extends V1VolumeSnapshotStatus {
+export type VirtualizationVolumeSnapshotStatus = {
   id?: string;
   message?: string;
   metadata: { [key: string]: string };
   severity?: DiagnosticSeverity;
   status?: boolean;
-}
+} & V1VolumeSnapshotStatus;
 
-export interface VirtualizationStatusCondition extends V1VirtualMachineCondition {
+export type VirtualizationStatusCondition = {
   id?: string;
   lastTransitionTime?: string;
   message?: string;
   metadata: { [key: string]: string };
   severity?: DiagnosticSeverity;
-}
+} & V1VirtualMachineCondition;
 
 export type DiagnosticSort = {
   column: string;

--- a/src/views/virtualmachines/details/tabs/metrics/StorageCharts/StorageCharts.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/StorageCharts/StorageCharts.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import StorageIOPSTotalThresholdChart from '@kubevirt-utils/components/Charts/StorageUtil/StorageIOPSTotalThresholdChart';
 import StorageReadLatencyAvgMaxChart from '@kubevirt-utils/components/Charts/StorageUtil/StorageReadLatencyAvgMaxChart';
 import StorageReadLatencyPerDriveChart from '@kubevirt-utils/components/Charts/StorageUtil/StorageReadLatencyPerDriveChart';
@@ -32,17 +31,17 @@ const StorageCharts: FC<StorageChartsProps> = ({ prometheusUnavailable, vmi }) =
 
   return (
     <Grid hasGutter>
-      {STORAGE_CHART_COMPONENTS.map(({ Chart, titleKey }) => {
-        const title = t(titleKey);
+      {STORAGE_CHART_COMPONENTS.map((chartConfig) => {
+        const title = t(chartConfig.titleKey);
         return (
-          <GridItem key={titleKey} span={6}>
+          <GridItem key={chartConfig.titleKey} span={6}>
             {prometheusUnavailable ? (
               <NoDataMetricsCard title={title} />
             ) : (
               <Card>
                 <CardTitle>{title}</CardTitle>
                 <CardBody>
-                  <Chart vmi={vmi} />
+                  <chartConfig.Chart vmi={vmi} />
                 </CardBody>
               </Card>
             )}

--- a/src/views/virtualmachines/details/tabs/metrics/TimeRange/TimeRange.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/TimeRange/TimeRange.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 import { Link } from 'react-router';
 
 import DurationDropdown from '@kubevirt-utils/components/DurationOption/DurationDropdown';
@@ -25,8 +24,9 @@ const TimeRange: FC = () => {
   const virtualizationObservabilityLink = useVirtualizationObservabilityLink();
 
   const { duration, setDuration } = useDuration();
-  const onDurationSelect = (value: string) =>
+  const onDurationSelect = (value: string): void => {
     setDuration(DurationOption.fromDropdownLabel(value).toString());
+  };
 
   return (
     <div className="timerange--main">

--- a/src/views/virtualmachines/details/tabs/metrics/VirtualMachineMetricsTab.tsx
+++ b/src/views/virtualmachines/details/tabs/metrics/VirtualMachineMetricsTab.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useEffect, useState } from 'react';
+import React, { type FC, useEffect, useState } from 'react';
 import { useLocation } from 'react-router';
 
 import {
@@ -14,7 +13,7 @@ import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { Overview } from '@openshift-console/dynamic-plugin-sdk';
 import { Alert, AlertVariant, ExpandableSection, Title } from '@patternfly/react-core';
-import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
+import { type NavPageComponentProps } from '@virtualmachines/details/utils/types';
 
 import MigrationCharts from './MigrationCharts/MigrationCharts';
 import NetworkCharts from './NetworkCharts/NetworkCharts';
@@ -32,14 +31,16 @@ const VirtualMachineMetricsTab: FC<NavPageComponentProps> = ({ obj: vm }) => {
   const { mcoError, prometheusUnavailable } = usePrometheusAvailability(vm);
 
   const [expended, setExpended] = useState<{ [key in MetricsTabExpendedSections]: boolean }>({
-    [MetricsTabExpendedSections.migration]: true,
-    [MetricsTabExpendedSections.network]: true,
-    [MetricsTabExpendedSections.storage]: true,
-    [MetricsTabExpendedSections.utilization]: true,
+    [MetricsTabExpendedSections.Migration]: true,
+    [MetricsTabExpendedSections.Network]: true,
+    [MetricsTabExpendedSections.Storage]: true,
+    [MetricsTabExpendedSections.Utilization]: true,
   });
 
-  const onToggle = (value: MetricsTabExpendedSections) => () =>
-    setExpended((currentOpen) => ({ ...currentOpen, [value]: !currentOpen?.[value] }));
+  const onToggle =
+    (value: MetricsTabExpendedSections): (() => void) =>
+    () =>
+      setExpended((currentOpen) => ({ ...currentOpen, [value]: !currentOpen?.[value] }));
 
   useEffect(() => {
     if (!isEmpty(location?.search) && vmiLoaded) {
@@ -74,34 +75,34 @@ const VirtualMachineMetricsTab: FC<NavPageComponentProps> = ({ obj: vm }) => {
       {!prometheusUnavailable && <TimeRange />}
       <Overview className="virtual-machine-metrics-tab__charts">
         <ExpandableSection
-          id={MetricsTabExpendedSections.utilization}
-          isExpanded={expended?.[MetricsTabExpendedSections.utilization]}
-          onToggle={onToggle(MetricsTabExpendedSections.utilization)}
+          id={MetricsTabExpendedSections.Utilization}
+          isExpanded={expended?.[MetricsTabExpendedSections.Utilization]}
+          onToggle={onToggle(MetricsTabExpendedSections.Utilization)}
           toggleText={t('Utilization')}
         >
           <UtilizationCharts prometheusUnavailable={prometheusUnavailable} vmi={vmi} />
         </ExpandableSection>
 
         <ExpandableSection
-          id={MetricsTabExpendedSections.storage}
-          isExpanded={expended?.[MetricsTabExpendedSections.storage]}
-          onToggle={onToggle(MetricsTabExpendedSections.storage)}
+          id={MetricsTabExpendedSections.Storage}
+          isExpanded={expended?.[MetricsTabExpendedSections.Storage]}
+          onToggle={onToggle(MetricsTabExpendedSections.Storage)}
           toggleText={t('Storage')}
         >
           <StorageCharts prometheusUnavailable={prometheusUnavailable} vmi={vmi} />
         </ExpandableSection>
         <ExpandableSection
-          id={MetricsTabExpendedSections.network}
-          isExpanded={expended?.[MetricsTabExpendedSections.network]}
-          onToggle={onToggle(MetricsTabExpendedSections.network)}
+          id={MetricsTabExpendedSections.Network}
+          isExpanded={expended?.[MetricsTabExpendedSections.Network]}
+          onToggle={onToggle(MetricsTabExpendedSections.Network)}
           toggleText={t('Network')}
         >
           <NetworkCharts prometheusUnavailable={prometheusUnavailable} vmi={vmi} />
         </ExpandableSection>
         <ExpandableSection
-          id={MetricsTabExpendedSections.migration}
-          isExpanded={expended?.[MetricsTabExpendedSections.migration]}
-          onToggle={onToggle(MetricsTabExpendedSections.migration)}
+          id={MetricsTabExpendedSections.Migration}
+          isExpanded={expended?.[MetricsTabExpendedSections.Migration]}
+          onToggle={onToggle(MetricsTabExpendedSections.Migration)}
           toggleText={t('Migration')}
         >
           <MigrationCharts prometheusUnavailable={prometheusUnavailable} vmi={vmi} />

--- a/src/views/virtualmachines/details/tabs/metrics/utils/utils.ts
+++ b/src/views/virtualmachines/details/tabs/metrics/utils/utils.ts
@@ -1,11 +1,10 @@
-/* eslint-disable */
 import { ProgressVariant } from '@patternfly/react-core';
 
 export enum MetricsTabExpendedSections {
-  'migration' = 'migration',
-  'network' = 'network',
-  'storage' = 'storage',
-  'utilization' = 'utilization',
+  Migration = 'migration',
+  Network = 'network',
+  Storage = 'storage',
+  Utilization = 'utilization',
 }
 
 export const getMigrationProgressVariant = (

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachineStatusWithPopover/VirtualMachineStatusWithPopover.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachineStatusWithPopover/VirtualMachineStatusWithPopover.tsx
@@ -1,7 +1,9 @@
-/* eslint-disable */
-import React, { FC, ReactNode } from 'react';
+import React, { type FC, type ReactNode } from 'react';
 
-import { V1VirtualMachine, V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getVMStatus } from '@kubevirt-utils/resources/shared';
 import { printableVMStatus } from '@virtualmachines/utils';
 
@@ -9,11 +11,6 @@ import MigrationProgressPopover from './MigrationProgressPopover';
 import StatusPopoverButton from './StatusPopoverButton';
 import VirtualMachineOverviewStatus from './VirtualMachineOverviewStatus';
 import VirtualMachineProvisioningStatus from './VirtualMachineProvisioningStatus';
-
-const Popovers = {
-  [printableVMStatus.Migrating]: MigrationProgressPopover,
-  [printableVMStatus.Provisioning]: VirtualMachineProvisioningStatus,
-};
 
 type StatusWithPopoverProps = {
   children?: ReactNode;
@@ -23,15 +20,21 @@ type StatusWithPopoverProps = {
 
 const StatusWithPopover: FC<StatusWithPopoverProps> = ({ vm, vmi }) => {
   const vmPrintableStatus = getVMStatus(vm);
+  const statusButton = <StatusPopoverButton vmPrintableStatus={vmPrintableStatus} />;
 
-  const Popover: FC<StatusWithPopoverProps> =
-    Popovers[vmPrintableStatus] || VirtualMachineOverviewStatus;
+  // Different popovers take different props (vm vs vmi), so a status→component map
+  // is not type-safe under @typescript-eslint/no-unsafe-assignment.
+  if (vmPrintableStatus === printableVMStatus.Migrating) {
+    return <MigrationProgressPopover vmi={vmi}>{statusButton}</MigrationProgressPopover>;
+  }
 
-  return (
-    <Popover vm={vm} vmi={vmi}>
-      <StatusPopoverButton vmPrintableStatus={vmPrintableStatus} />
-    </Popover>
-  );
+  if (vmPrintableStatus === printableVMStatus.Provisioning) {
+    return (
+      <VirtualMachineProvisioningStatus vm={vm}>{statusButton}</VirtualMachineProvisioningStatus>
+    );
+  }
+
+  return <VirtualMachineOverviewStatus vm={vm}>{statusButton}</VirtualMachineOverviewStatus>;
 };
 
 export default StatusWithPopover;

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachineStatusWithPopover/utils.ts
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabDetails/components/VirtualMachineStatusWithPopover/utils.ts
@@ -1,4 +1,5 @@
-/* eslint-disable */
+import { type ComponentType } from 'react';
+
 import { vmimStatuses } from '@kubevirt-utils/resources/vmim/statuses';
 import {
   CheckCircleIcon,
@@ -10,7 +11,7 @@ import {
   UnknownIcon,
 } from '@patternfly/react-icons';
 
-export const getMigrationPhaseIcon = (phase: string) => {
+export const getMigrationPhaseIcon = (phase: string): ComponentType => {
   switch (phase) {
     case vmimStatuses.Running:
       return RunningIcon;

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabFilesystem/VirtualMachinesOverviewTabFilesystemTitle.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabFilesystem/VirtualMachinesOverviewTabFilesystemTitle.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type FC } from 'react';
 
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -7,7 +6,7 @@ import PopoverContentWithLightspeedButton from '@lightspeed/components/PopoverCo
 import { OLSPromptType } from '@lightspeed/utils/prompts';
 import { CardTitle, PopoverPosition } from '@patternfly/react-core';
 
-const VirtualMachinesOverviewTabFilesystemTitle = () => {
+const VirtualMachinesOverviewTabFilesystemTitle: FC = () => {
   const { t } = useKubevirtTranslation();
 
   return (

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabSnapshots/VirtualMachinesOverviewTabSnapshotsRow.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabSnapshots/VirtualMachinesOverviewTabSnapshotsRow.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, { type FC, useState } from 'react';
 
 import {
@@ -10,6 +9,7 @@ import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider
 import RestoreModal from '@kubevirt-utils/components/SnapshotModal/RestoreModal';
 import { timestampFor } from '@kubevirt-utils/components/Timestamp/utils/datetime';
 import KebabToggle from '@kubevirt-utils/components/toggles/KebabToggle';
+import useCurrentTime from '@kubevirt-utils/hooks/useCurrentTime';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   DescriptionList,
@@ -40,16 +40,19 @@ const VirtualMachinesOverviewTabSnapshotsRow: FC<VirtualMachinesOverviewTabSnaps
   const { t } = useKubevirtTranslation();
   const [isKebabOpen, setIsKebabOpen] = useState(false);
   const { createModal } = useModal();
+  const currentTime = useCurrentTime();
 
-  const timestamp = timestampFor(
+  const timestampValue = timestampFor(
     new Date(snapshot?.metadata?.creationTimestamp),
-    new Date(Date.now()),
+    new Date(currentTime),
     false,
-  ) as string;
+  );
+  const timestamp = typeof timestampValue === 'string' ? timestampValue : timestampValue.time;
 
-  const StatusIcon = icon[snapshot?.status?.phase];
+  const phase = snapshot?.status?.phase ?? '';
+  const StatusIcon = icon[phase];
 
-  const onToggle = () => setIsKebabOpen((prevIsOpen) => !prevIsOpen);
+  const onToggle = (): void => setIsKebabOpen((prevIsOpen) => !prevIsOpen);
 
   return (
     <Flex flexWrap={{ default: 'nowrap' }}>
@@ -70,7 +73,7 @@ const VirtualMachinesOverviewTabSnapshotsRow: FC<VirtualMachinesOverviewTabSnaps
                   descriptionData={
                     <>
                       <StatusIcon />
-                      <span className="pf-v6-u-ml-xs">{snapshot?.status?.phase}</span>
+                      <span className="pf-v6-u-ml-xs">{phase}</span>
                     </>
                   }
                   descriptionHeader={t('Status')}

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabSnapshots/component/SnapshotDeleteModal.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabSnapshots/component/SnapshotDeleteModal.tsx
@@ -1,15 +1,20 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type FC } from 'react';
 
 import { VirtualMachineSnapshotModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1beta1VirtualMachineSnapshot } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1beta1VirtualMachineSnapshot } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ConfirmActionMessage from '@kubevirt-utils/components/ConfirmActionMessage/ConfirmActionMessage';
 import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { kubevirtK8sDelete } from '@multicluster/k8sRequests';
 import { ButtonVariant } from '@patternfly/react-core';
 
-const SnapshotDeleteModal = ({ isOpen, onClose, snapshot }) => {
+type SnapshotDeleteModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  snapshot: V1beta1VirtualMachineSnapshot;
+};
+
+const SnapshotDeleteModal: FC<SnapshotDeleteModalProps> = ({ isOpen, onClose, snapshot }) => {
   const { t } = useKubevirtTranslation();
   return (
     <TabModal<V1beta1VirtualMachineSnapshot>

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabSnapshots/utils/snapshotStatus.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabSnapshots/utils/snapshotStatus.tsx
@@ -1,23 +1,25 @@
-/* eslint-disable */
+import { type ComponentType } from 'react';
+
 import {
   GreenCheckCircleIcon,
   RedExclamationCircleIcon,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { InProgressIcon, UnknownIcon } from '@patternfly/react-icons';
 
-const iconHandler = {
-  get: (mapper: typeof iconMapper, prop: string) => {
-    const icon = mapper[prop?.toLowerCase()];
-    if (icon) return icon;
-    return InProgressIcon;
-  },
-};
+type SnapshotStatusIcon = ComponentType<object>;
 
-const iconMapper: { [key: string]: any } = {
+const iconMapper: Record<string, SnapshotStatusIcon> = {
   error: RedExclamationCircleIcon,
   failed: RedExclamationCircleIcon,
   succeeded: GreenCheckCircleIcon,
   unknown: UnknownIcon,
 };
 
-export const icon = new Proxy<typeof iconMapper>(iconMapper, iconHandler);
+const iconHandler: ProxyHandler<Record<string, SnapshotStatusIcon>> = {
+  get: (mapper, prop: string): SnapshotStatusIcon => {
+    const icon = mapper[prop?.toLowerCase()];
+    return icon ?? InProgressIcon;
+  },
+};
+
+export const icon = new Proxy(iconMapper, iconHandler);

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/CPUUtil/CPUUtil.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/CPUUtil/CPUUtil.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import SubTitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/SubTitleChartLabel';
 import TitleChartLabel from '@kubevirt-utils/components/Charts/ChartLabels/TitleChartLabel';
 import ComponentReady from '@kubevirt-utils/components/Charts/ComponentReady/ComponentReady';
@@ -44,7 +43,7 @@ const CPUUtil: FC<CPUUtilProps> = ({ vmi }) => {
   const vmCPU = getCPU(vmi);
   const hasData = dataCPUUsage?.data?.result?.length > 0;
 
-  const cpuUsage = +(dataCPUUsage?.data?.result?.[0]?.value?.[1] || 0);
+  const cpuUsage = +(dataCPUUsage?.data?.result?.[0]?.value?.[1] ?? 0);
   const cpuUsageHumanized = humanizeCpuCores(cpuUsage);
 
   const cpuRequested = getVCPUCount(vmCPU);

--- a/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/TimeDropdown.tsx
+++ b/src/views/virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabUtilization/components/TimeDropdown.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import DurationDropdown from '@kubevirt-utils/components/DurationOption/DurationDropdown';
 import DurationOption from '@kubevirt-utils/components/DurationOption/DurationOption';
@@ -8,8 +7,9 @@ import useDuration from '@virtualmachines/details/tabs/metrics/hooks/useDuration
 const TimeDropdown: FC = () => {
   const { duration, setDuration } = useDuration();
 
-  const onDurationSelect = (value: string) =>
+  const onDurationSelect = (value: string): void => {
     setDuration(DurationOption.fromDropdownLabel(value).toString());
+  };
 
   return (
     <div>

--- a/src/views/virtualmachines/details/tabs/snapshots/SnapshotListPage.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/SnapshotListPage.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import SnapshotModal from '@kubevirt-utils/components/SnapshotModal/SnapshotModal';
@@ -9,10 +8,9 @@ import {
   ListPageCreateButton,
   ListPageHeader,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { NavPageComponentProps } from '@virtualmachines/details/utils/types';
+import { type NavPageComponentProps } from '@virtualmachines/details/utils/types';
 
 import { printableVMStatus } from '../../../utils';
-
 import SnapshotList from './components/list/SnapshotList';
 import useSnapshotData from './hooks/useSnapshotData';
 

--- a/src/views/virtualmachines/details/tabs/snapshots/components/IndicationLabel/IndicationLabel.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/IndicationLabel/IndicationLabel.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { Label, Tooltip } from '@patternfly/react-core';
 
@@ -13,7 +12,7 @@ type IndicationLabelProps = {
 
 const IndicationLabel: FC<IndicationLabelProps> = ({ indicationObject }) => (
   <Tooltip content={indicationObject.message}>
-    <Label status={INDICATOR_STATUSES[indicationObject.indication] || 'info'}>
+    <Label status={INDICATOR_STATUSES[indicationObject.indication] ?? 'info'}>
       {indicationObject.indication}
     </Label>
   </Tooltip>

--- a/src/views/virtualmachines/details/tabs/snapshots/components/IndicationLabel/IndicationLabelList.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/IndicationLabel/IndicationLabelList.tsx
@@ -1,12 +1,16 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type FC } from 'react';
 
+import { type V1beta1VirtualMachineSnapshot } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { LabelGroup } from '@patternfly/react-core';
 
 import IndicationLabel from './IndicationLabel';
 
-const IndicationLabelList = ({ snapshot }) => {
-  const indications = snapshot?.status?.sourceIndications || [];
+type IndicationLabelListProps = {
+  snapshot: V1beta1VirtualMachineSnapshot;
+};
+
+const IndicationLabelList: FC<IndicationLabelListProps> = ({ snapshot }) => {
+  const indications = snapshot?.status?.sourceIndications ?? [];
 
   if (indications.length === 0) {
     return <>-</>;

--- a/src/views/virtualmachines/details/tabs/snapshots/components/SnapshotStatusIcon/SnapshotStatusIcon.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/SnapshotStatusIcon/SnapshotStatusIcon.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { ColoredIconProps, StatusIconAndText } from '@openshift-console/dynamic-plugin-sdk';
+import { type ColoredIconProps, StatusIconAndText } from '@openshift-console/dynamic-plugin-sdk';
 
 import { iconMapper } from '../../utils/consts';
 
@@ -10,7 +9,7 @@ type SnapshotStatusIconProps = {
 };
 
 const SnapshotStatusIcon: FC<SnapshotStatusIconProps> = ({ phase }) => {
-  const StatusIcon: FC<ColoredIconProps> = iconMapper?.[phase] || iconMapper.default;
+  const StatusIcon: FC<ColoredIconProps> = iconMapper?.[phase] ?? iconMapper.default;
 
   return <StatusIconAndText icon={<StatusIcon />} title={phase} />;
 };

--- a/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotActionsMenu.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotActionsMenu.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import React, { FC, useCallback, useState } from 'react';
+import React, { type FC, useCallback, useState } from 'react';
 
 import { VirtualMachineCloneModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineSnapshotModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1beta1VirtualMachineSnapshot } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1beta1VirtualMachineSnapshot } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import CloneVMModal from '@kubevirt-utils/components/CloneVMModal/CloneVMModal';
 import ConfirmActionMessage from '@kubevirt-utils/components/ConfirmActionMessage/ConfirmActionMessage';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
@@ -84,7 +83,7 @@ const SnapshotActionsMenu: FC<SnapshotActionsMenuProps> = ({
     setIsDropdownOpen(false);
   }, [createModal, deleteLabel, snapshot, t]);
 
-  const onToggle = () => setIsDropdownOpen((prevIsOpen) => !prevIsOpen);
+  const onToggle = (): void => setIsDropdownOpen((prevIsOpen) => !prevIsOpen);
 
   return (
     <Dropdown

--- a/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotList.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/list/SnapshotList.tsx
@@ -1,18 +1,16 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 
 import KubevirtFilterToolbar from '@kubevirt-utils/components/KubevirtFilterToolbar/KubevirtFilterToolbar';
 import KubevirtTable from '@kubevirt-utils/components/KubevirtTable/KubevirtTable';
 import useKubevirtDataViewFilters from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/useKubevirtDataViewFilters';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
-import { UseSnapshotData } from '../../hooks/useSnapshotData';
+import { type UseSnapshotData } from '../../hooks/useSnapshotData';
 import { getSnapshotFilters } from '../../utils/filters';
-
 import {
   getSnapshotListColumns,
   getSnapshotRowId,
-  SnapshotListCallbacks,
+  type SnapshotListCallbacks,
 } from './snapshotListDefinition';
 
 type SnapshotsListProps = UseSnapshotData & { isVMRunning?: boolean };

--- a/src/views/virtualmachines/details/tabs/snapshots/components/list/snapshotListDefinition.tsx
+++ b/src/views/virtualmachines/details/tabs/snapshots/components/list/snapshotListDefinition.tsx
@@ -1,14 +1,13 @@
-/* eslint-disable */
-import React, { FC, ReactNode } from 'react';
-import { TFunction } from 'i18next';
+import React, { type FC, type ReactNode } from 'react';
+import { type TFunction } from 'i18next';
 
 import { VirtualMachineSnapshotModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import {
-  V1beta1VirtualMachineRestore,
-  V1beta1VirtualMachineSnapshot,
+  type V1beta1VirtualMachineRestore,
+  type V1beta1VirtualMachineSnapshot,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import Timestamp from '@kubevirt-utils/components/Timestamp/Timestamp';
-import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
+import { type ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { getName, getNamespace, getUID } from '@kubevirt-utils/resources/shared';
 import MulticlusterResourceLink from '@multicluster/components/MulticlusterResourceLink/MulticlusterResourceLink';
 import { getCluster } from '@multicluster/helpers/selectors';
@@ -16,7 +15,6 @@ import { getCluster } from '@multicluster/helpers/selectors';
 import { snapshotStatuses } from '../../utils/consts';
 import IndicationLabelList from '../IndicationLabel/IndicationLabelList';
 import SnapshotStatusIcon from '../SnapshotStatusIcon/SnapshotStatusIcon';
-
 import SnapshotActionsMenu from './SnapshotActionsMenu';
 
 export type SnapshotListCallbacks = {
@@ -57,8 +55,10 @@ const StatusCell: FC<SnapshotCellProps> = ({ row }) => (
 );
 
 const LastRestoredCell: FC<SnapshotCellProps> = ({ callbacks, row }) => {
-  const relevantRestore = callbacks?.restores?.[getName(row)];
-  return <Timestamp timestamp={relevantRestore?.status?.restoreTime} />;
+  const snapshotName = getName(row);
+  const relevantRestore = snapshotName ? callbacks?.restores?.[snapshotName] : undefined;
+  const restoreTime = relevantRestore?.status?.restoreTime;
+  return <Timestamp timestamp={restoreTime} />;
 };
 
 const renderActionsCell = (

--- a/src/views/virtualmachines/details/tabs/snapshots/hooks/useSnapshotData.ts
+++ b/src/views/virtualmachines/details/tabs/snapshots/hooks/useSnapshotData.ts
@@ -1,25 +1,26 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import { VirtualMachineRestoreModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { VirtualMachineSnapshotModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import {
-  V1beta1VirtualMachineRestore,
-  V1beta1VirtualMachineSnapshot,
-  V1VirtualMachine,
+  type V1beta1VirtualMachineRestore,
+  type V1beta1VirtualMachineSnapshot,
+  type V1VirtualMachine,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getCluster } from '@multicluster/helpers/selectors';
 import { useFleetK8sWatchResource } from '@stolostron/multicluster-sdk';
 
-import { getVmRestoreSnapshotName, getVmRestoreTime } from '../utils/selectors';
+import { buildRestoresMap } from '../utils/restoresMap';
 
 export type UseSnapshotData = {
-  error: any;
+  error: unknown;
   loaded: boolean;
-  restoresMap: any;
+  restoresMap: Record<string, V1beta1VirtualMachineRestore>;
   snapshots: V1beta1VirtualMachineSnapshot[];
 };
+
+type WatchResult<T> = [T | undefined, boolean, unknown];
 
 const useSnapshotData = (vm: V1VirtualMachine): UseSnapshotData => {
   const cluster = getCluster(vm);
@@ -38,7 +39,7 @@ const useSnapshotData = (vm: V1VirtualMachine): UseSnapshotData => {
     isList: true,
     namespace,
     namespaced: true,
-  });
+  }) as WatchResult<V1beta1VirtualMachineSnapshot[]>;
 
   const [restores, restoresLoaded, restoresError] = useFleetK8sWatchResource<
     V1beta1VirtualMachineRestore[]
@@ -48,36 +49,25 @@ const useSnapshotData = (vm: V1VirtualMachine): UseSnapshotData => {
     isList: true,
     namespace,
     namespaced: true,
-  });
+  }) as WatchResult<V1beta1VirtualMachineRestore[]>;
 
   const loaded = useMemo(
     () => snapshotsLoaded && restoresLoaded,
     [snapshotsLoaded, restoresLoaded],
   );
 
-  const error = useMemo(() => snapshotsError || restoresError, [snapshotsError, restoresError]);
+  const error = useMemo(() => snapshotsError ?? restoresError, [snapshotsError, restoresError]);
 
-  const restoresMap = useMemo(() => {
-    // we map each snapshot to its restores array
-    const tempMap = restores?.reduce((restoreMap, currentRestore) => {
-      const relevantRestore = restoreMap[getVmRestoreSnapshotName(currentRestore)];
-      if (
-        !relevantRestore ||
-        new Date(getVmRestoreTime(relevantRestore)).getTime() <
-          new Date(getVmRestoreTime(currentRestore)).getTime()
-      ) {
-        restoreMap[getVmRestoreSnapshotName(currentRestore)] = currentRestore;
-      }
-      return restoreMap;
-    }, {});
-    return tempMap;
-  }, [restores]);
+  const restoresMap = useMemo(
+    (): Record<string, V1beta1VirtualMachineRestore> => buildRestoresMap(restores),
+    [restores],
+  );
 
   return {
     error,
     loaded,
     restoresMap,
-    snapshots: snapshots?.filter((snapshot) => snapshot?.spec?.source?.name === vmName),
+    snapshots: (snapshots ?? []).filter((snapshot) => snapshot?.spec?.source?.name === vmName),
   };
 };
 

--- a/src/views/virtualmachines/details/tabs/snapshots/utils/consts.test.ts
+++ b/src/views/virtualmachines/details/tabs/snapshots/utils/consts.test.ts
@@ -1,7 +1,7 @@
-import { deadlineUnits } from './consts';
+import { DeadlineUnits } from './consts';
 
 /**
- * Regression tests for deadlineUnits enum.
+ * Regression tests for DeadlineUnits enum.
  * Milliseconds has been removed per KubeVirt snapshot API (only h, m, s are supported).
  * SnapshotModal and SnapshotDeadlineFormField rely on this enum for deadline unit options.
  */
@@ -12,16 +12,16 @@ describe('snapshots consts', () => {
     Seconds: 's',
   } as const;
 
-  describe('deadlineUnits', () => {
+  describe('DeadlineUnits', () => {
     it('should expose exactly Hours, Minutes and Seconds', () => {
-      const entries = Object.entries(deadlineUnits);
+      const entries = Object.entries(DeadlineUnits);
       expect(entries).toHaveLength(3);
-      expect(deadlineUnits).toEqual(EXPECTED_DEADLINE_UNITS);
+      expect(DeadlineUnits).toEqual(EXPECTED_DEADLINE_UNITS);
     });
 
     it('should not include Milliseconds (regression: do not re-add ms)', () => {
-      const keys = Object.keys(deadlineUnits);
-      const values = Object.values(deadlineUnits);
+      const keys = Object.keys(DeadlineUnits);
+      const values = Object.values(DeadlineUnits);
 
       expect(keys).not.toContain('Milliseconds');
       expect(values).not.toContain('ms');
@@ -29,7 +29,7 @@ describe('snapshots consts', () => {
 
     it.each(Object.entries(EXPECTED_DEADLINE_UNITS))(
       'should have %s value compatible with KubeVirt snapshot deadline format (%s)',
-      (key, value) => expect(deadlineUnits[key as keyof typeof deadlineUnits]).toBe(value),
+      (key, value) => expect(DeadlineUnits[key as keyof typeof DeadlineUnits]).toBe(value),
     );
   });
 });

--- a/src/views/virtualmachines/details/tabs/snapshots/utils/consts.ts
+++ b/src/views/virtualmachines/details/tabs/snapshots/utils/consts.ts
@@ -1,5 +1,7 @@
-/* eslint-disable */
+import { type FC } from 'react';
+
 import {
+  type ColoredIconProps,
   GreenCheckCircleIcon,
   RedExclamationCircleIcon,
   YellowExclamationTriangleIcon,
@@ -11,7 +13,7 @@ export const snapshotStatuses = {
   Succeeded: 'Succeeded',
 };
 
-export const iconMapper = {
+export const iconMapper: Record<string, FC<ColoredIconProps>> = {
   default: GreenCheckCircleIcon,
   Error: RedExclamationCircleIcon,
   Failed: RedExclamationCircleIcon,
@@ -21,7 +23,7 @@ export const iconMapper = {
 };
 
 // https://kubevirt.io/user-guide/operations/snapshot_restore_api/#snapshot-a-virtualmachine
-export enum deadlineUnits {
+export enum DeadlineUnits {
   Hours = 'h',
   Minutes = 'm',
   Seconds = 's',

--- a/src/views/virtualmachines/details/tabs/snapshots/utils/restoresMap.ts
+++ b/src/views/virtualmachines/details/tabs/snapshots/utils/restoresMap.ts
@@ -1,0 +1,45 @@
+import { type V1beta1VirtualMachineRestore } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+
+import { getVmRestoreSnapshotName, getVmRestoreTime } from './selectors';
+
+const isNewerRestore = (
+  currentRestore: V1beta1VirtualMachineRestore,
+  existingRestore: V1beta1VirtualMachineRestore | undefined,
+): boolean => {
+  if (!existingRestore) {
+    return true;
+  }
+
+  const currentRestoreTime = getVmRestoreTime(currentRestore);
+  const existingRestoreTime = getVmRestoreTime(existingRestore);
+
+  if (!existingRestoreTime && currentRestoreTime) {
+    return true;
+  }
+
+  if (!currentRestoreTime || !existingRestoreTime) {
+    return false;
+  }
+
+  return new Date(existingRestoreTime).getTime() < new Date(currentRestoreTime).getTime();
+};
+
+export const buildRestoresMap = (
+  restores: V1beta1VirtualMachineRestore[] | undefined,
+): Record<string, V1beta1VirtualMachineRestore> =>
+  (restores ?? []).reduce<Record<string, V1beta1VirtualMachineRestore>>(
+    (restoreMap, currentRestore) => {
+      const snapshotName = getVmRestoreSnapshotName(currentRestore);
+      if (!snapshotName) {
+        return restoreMap;
+      }
+
+      const existingRestore = restoreMap[snapshotName];
+      if (isNewerRestore(currentRestore, existingRestore)) {
+        restoreMap[snapshotName] = currentRestore;
+      }
+
+      return restoreMap;
+    },
+    {},
+  );

--- a/src/views/virtualmachines/details/tabs/snapshots/utils/selectors.ts
+++ b/src/views/virtualmachines/details/tabs/snapshots/utils/selectors.ts
@@ -1,8 +1,8 @@
-/* eslint-disable */
-import { V1beta1VirtualMachineRestore } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1beta1VirtualMachineRestore } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 
-export const getVmRestoreTime = (restore: V1beta1VirtualMachineRestore) =>
+export const getVmRestoreTime = (restore: V1beta1VirtualMachineRestore): string | undefined =>
   restore?.status?.restoreTime;
 
-export const getVmRestoreSnapshotName = (restore: V1beta1VirtualMachineRestore) =>
-  restore?.spec?.virtualMachineSnapshotName;
+export const getVmRestoreSnapshotName = (
+  restore: V1beta1VirtualMachineRestore,
+): string | undefined => restore?.spec?.virtualMachineSnapshotName;

--- a/src/views/virtualmachines/details/utils/utils.ts
+++ b/src/views/virtualmachines/details/utils/utils.ts
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
 import {
   getVirtualMachineDetailsTabLabel,
@@ -7,7 +6,15 @@ import {
   VirtualMachineDetailsTab,
 } from '@kubevirt-utils/constants/tabs-constants';
 
-export const getTabNameAndTitle = (tab: VirtualMachineDetailsTab, t: TFunction) => {
+export type TabNameAndTitle = {
+  name: VirtualMachineDetailsTab;
+  title: string | undefined;
+};
+
+export const getTabNameAndTitle = (
+  tab: VirtualMachineDetailsTab,
+  t: TFunction,
+): TabNameAndTitle => {
   const tabLabels = getVirtualMachineDetailsTabLabel(t);
   return {
     name: tab,
@@ -15,7 +22,10 @@ export const getTabNameAndTitle = (tab: VirtualMachineDetailsTab, t: TFunction) 
   };
 };
 
-export const getTabHrefAndName = (tab: VirtualMachineDetailsTab, t: TFunction) => {
+export const getTabHrefAndName = (
+  tab: VirtualMachineDetailsTab,
+  t: TFunction,
+): { href: string; name: string | undefined } => {
   const tabLabels = getVirtualMachineDetailsTabLabel(t);
 
   if (VirtualMachineConfigurationTabInner.has(tab)) {

--- a/src/views/virtualmachines/hooks/useAutoHideNavigation/useAutoHideNavigation.ts
+++ b/src/views/virtualmachines/hooks/useAutoHideNavigation/useAutoHideNavigation.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useEffect, useRef, useState } from 'react';
 
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
@@ -29,7 +28,7 @@ const useAutoHideNavigation = (): boolean => {
       userExpandedNavSignal.value = false;
     }
 
-    return () => {
+    return (): void => {
       userExpandedNavSignal.value = false;
       expandSidebar();
     };
@@ -43,13 +42,15 @@ const useAutoHideNavigation = (): boolean => {
       if (didCollapse) setWasCollapsed(true);
     });
 
-    return () => cancelAnimationFrame(frameId);
+    return (): void => {
+      cancelAnimationFrame(frameId);
+    };
   }, [settingEnabled, userOverrode]);
 
   useEffect(() => {
     if (!settingEnabled) return;
 
-    const handleNavToggleClick = () => {
+    const handleNavToggleClick = (): void => {
       requestAnimationFrame(() => {
         if (isSidebarOpen()) {
           userExpandedNavSignal.value = true;
@@ -60,7 +61,7 @@ const useAutoHideNavigation = (): boolean => {
     const navButton = getNavToggleButton();
     navButton?.addEventListener('click', handleNavToggleClick);
 
-    return () => {
+    return (): void => {
       navButton?.removeEventListener('click', handleNavToggleClick);
     };
   }, [settingEnabled]);

--- a/src/views/virtualmachines/hooks/useHideNamespaceBar.ts
+++ b/src/views/virtualmachines/hooks/useHideNamespaceBar.ts
@@ -1,16 +1,15 @@
-/* eslint-disable */
 import { useEffect } from 'react';
 
-export const useHideNamespaceBar = () => {
+export const useHideNamespaceBar = (): void => {
   useEffect(() => {
-    const namespaceBar = document.querySelector('.co-namespace-bar') as HTMLElement;
+    const namespaceBar = document.querySelector<HTMLElement>('.co-namespace-bar');
     const originalDisplay = namespaceBar ? namespaceBar.style.display : '';
 
     if (namespaceBar) {
       namespaceBar.style.display = 'none';
     }
 
-    return () => {
+    return (): void => {
       if (namespaceBar) {
         namespaceBar.style.display = originalDisplay;
       }

--- a/src/views/virtualmachines/list/components/FirstItemListPopover/FirstItemListPopover.tsx
+++ b/src/views/virtualmachines/list/components/FirstItemListPopover/FirstItemListPopover.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, ReactNode } from 'react';
+import React, { type FC, type ReactNode } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
@@ -11,7 +10,7 @@ import {
   Popover,
   PopoverPosition,
 } from '@patternfly/react-core';
-import { IpAddresses } from '@virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabNetworkInterfaces/utils/types';
+import { type IpAddresses } from '@virtualmachines/details/tabs/overview/components/VirtualMachinesOverviewTabNetworkInterfaces/utils/types';
 
 type FirstItemListPopoverProps = {
   className?: string;
@@ -21,8 +20,8 @@ type FirstItemListPopoverProps = {
 };
 
 const FirstItemListPopover: FC<FirstItemListPopoverProps> = ({
-  className,
-  headerContent,
+  className = '',
+  headerContent = '',
   includeCopyFirstItem,
   items,
 }) => {
@@ -40,7 +39,7 @@ const FirstItemListPopover: FC<FirstItemListPopoverProps> = ({
             {items?.[0]?.ip}
           </ClipboardCopy>
         ) : (
-          items?.[0]?.ip || NO_DATA_DASH
+          (items?.[0]?.ip ?? NO_DATA_DASH)
         )}
       </div>
       {items?.length > 1 && (
@@ -59,11 +58,6 @@ const FirstItemListPopover: FC<FirstItemListPopoverProps> = ({
       )}
     </div>
   );
-};
-
-FirstItemListPopover.defaultProps = {
-  className: '',
-  headerContent: '',
 };
 
 export default FirstItemListPopover;

--- a/src/views/virtualmachines/list/components/OverviewTab/OverviewTab.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/OverviewTab.tsx
@@ -1,25 +1,24 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 
 import { VirtualMachineModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { useClusterObservabilityDisabled } from '@kubevirt-utils/hooks/useAlerts/utils/useClusterObservabilityDisabled';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import useKubevirtWatchResource from '@kubevirt-utils/hooks/useKubevirtWatchResource/useKubevirtWatchResource';
 import useIsAllClustersPage from '@multicluster/hooks/useIsAllClustersPage';
 import useIsACMPage from '@multicluster/useIsACMPage';
-import { WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
+import { type WatchK8sResource } from '@openshift-console/dynamic-plugin-sdk';
 import { Alert, Bullseye, PageSection, Spinner, Stack } from '@patternfly/react-core';
 import { useSignals } from '@preact/signals-react/runtime';
-import { AdvancedSearchFilter, useHubClusterName } from '@stolostron/multicluster-sdk';
+import { type AdvancedSearchFilter, useHubClusterName } from '@stolostron/multicluster-sdk';
 import { useAccessibleResources } from '@virtualmachines/search/hooks/useAccessibleResources';
 import { OBJECTS_FETCHING_LIMIT } from '@virtualmachines/utils';
 
 import OverviewAlerts from './components/OverviewAlerts';
+import { determineOverviewLevel, getOverviewConfig } from './config';
 import { KubeVirtOverviewClusterCsvProvider } from './context/KubeVirtOverviewClusterCsvContext';
 import useFolderFilter from './hooks/useFolderFilter';
-import { determineOverviewLevel, getOverviewConfig } from './config';
-import { OVERVIEW_LEVEL_PROJECT, OverviewTabProps } from './types';
+import { OVERVIEW_LEVEL_PROJECT, type OverviewTabProps } from './types';
 
 const OverviewTab: FC<OverviewTabProps> = ({ cluster, namespace }) => {
   useSignals();
@@ -68,7 +67,7 @@ const OverviewTab: FC<OverviewTabProps> = ({ cluster, namespace }) => {
     resources: accessibleVms,
   } = useAccessibleResources<V1VirtualMachine>({
     groupVersionKind: VirtualMachineModelGroupVersionKind,
-    namespace: namespace || undefined,
+    namespace: namespace ?? undefined,
   });
 
   const vms = namespace ? watchedVms : accessibleVms;
@@ -136,13 +135,23 @@ const OverviewTab: FC<OverviewTabProps> = ({ cluster, namespace }) => {
           observabilityLoaded={observabilityLoaded}
         />
         {overviewLevel === OVERVIEW_LEVEL_PROJECT ? (
-          config.sections.map(({ Component, id, subHeader, title }) => (
-            <Component key={id} {...sectionData} subHeader={subHeader} title={title} />
+          config.sections.map((section) => (
+            <section.Component
+              key={section.id}
+              {...sectionData}
+              subHeader={section.subHeader}
+              title={section.title}
+            />
           ))
         ) : (
           <KubeVirtOverviewClusterCsvProvider cluster={cluster}>
-            {config.sections.map(({ Component, id, subHeader, title }) => (
-              <Component key={id} {...sectionData} subHeader={subHeader} title={title} />
+            {config.sections.map((section) => (
+              <section.Component
+                key={section.id}
+                {...sectionData}
+                subHeader={section.subHeader}
+                title={section.title}
+              />
             ))}
           </KubeVirtOverviewClusterCsvProvider>
         )}

--- a/src/views/virtualmachines/list/components/OverviewTab/components/NoVMsAlert.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/components/NoVMsAlert.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, { type FC, useMemo, useState } from 'react';
 import { Link } from 'react-router';
 
@@ -18,7 +17,7 @@ const NoVMsAlert: FC<NoVMsAlertProps> = ({ cluster, namespace }) => {
   const { t } = useKubevirtTranslation();
   const [dismissed, setDismissed] = useState(false);
   const isACMPage = useIsACMPage();
-  const selectedNamespace = namespace || DEFAULT_NAMESPACE;
+  const selectedNamespace = namespace ?? DEFAULT_NAMESPACE;
 
   const [canCreateVM, loading] = useAccessReview({
     group: VirtualMachineModel.apiGroup,

--- a/src/views/virtualmachines/list/components/OverviewTab/components/utils.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/components/utils.ts
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
 type SpokeClusterParams = {
   cluster?: string;
@@ -69,7 +68,7 @@ export const getShowObservabilityWarning = ({
   ((isAllClustersPage && disabledClusters.length > 0) ||
     (isSpokeCluster && disabledClusters.includes(cluster)));
 
-export const getAlertMessage = (canCreate: boolean, t: TFunction) =>
+export const getAlertMessage = (canCreate: boolean, t: TFunction): string =>
   canCreate
     ? t('Create your first virtual machine to begin monitoring health and performance metrics.')
     : t('Health and performance metrics will appear after virtual machines are available.');

--- a/src/views/virtualmachines/list/components/OverviewTab/hooks/useFolderFilter.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/hooks/useFolderFilter.ts
@@ -1,7 +1,6 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import useQuery from '@kubevirt-utils/hooks/useQuery';
 import { getLabel, getName } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -22,7 +21,7 @@ const useFolderFilter = (vms: undefined | V1VirtualMachine[]): UseFolderFilterRe
   );
 
   const filteredVMs = useMemo(() => {
-    if (isEmpty(folderNames) || !vms) return vms || [];
+    if (isEmpty(folderNames) || !vms) return vms ?? [];
     return vms.filter((vm) => folderNames.includes(getLabel(vm, VM_FOLDER_LABEL)));
   }, [vms, folderNames]);
 

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/ClusterStatusWidget/components/ClusterResourcesCard/ClusterResourcesCard.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/ClusterStatusWidget/components/ClusterResourcesCard/ClusterResourcesCard.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import AllClustersResourcesCard from './AllClustersResourcesCard';
 import SingleClusterResourcesCard from './SingleClusterResourcesCard';
@@ -22,7 +21,7 @@ const ClusterResourcesCard: FC<ClusterResourcesCardProps> = ({
   if (isAllClustersPage) {
     return (
       <AllClustersResourcesCard
-        clustersCount={clustersCount || 0}
+        clustersCount={clustersCount ?? 0}
         projectsCount={projectsCount}
         vmsCount={vmsCount}
       />

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/components/CrossClusterMigrationPlansWidget.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/components/CrossClusterMigrationPlansWidget.tsx
@@ -1,13 +1,12 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 
-import { V1beta1Plan } from '@forklift-ui/types';
+import { type V1beta1Plan } from '@forklift-ui/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { vmStatusIcon } from '@overview/OverviewTab/vm-statuses-card/utils/utils';
 import { Card, CardBody, CardHeader, CardTitle, Grid } from '@patternfly/react-core';
 
 import StatusCountItem from '../../shared/StatusCountItem';
 import ViewAllLink from '../../shared/ViewAllLink';
+import { getCrossClusterStatusItems } from '../utils/crossClusterStatusItems';
 import {
   buildPhaseFilterPath,
   CROSS_CLUSTER_FAILED_STATUSES,
@@ -42,6 +41,8 @@ const CrossClusterMigrationPlansWidget: FC<CrossClusterMigrationPlansWidgetProps
     [plansListPath],
   );
 
+  const statusItems = useMemo(() => getCrossClusterStatusItems(statusCounts, t), [statusCounts, t]);
+
   return (
     <Card className="cross-cluster-migration-plans-widget" isCompact>
       <CardHeader
@@ -54,26 +55,7 @@ const CrossClusterMigrationPlansWidget: FC<CrossClusterMigrationPlansWidgetProps
       </CardHeader>
       <CardBody>
         <Grid className="status-count-grid" hasGutter>
-          {[
-            {
-              count: statusCounts.failed,
-              icon: <vmStatusIcon.Error />,
-              key: 'failed',
-              label: t('Failed'),
-            },
-            {
-              count: statusCounts.running,
-              icon: <vmStatusIcon.Running />,
-              key: 'running',
-              label: t('Running'),
-            },
-            {
-              count: statusCounts.other,
-              icon: <vmStatusIcon.Other />,
-              key: 'other',
-              label: t('Other'),
-            },
-          ].map(({ count, icon, key, label }) => (
+          {statusItems.map(({ count, icon, key, label }) => (
             <StatusCountItem
               count={count}
               href={statusLinks[key]}

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/hooks/useMTVPlans.ts
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/hooks/useMTVPlans.ts
@@ -1,7 +1,6 @@
-/* eslint-disable */
 import { useEffect, useRef } from 'react';
 
-import { PlanModel, V1beta1Plan } from '@forklift-ui/types';
+import { PlanModel, type V1beta1Plan } from '@forklift-ui/types';
 import { logMTVDetected } from '@kubevirt-utils/extensions/telemetry/mtv';
 import { modelToGroupVersionKind } from '@kubevirt-utils/models';
 import { MTV_MIGRATION_NAMESPACE } from '@multicluster/components/CrossClusterMigration/constants';
@@ -14,6 +13,8 @@ type UseMTVPlansResult = {
   loadError: unknown;
   plans: V1beta1Plan[];
 };
+
+type WatchResult<T> = [T | undefined, boolean, unknown];
 
 const useMTVPlans = (): UseMTVPlansResult => {
   const [isMTVInstalled, isMTVInFlight] = useIsMTVInstalled();
@@ -34,7 +35,7 @@ const useMTVPlans = (): UseMTVPlansResult => {
           namespace: MTV_MIGRATION_NAMESPACE,
         }
       : null,
-  );
+  ) as WatchResult<V1beta1Plan[]>;
 
   return {
     isMTVInstalled,

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/utils/crossClusterStatusItems.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/MigrationsWidget/utils/crossClusterStatusItems.tsx
@@ -1,0 +1,37 @@
+import React, { type ReactNode } from 'react';
+import { type TFunction } from 'i18next';
+
+import { vmStatusIcon } from '@overview/OverviewTab/vm-statuses-card/utils/utils';
+
+import { type CrossClusterMigrationCounts } from './mtvPlanStatus';
+
+export type CrossClusterStatusItem = {
+  count: number;
+  icon: ReactNode;
+  key: 'failed' | 'other' | 'running';
+  label: string;
+};
+
+export const getCrossClusterStatusItems = (
+  statusCounts: CrossClusterMigrationCounts,
+  t: TFunction,
+): CrossClusterStatusItem[] => [
+  {
+    count: statusCounts.failed,
+    icon: <vmStatusIcon.Error />,
+    key: 'failed',
+    label: t('Failed'),
+  },
+  {
+    count: statusCounts.running,
+    icon: <vmStatusIcon.Running />,
+    key: 'running',
+    label: t('Running'),
+  },
+  {
+    count: statusCounts.other,
+    icon: <vmStatusIcon.Other />,
+    key: 'other',
+    label: t('Other'),
+  },
+];

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/OpenShiftVirtualizationWidget/OpenShiftVirtualizationWidget.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/OpenShiftVirtualizationWidget/OpenShiftVirtualizationWidget.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 
 import useInfrastructureAlerts from '@kubevirt-utils/hooks/useInfrastructureAlerts/useInfrastructureAlerts';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -8,7 +7,6 @@ import { healthStateMapping } from '@overview/OverviewTab/status-card/utils/util
 import { Card, CardBody, CardHeader, CardTitle, Skeleton } from '@patternfly/react-core';
 
 import { useKubeVirtOverviewClusterCsv } from '../../context/KubeVirtOverviewClusterCsvContext';
-
 import { getUpdateAvailableActions } from './getUpdateAvailableActions';
 import OpenShiftVirtualizationWidgetBody from './OpenShiftVirtualizationWidgetBody';
 import { useCNVHealth } from './useCNVHealth';
@@ -48,7 +46,7 @@ const OpenShiftVirtualizationWidget: FC<OpenShiftVirtualizationWidgetProps> = ({
   const version = installedCSV?.spec?.version;
   const statusIcon = healthStateMapping[healthState]?.icon;
   const healthMessages = getHealthStateToMessage(t);
-  const statusMessage = healthMessages[healthState] || healthMessages[HealthState.NOT_AVAILABLE];
+  const statusMessage = healthMessages[healthState] ?? healthMessages[HealthState.NOT_AVAILABLE];
 
   const isLoading = isAllClustersPage
     ? !healthLoaded
@@ -61,7 +59,7 @@ const OpenShiftVirtualizationWidget: FC<OpenShiftVirtualizationWidgetProps> = ({
     if (!csvLoaded) {
       return <Skeleton width="50%" />;
     }
-    return t('Installed version {{version}}', { version: version || t('Unknown') });
+    return t('Installed version {{version}}', { version: version ?? t('Unknown') });
   }, [isAllClustersPage, csvLoaded, version, t]);
 
   return (

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/ResourceAllocationWidget/components/ResourceAllocationSection/ResourceAllocationSection.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/ResourceAllocationWidget/components/ResourceAllocationSection/ResourceAllocationSection.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useMemo, useState } from 'react';
+import React, { type FC, useMemo, useState } from 'react';
 
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -10,7 +9,11 @@ import useMetricChartData from '@overview/OverviewTab/metric-charts-card/utils/h
 import { Bullseye, Card, CardBody } from '@patternfly/react-core';
 
 import { determineOverviewLevel } from '../../../../config';
-import { GRID_FOUR_EQUAL, OVERVIEW_LEVEL_PROJECT, OverviewSectionData } from '../../../../types';
+import {
+  GRID_FOUR_EQUAL,
+  OVERVIEW_LEVEL_PROJECT,
+  type OverviewSectionData,
+} from '../../../../types';
 import OverviewSection from '../../../OverviewSection/OverviewSection';
 import OverviewSectionRow from '../../../OverviewSection/OverviewSectionRow';
 import useProjectResourceQuota from '../../hooks/useProjectResourceQuota';
@@ -18,8 +21,7 @@ import { useTopClusterNames, useTopClustersChartData } from '../../hooks/useTopC
 import ResourceAllocationWidget from '../../ResourceAllocationWidget';
 import ClusterLegend from '../ResourceAllocationChart/ClusterLegend';
 import ResourceAllocationSubHeader from '../ResourceAllocationSubHeader/ResourceAllocationSubHeader';
-
-import { getWidgetConfigs, WidgetDataMap } from './resourceAllocationSectionConfig';
+import { getWidgetConfigs, type WidgetDataMap } from './resourceAllocationSectionConfig';
 
 const ResourceAllocationSection: FC<OverviewSectionData> = ({
   metricsUnavailable,
@@ -128,7 +130,11 @@ const ResourceAllocationSection: FC<OverviewSectionData> = ({
         gridColumns={GRID_FOUR_EQUAL}
       >
         {widgetConfigs.map(({ graphTitle, metric, subtitle, title: widgetTitle }) => {
-          const { clusterData, metricChartData, quotaData } = dataMap[metric];
+          const widgetData = dataMap[metric];
+          if (!widgetData) {
+            return null;
+          }
+          const { clusterData, metricChartData, quotaData } = widgetData;
           return (
             <ResourceAllocationWidget
               clusterData={isAllClusters ? clusterData : undefined}

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/StorageMigrationPlansWidget.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/StorageMigrationPlansWidget/StorageMigrationPlansWidget.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, type ReactNode, useMemo } from 'react';
 
 import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -19,7 +18,6 @@ import { PendingIcon } from '@patternfly/react-icons';
 
 import StatusCountItem, { getLinkProps } from '../shared/StatusCountItem';
 import ViewAllLink from '../shared/ViewAllLink';
-
 import useStorageMigrationNavigation from './useStorageMigrationNavigation';
 import useStorageMigrationOverviewData from './useStorageMigrationOverviewData';
 import { getStorageMigrationStatusCounts } from './utils';
@@ -45,7 +43,7 @@ const StorageMigrationPlansWidget: FC<StorageMigrationPlansWidgetProps> = ({ clu
     [storageMigPlans],
   );
 
-  const headerActions = (() => {
+  const headerActions = ((): ReactNode => {
     if (storageMigAPI === STORAGE_MIGRATION_API.NONE) {
       return null;
     }
@@ -64,7 +62,7 @@ const StorageMigrationPlansWidget: FC<StorageMigrationPlansWidgetProps> = ({ clu
     );
   })();
 
-  const cardBodyContent = (() => {
+  const cardBodyContent = ((): ReactNode => {
     if (loadError) {
       return <ErrorAlert error={loadError} />;
     }

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/VirtualMachinesHealthWidget/components/VMAlerts.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/VirtualMachinesHealthWidget/components/VMAlerts.tsx
@@ -1,12 +1,10 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Alert, Flex } from '@patternfly/react-core';
 
 import useVMAlerts from '../hooks/useVMAlerts';
-import { getSeverityUrls, VMAlertsProps } from '../utils/vmAlerts';
-
+import { getSeverityUrls, type VMAlertsProps } from '../utils/vmAlerts';
 import TotalAlertCount from './TotalAlertCount';
 import VMAlertsCard from './VMAlertsCard';
 import VMAlertSeverityCounts from './VMAlertSeverityCounts';
@@ -17,8 +15,8 @@ const VMAlerts: FC<VMAlertsProps> = ({ alertsBaseHref, alertsBasePath, vmNames }
   const totalAlerts = critical + warning + info;
   const isLoading = !loaded;
 
-  const isExternal = !alertsBasePath && !!alertsBaseHref;
-  const baseUrl = alertsBasePath || alertsBaseHref;
+  const isExternal = alertsBasePath == null && alertsBaseHref != null;
+  const baseUrl = alertsBasePath ?? alertsBaseHref;
 
   const severityUrls = useMemo(() => getSeverityUrls(baseUrl), [baseUrl]);
 

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/VirtualMachinesHealthWidget/components/VMAlertsCard.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/VirtualMachinesHealthWidget/components/VMAlertsCard.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, PropsWithChildren, ReactNode } from 'react';
+import React, { type FC, type PropsWithChildren, type ReactNode } from 'react';
 
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -7,7 +6,7 @@ import { getNoDataAvailableMessage } from '@kubevirt-utils/utils/utils';
 import { Bullseye, Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
 
 import ViewAllLink from '../../shared/ViewAllLink';
-import { VMAlertsProps } from '../utils/vmAlerts';
+import { type VMAlertsProps } from '../utils/vmAlerts';
 
 import './health-card.scss';
 import './VMAlerts.scss';
@@ -25,13 +24,13 @@ const VMAlertsCard: FC<VMAlertsCardProps> = ({
   titleExtra,
 }) => {
   const { t } = useKubevirtTranslation();
-  const baseUrl = alertsBasePath || alertsBaseHref;
+  const baseUrl = alertsBasePath ?? alertsBaseHref;
 
   return (
     <Card className="vm-alerts health-card" data-test="vm-alerts-widget" isCompact>
       <CardHeader
         actions={
-          baseUrl
+          baseUrl != null
             ? {
                 actions: <ViewAllLink href={alertsBaseHref} linkPath={alertsBasePath} />,
                 hasNoOffset: false,

--- a/src/views/virtualmachines/list/components/OverviewTab/widgets/shared/ViewAllLink.tsx
+++ b/src/views/virtualmachines/list/components/OverviewTab/widgets/shared/ViewAllLink.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { AnchorHTMLAttributes, FC, useMemo } from 'react';
+import React, { type AnchorHTMLAttributes, type FC, type JSX, useMemo } from 'react';
 import { Link } from 'react-router';
 
 import ExternalLink from '@kubevirt-utils/components/ExternalLink/ExternalLink';
@@ -31,7 +30,9 @@ const ViewAllLink: FC<ViewAllLinkProps> = ({
   const LinkComponent = useMemo(
     () =>
       linkPath
-        ? (props: AnchorHTMLAttributes<HTMLAnchorElement>) => <Link {...props} to={linkPath} />
+        ? (props: AnchorHTMLAttributes<HTMLAnchorElement>): JSX.Element => (
+            <Link {...props} to={linkPath} />
+          )
         : undefined,
     [linkPath],
   );

--- a/src/views/virtualmachines/list/components/VMStatusConditionLabel/VMStatusConditionLabel.tsx
+++ b/src/views/virtualmachines/list/components/VMStatusConditionLabel/VMStatusConditionLabel.tsx
@@ -1,14 +1,13 @@
-/* eslint-disable */
-import React, { FC, memo } from 'react';
+import React, { type FC, memo } from 'react';
 
-import { V1VirtualMachineCondition } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachineCondition } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { Label, LabelGroup, Popover, PopoverPosition } from '@patternfly/react-core';
 
 export const VMStatusConditionLabel: FC<V1VirtualMachineCondition> = memo((condition) => {
   const bodyContentMessage = condition?.message ?? condition?.reason;
 
   const InnerLabel = (
-    <Label color="grey" onClick={bodyContentMessage ? (e) => e.preventDefault() : undefined}>
+    <Label color="grey" onClick={bodyContentMessage ? (e): void => e.preventDefault() : undefined}>
       {condition?.type}={condition?.status}
     </Label>
   );

--- a/src/views/virtualmachines/list/components/VirtualMachineRow/utils/utils.ts
+++ b/src/views/virtualmachines/list/components/VirtualMachineRow/utils/utils.ts
@@ -1,17 +1,16 @@
-/* eslint-disable */
 import {
-  V1VirtualMachine,
-  V1VirtualMachineCondition,
+  type V1VirtualMachine,
+  type V1VirtualMachineCondition,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { isLiveMigratable } from '@virtualmachines/utils';
 
-const isLiveMigratableCondition = (condition: V1VirtualMachineCondition) =>
+const isLiveMigratableCondition = (condition: V1VirtualMachineCondition): boolean =>
   condition?.type === 'LiveMigratable' && condition?.status === 'True';
 
-const isNotLiveMigratableCondition = (condition: V1VirtualMachineCondition) =>
+const isNotLiveMigratableCondition = (condition: V1VirtualMachineCondition): boolean =>
   condition?.type === 'LiveMigratable' && condition?.status === 'False';
 
-const isLiveMigratableType = (condition: V1VirtualMachineCondition) =>
+const isLiveMigratableType = (condition: V1VirtualMachineCondition): boolean =>
   condition?.type === 'LiveMigratable';
 
 export const filterConditions = (vm: V1VirtualMachine): V1VirtualMachineCondition[] => {

--- a/src/views/virtualmachines/list/filters/getCPUFilter.ts
+++ b/src/views/virtualmachines/list/filters/getCPUFilter.ts
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
-  KubevirtFilter,
+  type KubevirtFilter,
   KubevirtFilterLayout,
 } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { getInstanceTypeCPU } from '@kubevirt-utils/resources/instancetype/selectors';
@@ -14,8 +13,8 @@ import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
 import {
   getInstanceTypeFromMapper,
   getVMIFromMapper,
-  InstanceTypeMapper,
-  VMIMapper,
+  type InstanceTypeMapper,
+  type VMIMapper,
 } from '@virtualmachines/utils/mappers';
 
 import { getOperatorChipLabel } from './utils';
@@ -29,7 +28,7 @@ export const getCPUFilter = (
   filterLayout: KubevirtFilterLayout.HIDDEN,
   getChipLabel: getOperatorChipLabel,
   id: VirtualMachineRowFilterType.CPU,
-  match: (obj, selected) => {
+  match: (obj, selected): boolean => {
     const cpuInfo = selected[0];
     if (!cpuInfo) return true;
 
@@ -37,7 +36,7 @@ export const getCPUFilter = (
     const [operator, cpu] = cpuInfo.split(' ');
     const filterCPU = Number(cpu);
 
-    const cpuSpec = getCPU(obj) || getCPU(vmi);
+    const cpuSpec = getCPU(obj) ?? getCPU(vmi);
     const vmCPU = cpuSpec
       ? vCPUCount(cpuSpec)
       : getInstanceTypeCPU(getInstanceTypeFromMapper(instanceTypeMapper, obj));

--- a/src/views/virtualmachines/list/filters/getDateFilter.ts
+++ b/src/views/virtualmachines/list/filters/getDateFilter.ts
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
-  KubevirtFilter,
+  type KubevirtFilter,
   KubevirtFilterLayout,
 } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { getCreationTimestamp } from '@kubevirt-utils/resources/shared';
@@ -14,9 +13,9 @@ import {
 } from '@search/components/AdvancedSearchModal/constants/dateSelect';
 import {
   FROM_PREFIX,
-  TO_PREFIX,
   getDateCreatedChipLabel,
   resolveDateCreatedValue,
+  TO_PREFIX,
 } from '@search/utils/dateCreatedValues';
 import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
 
@@ -26,7 +25,8 @@ enum DATE_VARIANT {
 }
 
 const getMatchDateFunction =
-  (variant: DATE_VARIANT) => (obj: V1VirtualMachine, selected: string[]) => {
+  (variant: DATE_VARIANT) =>
+  (obj: V1VirtualMachine, selected: string[]): boolean => {
     const dateString = selected[0];
     if (!dateString) return true;
     const dateCreatedString = getCreationTimestamp(obj);
@@ -46,7 +46,7 @@ export const getDateCreatedFilter = (t: TFunction): KubevirtFilter<V1VirtualMach
     filterLayout: KubevirtFilterLayout.HIDDEN,
     getChipLabel: (value) => getDateCreatedChipLabel(value, t),
     id: VirtualMachineRowFilterType.DateCreated,
-    match: (obj, selected) => {
+    match: (obj, selected): boolean => {
       const value = selected[0];
       if (!value) return true;
 

--- a/src/views/virtualmachines/list/filters/getDescriptionFilter.ts
+++ b/src/views/virtualmachines/list/filters/getDescriptionFilter.ts
@@ -1,20 +1,19 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { fuzzyCaseInsensitive } from '@kubevirt-utils/utils/utils';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
-  KubevirtFilter,
+  type KubevirtFilter,
   KubevirtFilterLayout,
 } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { getDescription } from '@kubevirt-utils/resources/shared';
+import { fuzzyCaseInsensitive } from '@kubevirt-utils/utils/utils';
 import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
 
 export const getDescriptionFilter = (t: TFunction): KubevirtFilter<V1VirtualMachine> => ({
   categoryLabel: t('Description'),
   filterLayout: KubevirtFilterLayout.HIDDEN,
   id: VirtualMachineRowFilterType.Description,
-  match: (obj, selected) => {
+  match: (obj, selected): boolean => {
     const search = selected[0];
     if (!search) return true;
     return fuzzyCaseInsensitive(search, getDescription(obj) ?? '');

--- a/src/views/virtualmachines/list/filters/getGroupFilter.ts
+++ b/src/views/virtualmachines/list/filters/getGroupFilter.ts
@@ -1,20 +1,19 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
-  KubevirtFilter,
+  type KubevirtFilter,
   KubevirtFilterLayout,
 } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { getLabel } from '@kubevirt-utils/resources/shared';
-import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
 import { VM_FOLDER_LABEL } from '@virtualmachines/tree/utils/constants';
+import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
 
 export const getGroupFilter = (t: TFunction): KubevirtFilter<V1VirtualMachine> => ({
   categoryLabel: t('Group'),
   filterLayout: KubevirtFilterLayout.HIDDEN,
   id: VirtualMachineRowFilterType.Group,
-  match: (obj, selected) => {
+  match: (obj, selected): boolean => {
     const folder = getLabel(obj, VM_FOLDER_LABEL);
     return selected.includes(folder);
   },

--- a/src/views/virtualmachines/list/filters/getIPFilter.ts
+++ b/src/views/virtualmachines/list/filters/getIPFilter.ts
@@ -1,14 +1,13 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
-  KubevirtFilter,
+  type KubevirtFilter,
   KubevirtFilterLayout,
 } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { getVMIIPAddresses } from '@kubevirt-utils/resources/vmi';
 import { compareCIDR, VirtualMachineRowFilterType } from '@virtualmachines/utils';
-import { getVMIFromMapper, VMIMapper } from '@virtualmachines/utils/mappers';
+import { getVMIFromMapper, type VMIMapper } from '@virtualmachines/utils/mappers';
 
 export const getIPFilter = (
   t: TFunction,
@@ -17,7 +16,7 @@ export const getIPFilter = (
   categoryLabel: t('IP Address'),
   filterLayout: KubevirtFilterLayout.HIDDEN,
   id: VirtualMachineRowFilterType.IP,
-  match: (obj, selected) => {
+  match: (obj, selected): boolean => {
     const search = selected[0];
     if (!search) return true;
 

--- a/src/views/virtualmachines/list/filters/getMemoryFilter.ts
+++ b/src/views/virtualmachines/list/filters/getMemoryFilter.ts
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
-  KubevirtFilter,
+  type KubevirtFilter,
   KubevirtFilterLayout,
 } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { getInstanceTypeMemory } from '@kubevirt-utils/resources/instancetype/selectors';
@@ -14,8 +13,8 @@ import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
 import {
   getInstanceTypeFromMapper,
   getVMIFromMapper,
-  InstanceTypeMapper,
-  VMIMapper,
+  type InstanceTypeMapper,
+  type VMIMapper,
 } from '@virtualmachines/utils/mappers';
 
 import { getOperatorChipLabel } from './utils';
@@ -29,7 +28,7 @@ export const getMemoryFilter = (
   filterLayout: KubevirtFilterLayout.HIDDEN,
   getChipLabel: getOperatorChipLabel,
   id: VirtualMachineRowFilterType.Memory,
-  match: (obj, selected) => {
+  match: (obj, selected): boolean => {
     const memoryInfo = selected[0];
     if (!memoryInfo) return true;
 
@@ -37,8 +36,8 @@ export const getMemoryFilter = (
     const [operator, memoryFilterValue, memoryFilterUnit] = memoryInfo.split(' ');
     const filterBytes = convertToBaseValue(`${memoryFilterValue} ${memoryFilterUnit.slice(0, -1)}`);
     const vmMemory =
-      getMemory(obj) ||
-      getMemory(vmi) ||
+      getMemory(obj) ??
+      getMemory(vmi) ??
       getInstanceTypeMemory(getInstanceTypeFromMapper(instanceTypeMapper, obj))?.toString();
     const vmBytes = convertToBaseValue(vmMemory);
     return numberOperatorInfo[operator].compareFunction(vmBytes, filterBytes);

--- a/src/views/virtualmachines/list/filters/getNADsFilter.ts
+++ b/src/views/virtualmachines/list/filters/getNADsFilter.ts
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
-  KubevirtFilter,
+  type KubevirtFilter,
   KubevirtFilterLayout,
 } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
@@ -14,7 +13,7 @@ export const getNADsFilter = (t: TFunction): KubevirtFilter<V1VirtualMachine> =>
   categoryLabel: t('NADs'),
   filterLayout: KubevirtFilterLayout.HIDDEN,
   id: VirtualMachineRowFilterType.NAD,
-  match: (obj, selected) => {
+  match: (obj, selected): boolean => {
     const networkNames = getNetworks(obj)
       ?.map((network) => network.multus?.networkName)
       .filter(Boolean)

--- a/src/views/virtualmachines/list/filters/getStatusFilter.ts
+++ b/src/views/virtualmachines/list/filters/getStatusFilter.ts
@@ -1,9 +1,8 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
-  KubevirtFilter,
+  type KubevirtFilter,
   KubevirtFilterLayout,
 } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { getVMStatus } from '@kubevirt-utils/resources/shared';
@@ -19,7 +18,7 @@ export const getStatusFilter = (t: TFunction): KubevirtFilter<V1VirtualMachine> 
   categoryLabel: t('Status'),
   filterLayout: KubevirtFilterLayout.SELECT,
   id: VirtualMachineRowFilterType.Status,
-  match: (obj, selected) => {
+  match: (obj, selected): boolean => {
     const status = getVMStatus(obj);
     const isError = selected.includes(ERROR_STATUS) && isErrorPrintableStatus(status);
     return selected.includes(status) || isError;

--- a/src/views/virtualmachines/list/filters/useNodeFilter.ts
+++ b/src/views/virtualmachines/list/filters/useNodeFilter.ts
@@ -1,15 +1,15 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
-  KubevirtFilter,
+  type KubevirtFilter,
   KubevirtFilterLayout,
 } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getVMINodeName } from '@kubevirt-utils/resources/vmi';
 import { VirtualMachineRowFilterType } from '@virtualmachines/utils';
-import { getVMIFromMapper, VMIMapper } from '@virtualmachines/utils/mappers';
+import { getVMIFromMapper, type VMIMapper } from '@virtualmachines/utils/mappers';
+
 import { getNodes } from './utils';
 
 const useNodeFilter = (vmiMapper: VMIMapper): KubevirtFilter<V1VirtualMachine> => {
@@ -25,7 +25,7 @@ const useNodeFilter = (vmiMapper: VMIMapper): KubevirtFilter<V1VirtualMachine> =
       categoryLabel: t('Node'),
       filterLayout: KubevirtFilterLayout.SELECT,
       id: VirtualMachineRowFilterType.Node,
-      match: (obj: V1VirtualMachine, selected: string[]) => {
+      match: (obj: V1VirtualMachine, selected: string[]): boolean => {
         const nodeName = getVMINodeName(getVMIFromMapper(vmiMapper, obj));
         return selected.includes(nodeName);
       },

--- a/src/views/virtualmachines/list/hooks/useVirtualMachineInstanceMapper.ts
+++ b/src/views/virtualmachines/list/hooks/useVirtualMachineInstanceMapper.ts
@@ -1,13 +1,17 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import { VirtualMachineInstanceModelGroupVersionKind } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getClusterKey } from '@kubevirt-utils/resources/shared';
 import { useAccessibleResources } from '@virtualmachines/search/hooks/useAccessibleResources';
-import { VMIMapper } from '@virtualmachines/utils/mappers';
+import { type VMIMapper } from '@virtualmachines/utils/mappers';
 
-export const useVirtualMachineInstanceMapper = () => {
+type UseVirtualMachineInstanceMapperResult = {
+  vmiMapper: VMIMapper;
+  vmisLoaded: boolean;
+};
+
+export const useVirtualMachineInstanceMapper = (): UseVirtualMachineInstanceMapperResult => {
   const { loaded: vmisLoaded, resources: vmis } = useAccessibleResources<V1VirtualMachineInstance>({
     groupVersionKind: VirtualMachineInstanceModelGroupVersionKind,
   });

--- a/src/views/virtualmachines/list/hooks/utils.ts
+++ b/src/views/virtualmachines/list/hooks/utils.ts
@@ -1,22 +1,21 @@
-/* eslint-disable */
 import { VirtualMachineInstanceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1Pod } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1Pod } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon, type OwnerReference } from '@openshift-console/dynamic-plugin-sdk';
 
 import { VMListQueries } from './constants';
 
-const getVMIOwner = (resource: K8sResourceCommon) =>
+const getVMIOwner = (resource: K8sResourceCommon): OwnerReference | undefined =>
   resource?.metadata?.ownerReferences?.find(
     (owner) => owner.kind === VirtualMachineInstanceModel.kind,
   );
 
-export const getVMNamesFromPodsNames = (pods: IoK8sApiCoreV1Pod[]) => {
-  return pods?.reduce((acc, pod) => {
+export const getVMNamesFromPodsNames = (pods: IoK8sApiCoreV1Pod[]): Record<string, string> => {
+  return pods?.reduce<Record<string, string>>((acc, pod) => {
     const vmiOwner = getVMIOwner(pod);
 
-    if (!vmiOwner) return acc;
+    if (!vmiOwner?.name) return acc;
 
     acc[`${getNamespace(pod)}-${getName(pod)}`] = vmiOwner.name;
 
@@ -24,7 +23,10 @@ export const getVMNamesFromPodsNames = (pods: IoK8sApiCoreV1Pod[]) => {
   }, {});
 };
 
-export const getVMListQueries = (namespaces: string[], clusters?: string[]) => {
+export const getVMListQueries = (
+  namespaces: string[],
+  clusters?: string[],
+): Record<string, string> => {
   const namespacesFilter = isEmpty(namespaces) ? '' : `namespace=~'${namespaces.join('|')}'`;
 
   const clustersFilter = isEmpty(clusters) ? '' : `cluster=~'${clusters.join('|')}'`;

--- a/src/views/virtualmachines/list/listPageBodySize.ts
+++ b/src/views/virtualmachines/list/listPageBodySize.ts
@@ -1,12 +1,11 @@
-/* eslint-disable */
 export enum ListPageBodySize {
-  lg = 'lg',
-  md = 'md',
-  sm = 'sm',
+  Lg = 'lg',
+  Md = 'md',
+  Sm = 'sm',
 }
 
-export const getListPageBodySize = (width: number) => {
-  if (width < 660) return ListPageBodySize.sm;
-  if (width < 1100) return ListPageBodySize.md;
-  return ListPageBodySize.lg;
+export const getListPageBodySize = (width: number): ListPageBodySize => {
+  if (width < 660) return ListPageBodySize.Sm;
+  if (width < 1100) return ListPageBodySize.Md;
+  return ListPageBodySize.Lg;
 };

--- a/src/views/virtualmachines/list/selectedVMs.ts
+++ b/src/views/virtualmachines/list/selectedVMs.ts
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
@@ -7,14 +6,14 @@ import { signal } from '@preact/signals-core';
 
 export const selectedVMs = signal<{ cluster?: string; name: string; namespace: string }[]>([]);
 
-export const selectVM = (vm: V1VirtualMachine) => {
+export const selectVM = (vm: V1VirtualMachine): void => {
   const vmIdentifier = { cluster: getCluster(vm), name: getName(vm), namespace: getNamespace(vm) };
   if (isEmpty(findVM(vm))) {
     selectedVMs.value = [...selectedVMs.value, vmIdentifier];
   }
 };
 
-export const deselectVM = (vm: V1VirtualMachine) => {
+export const deselectVM = (vm: V1VirtualMachine): void => {
   const vmIdentifier = { cluster: getCluster(vm), name: getName(vm), namespace: getNamespace(vm) };
   selectedVMs.value = selectedVMs.value.filter(
     (selectedVM) =>
@@ -24,7 +23,7 @@ export const deselectVM = (vm: V1VirtualMachine) => {
   );
 };
 
-export const selectAllVMs = (vms: V1VirtualMachine[]) => {
+export const selectAllVMs = (vms: V1VirtualMachine[]): void => {
   const vmIdentifiers = vms.map((vm) => ({
     cluster: getCluster(vm),
     name: getName(vm),
@@ -33,11 +32,13 @@ export const selectAllVMs = (vms: V1VirtualMachine[]) => {
   selectedVMs.value = [...vmIdentifiers];
 };
 
-export const deselectAllVMs = () => {
+export const deselectAllVMs = (): void => {
   selectedVMs.value = [];
 };
 
-export const findVM = (vm: V1VirtualMachine) => {
+export const findVM = (
+  vm: V1VirtualMachine,
+): { cluster?: string; name: string; namespace: string } | undefined => {
   const vmIdentifier = { cluster: getCluster(vm), name: getName(vm), namespace: getNamespace(vm) };
   return selectedVMs.value.find(
     (selectedVM) =>

--- a/src/views/virtualmachines/list/utils/processVMTotalsMetrics.ts
+++ b/src/views/virtualmachines/list/utils/processVMTotalsMetrics.ts
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getCPU, getMemory, getVCPUCount } from '@kubevirt-utils/resources/vm';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 import { convertToBaseValue, humanizeCpuCores } from '@kubevirt-utils/utils/humanize.js';
@@ -9,29 +8,29 @@ import {
   getHumanizedValue,
 } from '@overview/OverviewTab/metric-charts-card/utils/hooks/utils';
 
-export const getValueWithUnitText = (bytes: number, metric: string) => {
+export const getValueWithUnitText = (bytes: number, metric: string): string => {
   const unit = findUnit(metric, bytes);
   const value = getHumanizedValue(metric, bytes, unit).toLocaleString();
 
   return `${value} ${unit}`;
 };
 
-export const getCpuRequestedText = (vmis: V1VirtualMachineInstance[]) => {
+export const getCpuRequestedText = (vmis: V1VirtualMachineInstance[]): string => {
   const totalCPU = vmis.map((vmi) => getCPU(vmi)).reduce((acc, cpu) => acc + getVCPUCount(cpu), 0);
 
   return humanizeCpuCores(totalCPU).string;
 };
 
-export const getCpuUsageText = (cpuUsage: number) => {
+export const getCpuUsageText = (cpuUsage: number): string => {
   if (isNaN(cpuUsage)) {
     return NO_DATA_DASH;
   }
   return humanizeCpuCores(cpuUsage).string;
 };
 
-export const getMemoryCapacityText = (vmis: V1VirtualMachineInstance[]) => {
+export const getMemoryCapacityText = (vmis: V1VirtualMachineInstance[]): string => {
   const bytes = vmis
-    .map((vmi) => convertToBaseValue(getMemory(vmi)) || 0)
+    .map((vmi) => convertToBaseValue(getMemory(vmi)) ?? 0)
     .reduce((acc, cur) => acc + cur, 0);
 
   return getValueWithUnitText(bytes, METRICS.MEMORY);

--- a/src/views/virtualmachines/list/utils/utils.ts
+++ b/src/views/virtualmachines/list/utils/utils.ts
@@ -1,16 +1,16 @@
-/* eslint-disable */
+import { type TFunction } from 'i18next';
+
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getCluster } from '@multicluster/helpers/selectors';
-import { FleetAccessReviewResourceAttributes } from '@stolostron/multicluster-sdk';
-import { TFunction } from 'i18next';
+import { type FleetAccessReviewResourceAttributes } from '@stolostron/multicluster-sdk';
 
 export const filterVMsByClusterAndNamespace = (
   vms: V1VirtualMachine[],
   namespace: string,
   cluster?: string,
-) =>
+): V1VirtualMachine[] =>
   (vms ?? []).filter((vm) => {
     if (!vm) return false;
     const vmNamespace = getNamespace(vm);
@@ -37,7 +37,7 @@ export const getNamespacesWithVMsCount = (
   return new Set(vms.map((vm) => getNamespace(vm))).size;
 };
 
-export const getDisabledCreateVMTooltip = (t: TFunction, isInAllNamespaces: boolean) => {
+export const getDisabledCreateVMTooltip = (t: TFunction, isInAllNamespaces: boolean): string => {
   if (isInAllNamespaces) {
     return t(
       'To create a VM, select a project where you have create permissions, or create a new project',

--- a/src/views/virtualmachines/list/vmSortFunctions.ts
+++ b/src/views/virtualmachines/list/vmSortFunctions.ts
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getCPU, getMemory } from '@kubevirt-utils/resources/vm';
 import { getVMINodeName } from '@kubevirt-utils/resources/vmi';
 import { SortByDirection } from '@patternfly/react-table';
@@ -10,7 +9,7 @@ import {
   getMemoryUsagePercentage,
   getNetworkUsagePercentage,
 } from './metrics';
-import { VMCallbacks } from './virtualMachinesDefinition';
+import { type VMCallbacks } from './virtualMachinesDefinition';
 
 const EMPTY_STRING_VALUE = '';
 const EMPTY_NUMBER_VALUE = 0;
@@ -33,7 +32,11 @@ const createVMSort = (
 const createNullSafeSort = (
   extractor: (vm: V1VirtualMachine, callbacks?: VMCallbacks) => number | string | undefined,
   isString = false,
-) => {
+): ((
+  data: V1VirtualMachine[],
+  direction: SortByDirection,
+  callbacks?: VMCallbacks,
+) => V1VirtualMachine[]) => {
   return createVMSort((a, b, callbacks) => {
     const firstValue = extractor(a, callbacks);
     const secondValue = extractor(b, callbacks);

--- a/src/views/virtualmachines/navigator/VirtualMachineYAMLCreatePage.tsx
+++ b/src/views/virtualmachines/navigator/VirtualMachineYAMLCreatePage.tsx
@@ -1,10 +1,9 @@
-/* eslint-disable */
-import React, { FC, useState } from 'react';
+import React, { type FC, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { load } from 'js-yaml';
 
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
 import {
   TELEMETRY_RESOURCE_CREATION_METHOD,
@@ -34,7 +33,7 @@ const VirtualMachineYAMLCreatePage: FC = () => {
   const isIPv6SingleStack = useIsIPv6SingleStackCluster(cluster);
   const [error, setError] = useState<Error | null>(null);
 
-  const onSave = async (yaml: string) => {
+  const onSave = async (yaml: string): Promise<void> => {
     setError(null);
     try {
       const vm = load(yaml) as V1VirtualMachine;
@@ -48,7 +47,7 @@ const VirtualMachineYAMLCreatePage: FC = () => {
       logResourceCreated(TELEMETRY_RESOURCE_TYPE.VM, TELEMETRY_RESOURCE_CREATION_METHOD.YAML);
       logVMCreated(TELEMETRY_VM_CREATION_METHOD.SCRATCH);
 
-      const vmCluster = getCluster(createdVM) || cluster;
+      const vmCluster = getCluster(createdVM) ?? cluster;
       navigate(
         vmCluster
           ? getVMURL(vmCluster, namespace, getName(createdVM))

--- a/src/views/virtualmachines/tree/components/TreeViewContent.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewContent.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC, MouseEvent } from 'react';
+import React, { type FC, type MouseEvent } from 'react';
 
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import CreateProjectOnboardingPopover from '@kubevirt-utils/components/OnboardingPopover/components/CreateProjectOnboardingPopover';
@@ -12,7 +11,7 @@ import {
   Stack,
   Title,
   TreeView,
-  TreeViewDataItem,
+  type TreeViewDataItem,
 } from '@patternfly/react-core';
 
 import useFilteredTreeView from '../hooks/useFilteredTreeView';
@@ -23,9 +22,8 @@ import {
   getMatchedProjectItems,
   highlightMatchedTreeItems,
 } from '../utils/utils';
-
-import TreeViewRightClickActionMenu from './TreeViewRightClickActionMenu/TreeViewRightClickActionMenu';
 import PanelToggleButton from './PanelToggleButton';
+import TreeViewRightClickActionMenu from './TreeViewRightClickActionMenu/TreeViewRightClickActionMenu';
 import TreeViewToolbar from './TreeViewToolbar';
 
 type TreeViewContentProps = {
@@ -69,7 +67,7 @@ const TreeViewContent: FC<TreeViewContentProps> = ({
   const filteredProjectsCount = getMatchedProjectItems(filteredTreeData, searchText).length;
   const filteredClustersCount = getMatchedClusterItems(filteredTreeData, searchText).length;
 
-  const getSearchResultInfo = () => {
+  const getSearchResultInfo = (): string | undefined => {
     if (filteredClustersCount && filteredProjectsCount) {
       return t('{{clustersCount}} clusters, {{projectsCount}} projects found', {
         clustersCount: filteredClustersCount,

--- a/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/VMRightClickActionMenu.tsx
+++ b/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/VMRightClickActionMenu.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { getLabel, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getCluster } from '@multicluster/helpers/selectors';
@@ -8,7 +7,6 @@ import { VM_FOLDER_LABEL } from '@virtualmachines/tree/utils/constants';
 import { getVMIMFromMapper } from '@virtualmachines/utils/mappers';
 
 import { vmimMapperSignal, vmsSignal } from '../../utils/signals';
-
 import RightClickActionMenu from './RightClickActionMenu';
 import { getVMComponentsFromID } from './utils';
 
@@ -32,7 +30,7 @@ const VMRightClickActionMenu: FC<VMRightClickActionMenuProps> = ({ hideMenu, tri
 
   const vmHasFolder = !!getLabel(vm, VM_FOLDER_LABEL);
 
-  const getNestedLevel = () => {
+  const getNestedLevel = (): number => {
     if (vmHasFolder) {
       return vmCluster ? 4 : 3;
     }

--- a/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/hooks/useDismissMenu.ts
+++ b/src/views/virtualmachines/tree/components/TreeViewRightClickActionMenu/hooks/useDismissMenu.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useCallback, useEffect } from 'react';
 
 import { CLICK, ESCAPE, KEYDOWN } from '@kubevirt-utils/hooks/useClickOutside/constants';
@@ -26,7 +25,7 @@ const useDismissMenu = (hideMenu: () => void, isOpen: boolean): void => {
     document.addEventListener(CLICK, handleClick, true);
     document.addEventListener(KEYDOWN, handleKeyDown, true);
 
-    return () => {
+    return (): void => {
       document.removeEventListener(CLICK, handleClick, true);
       document.removeEventListener(KEYDOWN, handleKeyDown, true);
     };

--- a/src/views/virtualmachines/tree/hooks/utils.ts
+++ b/src/views/virtualmachines/tree/hooks/utils.ts
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
 import { getLabel, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getCluster } from '@multicluster/helpers/selectors';
@@ -18,7 +17,7 @@ export const getVMFromElementID = (elementID: string): V1VirtualMachine => {
   );
 };
 
-export const isVMAloneInFolder = (draggingVM: V1VirtualMachine) => {
+export const isVMAloneInFolder = (draggingVM: V1VirtualMachine): boolean => {
   const draggingVMFolder = getLabel(draggingVM, VM_FOLDER_LABEL);
 
   return (

--- a/src/views/virtualmachines/tree/icons/utils.ts
+++ b/src/views/virtualmachines/tree/icons/utils.ts
@@ -1,4 +1,5 @@
-/* eslint-disable */
+import { type FC } from 'react';
+
 import { printableVMStatus } from '@virtualmachines/utils';
 
 import PausedVirtualMachineIcon from './PausedVirtualMachineIcon';
@@ -6,14 +7,14 @@ import RunningVirtualMachineIcon from './RunningVirtualMachineIcon';
 import StoppedVirtualMachineIcon from './StoppedVirtualMachineIcon';
 import TreeViewVirtualMachineIcon from './TreeViewVirtualMachineIcon';
 
-const statusIconMapper = {
+const statusIconMapper: Record<string, FC> = {
   [printableVMStatus.Paused]: PausedVirtualMachineIcon,
   [printableVMStatus.Running]: RunningVirtualMachineIcon,
   [printableVMStatus.Stopped]: StoppedVirtualMachineIcon,
 };
 
 export const statusIcon = new Proxy(statusIconMapper, {
-  get(target, prop: string) {
+  get(target, prop: string): FC {
     return target[prop] ?? TreeViewVirtualMachineIcon;
   },
 });

--- a/src/views/virtualmachines/utils/mappers.ts
+++ b/src/views/virtualmachines/utils/mappers.ts
@@ -1,13 +1,12 @@
-/* eslint-disable */
-import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import {
-  V1VirtualMachine,
-  V1VirtualMachineInstance,
-  V1VirtualMachineInstanceMigration,
+  type V1VirtualMachine,
+  type V1VirtualMachineInstance,
+  type V1VirtualMachineInstanceMigration,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { VirtualMachineInstancetypeModel } from '@kubevirt-utils/models';
 import { SINGLE_CLUSTER_KEY } from '@kubevirt-utils/resources/constants';
-import { InstanceTypeUnion } from '@kubevirt-utils/resources/instancetype/types';
+import { type InstanceTypeUnion } from '@kubevirt-utils/resources/instancetype/types';
 import { getClusterKey, getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { getInstanceTypeMatcher, getVolumes } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
@@ -25,15 +24,19 @@ export type VMIMMapper = {
   };
 };
 
-export const getVMIFromMapper = (VMIMapper: VMIMapper, vm: V1VirtualMachine) =>
-  VMIMapper?.mapper?.[getClusterKey(vm)]?.[getNamespace(vm)]?.[getName(vm)];
+export const getVMIFromMapper = (
+  vmiMapper: VMIMapper,
+  vm: V1VirtualMachine,
+): V1VirtualMachineInstance | undefined =>
+  vmiMapper?.mapper?.[getClusterKey(vm)]?.[getNamespace(vm)]?.[getName(vm)];
 
 export const getVMIMFromMapper = (
-  VMIMMapper: VMIMMapper,
+  vmimMapper: VMIMMapper,
   name: string,
   namespace: string,
   cluster?: string,
-) => VMIMMapper?.[cluster || SINGLE_CLUSTER_KEY]?.[namespace]?.[name];
+): V1VirtualMachineInstanceMigration | undefined =>
+  vmimMapper?.[cluster ?? SINGLE_CLUSTER_KEY]?.[namespace]?.[name];
 
 export type InstanceTypeMapper = {
   clusterInstanceTypes: {
@@ -66,7 +69,7 @@ export type PVCMapper = {
 };
 
 export const convertIntoPVCMapper = (pvcs: IoK8sApiCoreV1PersistentVolumeClaim[]): PVCMapper => {
-  return (pvcs || []).reduce((acc, pvc) => {
+  return (pvcs ?? []).reduce((acc, pvc) => {
     const cluster = getClusterKey(pvc);
     const namespace = getNamespace(pvc);
 
@@ -79,17 +82,36 @@ export const convertIntoPVCMapper = (pvcs: IoK8sApiCoreV1PersistentVolumeClaim[]
   }, {} as PVCMapper);
 };
 
-export const getVirtualMachineStorageClasses = (vm: V1VirtualMachine, pvcMapper: PVCMapper) => {
-  const cluster = getClusterKey(vm);
-  const storageClassesSet = (getVolumes(vm) || []).reduce((acc, volume) => {
-    const volumePVC =
-      pvcMapper?.[cluster]?.[getNamespace(vm)]?.[
-        volume.dataVolume?.name || volume.persistentVolumeClaim?.claimName
-      ];
+const getPvcFromMapper = (
+  mapper: PVCMapper,
+  cluster: string,
+  namespace: string,
+  name: string,
+): IoK8sApiCoreV1PersistentVolumeClaim | undefined => mapper[cluster]?.[namespace]?.[name];
 
-    if (volumePVC) acc.add(volumePVC.spec.storageClassName);
+export const getVirtualMachineStorageClasses = (
+  vm: V1VirtualMachine,
+  pvcMapper: PVCMapper,
+): string[] => {
+  const cluster = getClusterKey(vm);
+  const storageClassesSet = (getVolumes(vm) ?? []).reduce((acc, volume) => {
+    const volumeKey: string | undefined =
+      volume.dataVolume?.name ?? volume.persistentVolumeClaim?.claimName;
+    if (!volumeKey) {
+      return acc;
+    }
+
+    const storageClassName: string | undefined = getPvcFromMapper(
+      pvcMapper,
+      cluster,
+      getNamespace(vm),
+      volumeKey,
+    )?.spec?.storageClassName;
+    if (storageClassName) {
+      acc.add(storageClassName);
+    }
     return acc;
   }, new Set<string>());
 
-  return Array.from(storageClassesSet).sort();
+  return Array.from(storageClassesSet).sort((a, b) => a.localeCompare(b));
 };

--- a/src/views/virtualmachines/wizard/steps/CloneSourceStep/components/VirtualMachinesList/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/wizard/steps/CloneSourceStep/components/VirtualMachinesList/VirtualMachinesList.tsx
@@ -90,7 +90,7 @@ const VirtualMachinesList: FC = () => {
         filterDefinitions={filterDefinitions}
         filteredVMsCount={filteredVMs?.length}
         filters={filters}
-        isCompact={listPageBodySize !== ListPageBodySize.lg}
+        isCompact={listPageBodySize !== ListPageBodySize.Lg}
         onPageChange={onPageChange}
         pagination={pagination}
       />


### PR DESCRIPTION
## 📝 Description

Adds eslint typescript rules to the code base part- 10


## 🔗 Links

https://redhat.atlassian.net/browse/CNV-90382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved valid empty and zero values across virtual machine lists, metrics, filters, alerts, and storage views.
  - Improved snapshot restore and status handling when names, timestamps, or related data are unavailable.
  - Prevented storage and resource widgets from failing when information is missing.
  - Improved disk source labeling and hotplug status handling.
  - Standardized sorting behavior across diagnostic tables.

- **Refactor**
  - Improved type safety and consistency across virtual machine, snapshot, diagnostic, and navigation features.
  - Organized migration status information for clearer overview display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->