### PR TITLE
CNV-90382: add typescript-linters-part-11

### DIFF
--- a/src/utils/components/ServicesList/useServiceActionsProvider.tsx
+++ b/src/utils/components/ServicesList/useServiceActionsProvider.tsx
@@ -1,6 +1,7 @@
-import { createElement, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { useNavigate } from 'react-router';
 
+import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToRef, ServiceModel } from '@kubevirt-utils/models';
 import { asAccessReview, getName, getNamespace } from '@kubevirt-utils/resources/shared';
@@ -8,25 +9,17 @@ import {
   type Action,
   type ExtensionHook,
   type K8sResourceKind,
-  type OverlayComponent,
   useAnnotationsModal,
   useDeleteModal,
   useK8sModel,
   useLabelsModal,
-  useOverlay,
 } from '@openshift-console/dynamic-plugin-sdk';
 
-import PodSelectorModal, { type PodSelectorModalProps } from '../PodSelectorModal/PodSelectorModal';
-
-type PodSelectorOverlayProps = Omit<PodSelectorModalProps, 'closeModal'>;
-
-const PodSelectorOverlay: OverlayComponent<PodSelectorOverlayProps> = ({
-  closeOverlay,
-  ...props
-}) => createElement(PodSelectorModal, { ...props, closeModal: closeOverlay });
+import PodSelectorModal from '../PodSelectorModal/PodSelectorModal';
 
 const useServiceActionsProvider: ExtensionHook<Action[], K8sResourceKind> = (obj) => {
   const { t } = useKubevirtTranslation();
+  const { createModal } = useModal();
   const serviceModelRef = modelToRef({ apiGroup: 'core', ...ServiceModel });
   const [, inFlight] = useK8sModel(serviceModelRef);
 
@@ -37,17 +30,15 @@ const useServiceActionsProvider: ExtensionHook<Action[], K8sResourceKind> = (obj
 
   const objNamespace = getNamespace(obj);
   const objName = getName(obj);
-  const launchOverlay = useOverlay();
 
   const actions = useMemo(
     () => [
       {
         accessReview: asAccessReview(ServiceModel, obj, 'update'),
         cta: (): void =>
-          launchOverlay(PodSelectorOverlay, {
-            model: ServiceModel,
-            resource: obj,
-          }),
+          createModal(({ onClose }) => (
+            <PodSelectorModal closeModal={onClose} model={ServiceModel} resource={obj} />
+          )),
         id: 'edit-pod-selectors-services',
         label: t('Edit Pod selector'),
       },
@@ -79,7 +70,7 @@ const useServiceActionsProvider: ExtensionHook<Action[], K8sResourceKind> = (obj
       },
     ],
     [
-      launchOverlay,
+      createModal,
       launchAnnotationsModal,
       launchDeleteModal,
       launchLabelsModal,

--- a/src/utils/resources/vmi/utils/status.ts
+++ b/src/utils/resources/vmi/utils/status.ts
@@ -1,3 +1,5 @@
+import { type ComponentClass, type FC } from 'react';
+
 import { GreenRunningIcon } from '@kubevirt-utils/icons/GreenRunningIcon';
 import {
   ExclamationCircleIcon,
@@ -38,6 +40,11 @@ const iconHandler = {
     const icon = mapper[prop?.toLowerCase() as keyof typeof iconMapper];
     return icon ?? InProgressIcon;
   },
+};
+
+export const getVMIPhaseIcon = (phase: string | undefined): ComponentClass | FC => {
+  const iconComponent = iconMapper[phase?.toLowerCase() as keyof typeof iconMapper];
+  return iconComponent ?? InProgressIcon;
 };
 
 export const icon = new Proxy(iconMapper, iconHandler);

--- a/src/views/virtualmachines/extensions.ts
+++ b/src/views/virtualmachines/extensions.ts
@@ -14,7 +14,7 @@ export const exposedModules: ConsolePluginBuildMetadata['exposedModules'] = {
   Navigator: './views/virtualmachines/navigator/VirtualMachineNavigator.tsx',
   NodeInventoryItem: './views/virtualmachines/node/inventoryitem/NodeInventoryItem.tsx',
   NodeVirtualMachineList: './views/virtualmachines/node/list/NodeVirtualMachinesList.tsx',
-  useServiceActionsProvider: './utils/components/ServicesList/useServiceActionsProvider.ts',
+  useServiceActionsProvider: './utils/components/ServicesList/useServiceActionsProvider.tsx',
 };
 
 export const extensions: EncodedExtension[] = [

--- a/src/views/virtualmachines/utils/virtualMachineStatuses.ts
+++ b/src/views/virtualmachines/utils/virtualMachineStatuses.ts
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import { ComponentClass, FC } from 'react';
+import { type ComponentClass, type FC } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { ErrorIcon } from '@kubevirt-utils/components/ErrorIcon/ErrorIcon';
 import { GreenRunningIcon } from '@kubevirt-utils/icons/GreenRunningIcon';
 import {
@@ -9,7 +8,7 @@ import {
   getVMSnapshottingStatus,
   getVMStatus,
 } from '@kubevirt-utils/resources/shared';
-import { ERROR_STATUS, VM_ERROR_STATUSES, VM_STATUS } from '@kubevirt-utils/resources/vm';
+import { ERROR_STATUS, VM_ERROR_STATUSES } from '@kubevirt-utils/resources/vm';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
 import {
   HourglassHalfIcon,
@@ -66,8 +65,10 @@ export const STATUS_VALUE_GROUPS: string[][] = [
   [printableVMStatus.Stopping, printableVMStatus.Deleting, printableVMStatus.Terminating],
 ];
 
-export const isErrorPrintableStatus = (printableStatus: string) =>
-  Object.values(VM_ERROR_STATUSES).includes(printableStatus as VM_STATUS);
+const errorPrintableStatuses: string[] = [...VM_ERROR_STATUSES];
+
+export const isErrorPrintableStatus = (printableStatus: string): boolean =>
+  errorPrintableStatuses.includes(printableStatus);
 
 export const getVMStatusIcon = (status: string): ComponentClass | FC => {
   switch (status) {

--- a/src/views/virtualmachines/wizard/components/DefaultWizardFooter.tsx
+++ b/src/views/virtualmachines/wizard/components/DefaultWizardFooter.tsx
@@ -1,8 +1,13 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import { useWizardContext, WizardFooter } from '@patternfly/react-core';
 import useCloseWizard from '@virtualmachines/wizard/hooks/useCloseWizard';
+
+import {
+  WIZARD_BACK_BUTTON_PROPS,
+  WIZARD_CANCEL_BUTTON_PROPS,
+  WIZARD_NEXT_BUTTON_PROPS,
+} from './constants';
 
 type DefaultWizardFooterProps = {
   isNextDisabled?: boolean;
@@ -15,11 +20,11 @@ const DefaultWizardFooter: FC<DefaultWizardFooterProps> = ({ isNextDisabled }) =
   return (
     <WizardFooter
       activeStep={activeStep}
-      backButtonProps={{ 'data-test': 'wizard-back-button' } as any}
-      cancelButtonProps={{ 'data-test': 'wizard-cancel-button' } as any}
+      backButtonProps={WIZARD_BACK_BUTTON_PROPS}
+      cancelButtonProps={WIZARD_CANCEL_BUTTON_PROPS}
       isBackDisabled={activeStep.index === 1}
       isNextDisabled={isNextDisabled}
-      nextButtonProps={{ 'data-test': 'wizard-next-button' } as any}
+      nextButtonProps={WIZARD_NEXT_BUTTON_PROPS}
       onBack={goToPrevStep}
       onClose={closeWizard}
       onNext={goToNextStep}

--- a/src/views/virtualmachines/wizard/components/DisksReviewTable/hooks/useWizardDisksTableData/utils/utils.ts
+++ b/src/views/virtualmachines/wizard/components/DisksReviewTable/hooks/useWizardDisksTableData/utils/utils.ts
@@ -1,12 +1,11 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
-import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import {
-  V1DataVolumeTemplateSpec,
-  V1Disk,
-  V1VirtualMachine,
-  V1Volume,
+  type V1DataVolumeTemplateSpec,
+  type V1Disk,
+  type V1VirtualMachine,
+  type V1Volume,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import {
   getPVCSize,
@@ -28,7 +27,7 @@ import {
   getDataVolumeStorageClassName,
   getDataVolumeStorageRequest,
 } from '@kubevirt-utils/resources/vm/utils/dataVolumeTemplate/selectors';
-import { DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
+import { type DiskRowDataLayout } from '@kubevirt-utils/resources/vm/utils/disk/constants';
 import {
   getCDRom,
   getContainerDisk,
@@ -39,7 +38,8 @@ import {
   getPVCClaimName,
 } from '@kubevirt-utils/resources/vm/utils/disk/selectors';
 import { getHumanizedSize } from '@kubevirt-utils/utils/units';
-import { DiskDevice, SourceNameByPriority } from './types';
+
+import { type DiskDevice, type SourceNameByPriority } from './types';
 
 const findVolumeForDisk = (disk: V1Disk, volumes: V1Volume[]): undefined | V1Volume =>
   volumes?.find(({ name }) => name === disk?.name);
@@ -48,7 +48,7 @@ const findPVCForVolume = (
   volume: V1Volume,
   pvcs: IoK8sApiCoreV1PersistentVolumeClaim[],
 ): IoK8sApiCoreV1PersistentVolumeClaim | undefined => {
-  const claimName = volume?.persistentVolumeClaim?.claimName || volume?.dataVolume?.name;
+  const claimName = volume?.persistentVolumeClaim?.claimName ?? volume?.dataVolume?.name;
   return pvcs?.find(({ metadata }) => metadata?.name === claimName);
 };
 
@@ -66,7 +66,7 @@ export const resolveDiskDevices = (
   const volumes = getVolumes(vm);
   const dataVolumeTemplates = getDataVolumeTemplates(vm);
 
-  return (disks || []).map((disk) => {
+  return (disks ?? []).map((disk) => {
     const volume = findVolumeForDisk(disk, volumes);
     const pvc = findPVCForVolume(volume, pvcs);
     const dataVolumeTemplate = findDataVolumeTemplateForVolume(volume, dataVolumeTemplates);
@@ -77,17 +77,17 @@ export const resolveDiskDevices = (
 
 const getDiskSize = (device: DiskDevice): string => {
   const size =
-    getDataVolumeStorageRequest(device?.dataVolumeTemplate) ||
-    getDataVolumePVCStorageRequest(device?.dataVolumeTemplate) ||
+    getDataVolumeStorageRequest(device?.dataVolumeTemplate) ??
+    getDataVolumePVCStorageRequest(device?.dataVolumeTemplate) ??
     getPVCSize(device?.pvc);
 
   return size ? getHumanizedSize(size).string : NO_DATA_DASH;
 };
 
 const getDiskStorageClass = (device: DiskDevice): string =>
-  getDataVolumeStorageClassName(device?.dataVolumeTemplate) ||
-  getDataVolumePVCStorageClassName(device?.dataVolumeTemplate) ||
-  getPVCStorageClassName(device?.pvc) ||
+  getDataVolumeStorageClassName(device?.dataVolumeTemplate) ??
+  getDataVolumePVCStorageClassName(device?.dataVolumeTemplate) ??
+  getPVCStorageClassName(device?.pvc) ??
   NO_DATA_DASH;
 
 const isEnvironmentDisk = (volume: V1Volume): boolean =>
@@ -138,7 +138,7 @@ export const getSource = (device: DiskDevice, t: TFunction): string => {
     return sourceName;
   }
 
-  return getName(device?.pvc) || t('Other');
+  return getName(device?.pvc) ?? t('Other');
 };
 
 export const mapDiskDevicesToRows = (

--- a/src/views/virtualmachines/wizard/components/constants.ts
+++ b/src/views/virtualmachines/wizard/components/constants.ts
@@ -1,0 +1,15 @@
+import { type ButtonProps } from '@patternfly/react-core';
+
+type WizardFooterButtonProps = Omit<ButtonProps, 'children'> & { 'data-test': string };
+
+export const WIZARD_BACK_BUTTON_PROPS: WizardFooterButtonProps = {
+  'data-test': 'wizard-back-button',
+};
+
+export const WIZARD_CANCEL_BUTTON_PROPS: WizardFooterButtonProps = {
+  'data-test': 'wizard-cancel-button',
+};
+
+export const WIZARD_NEXT_BUTTON_PROPS: WizardFooterButtonProps = {
+  'data-test': 'wizard-next-button',
+};

--- a/src/views/virtualmachines/wizard/hooks/useApplyAutoLabels.ts
+++ b/src/views/virtualmachines/wizard/hooks/useApplyAutoLabels.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useEffect, useRef } from 'react';
 import { useWatch } from 'react-hook-form';
 
@@ -42,7 +41,7 @@ const useApplyAutoLabels = (): void => {
     const existingLabels = getLabels(vm, {});
     const labelsToMerge = labels.reduce<Record<string, string>>((acc, { key, value }) => {
       if (!existingLabels[key]) {
-        acc[key] = String(value || userDefaults?.[key] || '');
+        acc[key] = String(value ?? userDefaults?.[key] ?? '');
       }
       return acc;
     }, {});

--- a/src/views/virtualmachines/wizard/hooks/useCloneVM.ts
+++ b/src/views/virtualmachines/wizard/hooks/useCloneVM.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
@@ -62,7 +61,7 @@ const useCloneVM: UseCloneVM = () => {
     });
   }, [cloneRequest, getValues, navigate, submittedCloneRequest, t]);
 
-  const cloneVM = async () => {
+  const cloneVM = async (): Promise<void> => {
     if (isSubmitting || submittedCloneRequest) {
       return;
     }

--- a/src/views/virtualmachines/wizard/hooks/useCreateCustomizedVM.ts
+++ b/src/views/virtualmachines/wizard/hooks/useCreateCustomizedVM.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useState } from 'react';
 import { useWatch } from 'react-hook-form';
 import { useLocation, useNavigate } from 'react-router';
@@ -17,13 +16,13 @@ import { useSignals } from '@preact/signals-react/runtime';
 
 import { useVMWizard } from '../state/vm-wizard-context/VMWizardContext';
 import { CREATE_VM_FORM_FIELDS_VM_DATA } from '../state/vm-wizard-form/consts';
+import { SELECTED_CLUSTER } from '../utils/constants';
 import {
   createHeadlessServiceSafely,
   logFailedVMCreation,
   logSuccessfulVMCreation,
   prepareVMToCreate,
 } from './utils/utils';
-import { SELECTED_CLUSTER } from '../utils/constants';
 
 type UseCreateCustomizedVM = () => {
   createCustomizedVM: () => Promise<void>;
@@ -48,7 +47,7 @@ const useCreateCustomizedVM: UseCreateCustomizedVM = () => {
     SELECTED_CLUSTER.LOCAL_STORAGE_KEY,
   );
 
-  const createCustomizedVM = async () => {
+  const createCustomizedVM = async (): Promise<void> => {
     const {
       creationMethod,
       name: vmName,

--- a/src/views/virtualmachines/wizard/hooks/useSyncDeploymentDetails.ts
+++ b/src/views/virtualmachines/wizard/hooks/useSyncDeploymentDetails.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { getAnnotation } from '@kubevirt-utils/resources/shared';
 import { DESCRIPTION_ANNOTATION, getFolder } from '@kubevirt-utils/resources/vm';
 import {
@@ -51,7 +50,7 @@ export const useSyncDeploymentDetails: UseSyncDeploymentDetails = () => {
       );
       setValue(
         CREATE_VM_FORM_FIELDS_VM_DATA.FOLDER,
-        getFolder(customizeWizardVMSignal.value) || '',
+        getFolder(customizeWizardVMSignal.value) ?? '',
       );
     }
   };

--- a/src/views/virtualmachines/wizard/hooks/useWizardInitialValues.ts
+++ b/src/views/virtualmachines/wizard/hooks/useWizardInitialValues.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useLocation } from 'react-router';
 
 import useActiveNamespace from '@kubevirt-utils/hooks/useActiveNamespace';
@@ -18,7 +17,7 @@ type WizardLocationState = {
 
 type WizardInitialValues = {
   cluster: string;
-  hubClusterError: any;
+  hubClusterError: unknown;
   isLoadingHubCluster: boolean;
   namespace: string;
 };
@@ -28,7 +27,11 @@ const useWizardInitialValues = (): WizardInitialValues => {
   const { state } = location as { state: null | WizardLocationState };
   const activeNamespaceFromUtil = useActiveNamespace();
   const [activeNamespaceFromSDK] = useActiveNamespaceSDK();
-  const [hubClusterName, hubClusterLoaded, hubClusterError] = useHubClusterName();
+  const [hubClusterName, hubClusterLoaded, hubClusterError] = useHubClusterName() as [
+    string | undefined,
+    boolean,
+    unknown,
+  ];
 
   const isACM = useIsACMPage();
 

--- a/src/views/virtualmachines/wizard/hooks/utils/utils.ts
+++ b/src/views/virtualmachines/wizard/hooks/utils/utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import type { TFunction } from 'i18next';
 import produce from 'immer';
 
@@ -108,13 +107,13 @@ export const handleCloneRequestPhaseChange = ({
 
   if (clonePhase === CLONING_STATUSES.SUCCEEDED) {
     logVMCreated(TELEMETRY_VM_CREATION_METHOD.CLONE);
-    navigate(getVMURL(getCluster(cloneRequest) || cluster, targetNamespace, name));
+    navigate(getVMURL(getCluster(cloneRequest) ?? cluster, targetNamespace, name));
     return;
   }
 
   if (isClonePhaseFailed(clonePhase)) {
     const cloneError = new Error(
-      cloneRequest?.status?.conditions?.[0]?.message || t('Clone failed'),
+      cloneRequest?.status?.conditions?.[0]?.message ?? t('Clone failed'),
     );
     setError(cloneError);
     setIsSubmitting(false);

--- a/src/views/virtualmachines/wizard/state/vm-wizard-context/VMWizardContext.tsx
+++ b/src/views/virtualmachines/wizard/state/vm-wizard-context/VMWizardContext.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable */
 import React, { type FC, type ReactNode, useEffect } from 'react';
-import { FormProvider, useForm, useFormContext } from 'react-hook-form';
+import { FormProvider, useForm, useFormContext, type UseFormReturn } from 'react-hook-form';
 
 import Loading from '@kubevirt-utils/components/Loading/Loading';
-import { isEmpty } from '@kubevirt-utils/utils/utils';
+import { getErrorMessage, isEmpty } from '@kubevirt-utils/utils/utils';
 import useWizardInitialValues from '@virtualmachines/wizard/hooks/useWizardInitialValues';
 import { createInitialVMWizardFormValues } from '@virtualmachines/wizard/state/vm-wizard-form/consts';
 import { type VMWizardFormValues } from '@virtualmachines/wizard/state/vm-wizard-form/types';
@@ -27,13 +26,13 @@ export const VMWizardProvider: FC<VMWizardProviderProps> = ({ children }) => {
   }
 
   if (!isEmpty(hubClusterError)) {
-    throw new Error(hubClusterError?.message ?? hubClusterError?.toString());
+    throw new Error(getErrorMessage(hubClusterError));
   }
 
   return <FormProvider {...methods}>{children}</FormProvider>;
 };
 
-export const useVMWizard = () => {
+export const useVMWizard = (): UseFormReturn<VMWizardFormValues> => {
   const context = useFormContext<VMWizardFormValues>();
 
   if (!context?.control) {

--- a/src/views/virtualmachines/wizard/steps/CloneSourceStep/components/VirtualMachinesList/VirtualMachinesList.tsx
+++ b/src/views/virtualmachines/wizard/steps/CloneSourceStep/components/VirtualMachinesList/VirtualMachinesList.tsx
@@ -1,10 +1,10 @@
-/* eslint-disable */
-import React, { FC, useMemo, useRef, useState } from 'react';
+import React, { type FC, useMemo, useRef, useState } from 'react';
 
 import useContainerWidth from '@kubevirt-utils/hooks/useContainerWidth';
 import useKubevirtDataViewFilters from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/useKubevirtDataViewFilters';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { paginationInitialState } from '@kubevirt-utils/hooks/usePagination/utils/constants';
+import { type PaginationState } from '@kubevirt-utils/hooks/usePagination/utils/types';
 import { Label } from '@patternfly/react-core';
 import { getListPageBodySize, ListPageBodySize } from '@virtualmachines/list/listPageBodySize';
 
@@ -53,7 +53,7 @@ const VirtualMachinesList: FC = () => {
     setPagination((prevPagination) => getPaginationFirstPageState(prevPagination));
   };
 
-  const onPageChange = ({ endIndex, page, perPage, startIndex }) => {
+  const onPageChange = ({ endIndex, page, perPage, startIndex }: PaginationState): void => {
     setPagination({ endIndex, page, perPage, startIndex });
   };
 

--- a/src/views/virtualmachines/wizard/steps/CloneSourceStep/components/VirtualMachinesList/components/VirtualMachineRow.tsx
+++ b/src/views/virtualmachines/wizard/steps/CloneSourceStep/components/VirtualMachinesList/components/VirtualMachineRow.tsx
@@ -1,13 +1,12 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { getDescription } from '@kubevirt-utils/resources/shared';
 import { customizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
 import { Radio } from '@patternfly/react-core';
 import { Td, Tr } from '@patternfly/react-table';
-import { VMCallbacks } from '@virtualmachines/list/virtualMachinesDefinition';
+import { type VMCallbacks } from '@virtualmachines/list/virtualMachinesDefinition';
 import { useVMWizard } from '@virtualmachines/wizard/state/vm-wizard-context/VMWizardContext';
 import { CREATE_VM_FORM_FIELDS_VM_DATA } from '@virtualmachines/wizard/state/vm-wizard-form/consts';
 
@@ -24,7 +23,7 @@ const VirtualMachineRow: FC<VirtualMachineRowProps> = ({ callbacks, columns, vm 
 
   const { isRowSelected, rowId } = getVMConfiguration(vm);
 
-  const handleClick = () => {
+  const handleClick = (): void => {
     setValue(CREATE_VM_FORM_FIELDS_VM_DATA.NAME, getCloneSourceVMName(vm));
     setValue(CREATE_VM_FORM_FIELDS_VM_DATA.DESCRIPTION, getDescription(vm) ?? '');
     customizeWizardVMSignal.value = vm;

--- a/src/views/virtualmachines/wizard/steps/CloneSourceStep/components/VirtualMachinesList/utils/utils.ts
+++ b/src/views/virtualmachines/wizard/steps/CloneSourceStep/components/VirtualMachinesList/utils/utils.ts
@@ -1,26 +1,25 @@
-/* eslint-disable */
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
-import { PaginationState } from '@kubevirt-utils/hooks/usePagination/utils/types';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
+import { type PaginationState } from '@kubevirt-utils/hooks/usePagination/utils/types';
 import { getName, getNamespace } from '@kubevirt-utils/resources/shared';
 import { customizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
 import { isVM } from '@kubevirt-utils/utils/typeGuards';
 import { isEmpty, truncateToK8sName } from '@kubevirt-utils/utils/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
-import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
-import { VMCallbacks } from '@virtualmachines/list/virtualMachinesDefinition';
+import { type TableColumn } from '@openshift-console/dynamic-plugin-sdk';
+import { type VMCallbacks } from '@virtualmachines/list/virtualMachinesDefinition';
 import {
   getVMIFromMapper,
   getVMIMFromMapper,
-  PVCMapper,
-  VMIMapper,
-  VMIMMapper,
+  type PVCMapper,
+  type VMIMapper,
+  type VMIMMapper,
 } from '@virtualmachines/utils/mappers';
 
 const getActiveColumnsManagedKeys = <TCallbacks>(
   activeColumns: TableColumn<V1VirtualMachine>[] | undefined,
   manageableColumns: ColumnConfig<V1VirtualMachine, TCallbacks>[],
-) => {
+): (string | undefined)[] => {
   if (isEmpty(activeColumns)) {
     return manageableColumns.filter((col) => !col.additional).map((col) => col.key);
   }
@@ -90,7 +89,12 @@ export const resolveVMListSource = (
   accessibleSource: VMListSource,
 ): VMListSource => (targetNamespace ? namespacedSource : accessibleSource);
 
-export const getVMConfiguration = (currentVM: V1VirtualMachine) => {
+type VMConfiguration = {
+  isRowSelected: boolean;
+  rowId: string;
+};
+
+export const getVMConfiguration = (currentVM: V1VirtualMachine): VMConfiguration => {
   const selectedVM = customizeWizardVMSignal.value;
 
   const currentVMName = getName(currentVM);

--- a/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeDetailsTab.tsx
+++ b/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeDetailsTab.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { useEffect, useState } from 'react';
+import React, { type FC, useEffect, useState } from 'react';
 
 import { VirtualMachineModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
@@ -12,16 +11,15 @@ import { getPreferredBootmode } from '@kubevirt-utils/resources/preference/helpe
 import { asAccessReview } from '@kubevirt-utils/resources/shared';
 import { getDevices } from '@kubevirt-utils/resources/vm';
 import { customizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
-import { K8sVerb, useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sVerb, useAccessReview } from '@openshift-console/dynamic-plugin-sdk';
 import { Grid } from '@patternfly/react-core';
 import { isDeletionProtectionEnabled } from '@virtualmachines/details/tabs/configuration/details/components/DeletionProtection/utils/utils';
 
 import usePreference from '../hooks/usePreference';
-
 import DetailsLeftColumn from './components/DetailsLeftColumn';
 import DetailsRightColumn from './components/DetailsRightColumn';
 
-const CustomizeInstanceTypeDetailsTab = () => {
+const CustomizeInstanceTypeDetailsTab: FC = () => {
   const vm = customizeWizardVMSignal.value;
 
   const [preference, preferenceLoading] = usePreference(vm);

--- a/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeInitialRunTab.tsx
+++ b/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeInitialRunTab.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type FC } from 'react';
 
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
@@ -13,7 +12,7 @@ import { DescriptionList, Divider, PageSection, Title } from '@patternfly/react-
 import InitialRunTabCloudinit from '@virtualmachines/details/tabs/configuration/initialrun/components/InitialRunTabCloudinit';
 import InitialRunTabSysprep from '@virtualmachines/details/tabs/configuration/initialrun/components/InitialRunTabSysprep';
 
-const CustomizeInstanceTypeInitialRunTab = () => {
+const CustomizeInstanceTypeInitialRunTab: FC = () => {
   const { t } = useKubevirtTranslation();
   const vm = customizeWizardVMSignal.value;
 

--- a/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeNetworkTab.tsx
+++ b/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeNetworkTab.tsx
@@ -1,11 +1,10 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type FC } from 'react';
 
 import {
-  V1Disk,
-  V1Interface,
-  V1Network,
-  V1VirtualMachine,
+  type V1Disk,
+  type V1Interface,
+  type V1Network,
+  type V1VirtualMachine,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
@@ -18,7 +17,7 @@ import { PageSection, Title } from '@patternfly/react-core';
 import AddNetworkInterfaceButton from '@virtualmachines/details/tabs/configuration/network/components/AddNetworkInterfaceButton';
 import NetworkInterfaceList from '@virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/network/NetworkInterfaceList';
 
-const CustomizeInstanceTypeNetworkTab = () => {
+const CustomizeInstanceTypeNetworkTab: FC = () => {
   const { t } = useKubevirtTranslation();
   const vm = customizeWizardVMSignal.value;
 
@@ -30,7 +29,7 @@ const CustomizeInstanceTypeNetworkTab = () => {
     updatedNetworks: V1Network[],
     updatedInterfaces: V1Interface[],
     updatedDisks?: V1Disk[],
-  ) => {
+  ): Promise<V1VirtualMachine> => {
     const updates: Parameters<typeof patchCustomizeWizardVMSignal>[0] = [
       { data: updatedNetworks, path: 'spec.template.spec.networks' },
       { data: updatedInterfaces, path: 'spec.template.spec.domain.devices.interfaces' },
@@ -41,7 +40,7 @@ const CustomizeInstanceTypeNetworkTab = () => {
     return Promise.resolve(patchCustomizeWizardVMSignal(updates));
   };
 
-  const onUpdateVM = (updatedVM: V1VirtualMachine) => {
+  const onUpdateVM = (updatedVM: V1VirtualMachine): Promise<void> => {
     patchCustomizeWizardVMSignal([{ data: updatedVM }]);
     return Promise.resolve();
   };

--- a/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeSSHTab.tsx
+++ b/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeSSHTab.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type FC } from 'react';
 
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import SearchItem from '@kubevirt-utils/components/SearchItem/SearchItem';
@@ -12,7 +11,7 @@ import { Grid, GridItem, PageSection, Stack, Title } from '@patternfly/react-cor
 import SSHTabAuthorizedSSHKey from '@virtualmachines/details/tabs/configuration/ssh/components/SSHTabAuthorizedSSHKey';
 import SSHTabSSHAccess from '@virtualmachines/details/tabs/configuration/ssh/components/SSHTabSSHAccess';
 
-const CustomizeInstanceTypeSSHTab = () => {
+const CustomizeInstanceTypeSSHTab: FC = () => {
   const { t } = useKubevirtTranslation();
   const vm = customizeWizardVMSignal.value;
 

--- a/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeSchedulingTab.tsx
+++ b/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeSchedulingTab.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type FC } from 'react';
 
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import {
@@ -9,7 +8,7 @@ import {
 import { PageSection } from '@patternfly/react-core';
 import SchedulingSection from '@virtualmachines/details/tabs/configuration/scheduling/components/SchedulingSection';
 
-const CustomizeInstanceTypeSchedulingTab = () => {
+const CustomizeInstanceTypeSchedulingTab: FC = () => {
   const vm = customizeWizardVMSignal.value;
 
   if (!vm) {

--- a/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeStorageTab.tsx
+++ b/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeStorageTab.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import EnvironmentForm from '@kubevirt-utils/components/EnvironmentEditor/EnvironmentForm';
 import Loading from '@kubevirt-utils/components/Loading/Loading';
 import { getDataVolumeTemplates, getDisks, getVolumes } from '@kubevirt-utils/resources/vm';
@@ -14,7 +13,7 @@ import { Divider, Grid, GridItem, PageSection } from '@patternfly/react-core';
 import { useSignals } from '@preact/signals-react/runtime';
 import DiskList from '@virtualmachines/details/tabs/configuration/storage/components/tables/disk/DiskList';
 
-const CustomizeInstanceTypeStorageTab = () => {
+const CustomizeInstanceTypeStorageTab: FC = () => {
   useSignals();
   const vm = customizeWizardVMSignal.value;
 

--- a/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/components/DetailsEditableItems.tsx
+++ b/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/components/DetailsEditableItems.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import { DescriptionModal } from '@kubevirt-utils/components/DescriptionModal/DescriptionModal';
@@ -32,7 +31,7 @@ const DetailsEditableItems: FC<DetailsEditableItemsProps> = ({ treeViewFoldersEn
     <>
       <DescriptionItem
         descriptionData={
-          getAnnotation(vm, DESCRIPTION_ANNOTATION) || <MutedTextSpan text={t('None')} />
+          getAnnotation(vm, DESCRIPTION_ANNOTATION) ?? <MutedTextSpan text={t('None')} />
         }
         onEditClick={() =>
           createModal(({ isOpen, onClose }) => (

--- a/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/network/NetworkInterfaceActions.tsx
+++ b/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/network/NetworkInterfaceActions.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC, useCallback, useState } from 'react';
+import React, { type FC, useCallback, useState } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ConfirmActionMessage from '@kubevirt-utils/components/ConfirmActionMessage/ConfirmActionMessage';
 import { produceVMNetworks } from '@kubevirt-utils/components/DiskModal/utils/helpers';
 import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
@@ -9,7 +8,7 @@ import TabModal from '@kubevirt-utils/components/TabModal/TabModal';
 import KebabToggle from '@kubevirt-utils/components/toggles/KebabToggle';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getInterfaces, getNetworks } from '@kubevirt-utils/resources/vm';
-import { NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
+import { type NetworkPresentation } from '@kubevirt-utils/resources/vm/utils/network/constants';
 import {
   getConfigInterfaceStateFromVM,
   isSRIOVNetworkByVM,
@@ -39,7 +38,7 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
   const interfaceState = getConfigInterfaceStateFromVM(vm, nicName);
   const isSRIOVIface = isSRIOVNetworkByVM(vm, nicName);
 
-  const onEditModalOpen = () => {
+  const onEditModalOpen = (): void => {
     createModal(({ isOpen, onClose }) => (
       <WizardEditNetworkInterfaceModal
         isOpen={isOpen}
@@ -64,7 +63,7 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
     return onUpdateVM(updatedVM);
   }, [nicName, onUpdateVM, vm]);
 
-  const onDeleteModalToggle = () => {
+  const onDeleteModalToggle = (): void => {
     createModal(({ isOpen, onClose }) => (
       <TabModal<V1VirtualMachine>
         headerText={t('Delete NIC?')}
@@ -83,7 +82,7 @@ const NetworkInterfaceActions: FC<NetworkInterfaceActionsProps> = ({
     setIsDropdownOpen(false);
   };
 
-  const onToggle = () => setIsDropdownOpen((prev) => !prev);
+  const onToggle = (): void => setIsDropdownOpen((prev) => !prev);
 
   return (
     <Dropdown

--- a/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/network/WizardNetworkInterfaceModal.tsx
+++ b/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/network/WizardNetworkInterfaceModal.tsx
@@ -1,9 +1,9 @@
-/* eslint-disable */
-import React, { FC, useCallback } from 'react';
+import React, { type FC, useCallback } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { produceVMNetworks } from '@kubevirt-utils/components/DiskModal/utils/helpers';
 import NetworkInterfaceModal from '@kubevirt-utils/components/NetworkInterfaceModal/NetworkInterfaceModal';
+import { type NetworkInterfaceModalOnSubmit } from '@kubevirt-utils/components/NetworkInterfaceModal/types';
 import {
   createInterface,
   createNetwork,
@@ -35,8 +35,8 @@ const WizardNetworkInterfaceModal: FC<WizardNetworkInterfaceModalProps> = ({
       isLegacyPasst,
       networkName,
       nicName,
-    }) =>
-      (currentVM: V1VirtualMachine) => {
+    }: NetworkInterfaceModalOnSubmit) =>
+      (currentVM: V1VirtualMachine): Promise<void> => {
         const resultNetwork = createNetwork(nicName, networkName);
         const resultInterface = createInterface({
           interfaceLinkState,

--- a/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/network/utils.ts
+++ b/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/network/utils.ts
@@ -1,16 +1,15 @@
-/* eslint-disable */
 import produce from 'immer';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getInterface } from '@kubevirt-utils/resources/vm';
-import { NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
+import { type NetworkInterfaceState } from '@kubevirt-utils/resources/vm/utils/network/types';
 import { ensurePath } from '@kubevirt-utils/utils/utils';
 
 export const setInterfaceLinkState = (
   vm: V1VirtualMachine,
   nicName: string,
   desiredState: NetworkInterfaceState,
-) =>
+): V1VirtualMachine =>
   produce(vm, (draftVM) => {
     ensurePath(draftVM, ['spec.template.spec.domain.devices.interfaces']);
     const interfaceToUpdate = getInterface(draftVM, nicName);

--- a/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/utils/constants.ts
+++ b/src/views/virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/utils/constants.ts
@@ -1,8 +1,8 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
-import { FC } from 'react';
+import { type FC } from 'react';
+import { type TFunction } from 'i18next';
 
 import { VirtualMachineDetailsTab } from '@kubevirt-utils/constants/tabs-constants';
+import { getTabNameAndTitle } from '@virtualmachines/details/utils/utils';
 import CustomizeInstanceTypeDetailsTab from '@virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeDetailsTab';
 import CustomizeInstanceTypeInitialRunTab from '@virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeInitialRunTab';
 import CustomizeInstanceTypeMetadataTab from '@virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeMetadataTab';
@@ -10,7 +10,6 @@ import CustomizeInstanceTypeNetworkTab from '@virtualmachines/wizard/steps/Custo
 import CustomizeInstanceTypeSchedulingTab from '@virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeSchedulingTab';
 import CustomizeInstanceTypeSSHTab from '@virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeSSHTab';
 import CustomizeInstanceTypeStorageTab from '@virtualmachines/wizard/steps/CustomizationStep/components/CustomizeVirtualMachine/components/CustomizeVMTabs/tabs/CustomizeInstanceTypeStorageTab';
-import { getTabNameAndTitle } from '@virtualmachines/details/utils/utils';
 
 export type TabConfig = {
   Component: FC;
@@ -18,7 +17,7 @@ export type TabConfig = {
   title: string;
 };
 
-export const getTabs = (t: TFunction) => [
+export const getTabs = (t: TFunction): TabConfig[] => [
   {
     Component: CustomizeInstanceTypeDetailsTab,
     ...getTabNameAndTitle(VirtualMachineDetailsTab.Details, t),

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/AddBootableVolumeLink/AddBootableVolumeLink.tsx
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/components/AddBootableVolumeLink/AddBootableVolumeLink.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, { type FC } from 'react';
 
 import AddBootableVolumeModal from '@kubevirt-utils/components/AddBootableVolumeModal/AddBootableVolumeModal';
@@ -47,7 +46,7 @@ const AddBootableVolumeLink: FC<AddBootableVolumeLinkProps> = ({
       }}
       variant={ButtonVariant.link}
     >
-      {text || t('Add volume')}
+      {text ?? t('Add volume')}
     </Button>
   );
 };

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/hooks/useBootVolumeSortColumns.ts
@@ -1,23 +1,22 @@
-/* eslint-disable */
 import { useMemo, useState } from 'react';
 
-import { V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
-import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import {
-  V1beta1VirtualMachineClusterPreference,
-  V1beta1VirtualMachinePreference,
+  type V1beta1VirtualMachineClusterPreference,
+  type V1beta1VirtualMachinePreference,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
-import { VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
-import { PaginationState } from '@kubevirt-utils/hooks/usePagination/utils/types';
-import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
+import { type VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
+import { type PaginationState } from '@kubevirt-utils/hooks/usePagination/utils/types';
+import { type BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import {
-  ClusterNamespacedResourceMap,
-  NamespacedResourceMap,
-  ResourceMap,
+  type ClusterNamespacedResourceMap,
+  type NamespacedResourceMap,
+  type ResourceMap,
 } from '@kubevirt-utils/resources/shared';
-import { ThSortType } from '@patternfly/react-table/dist/esm/components/Table/base/types';
+import { type ThSortType } from '@patternfly/react-table/dist/esm/components/Table/base/types';
 import {
-  BootableVolumeSortCriterion,
+  type BootableVolumeSortCriterion,
   sortBootableVolumesWithColumnGetters,
 } from '@virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/utils/getSortedBootableVolumes';
 
@@ -79,7 +78,7 @@ const useBootVolumeSortColumns: UseBootVolumeSortColumns = (
 
   const getSortType = (columnIndex: number): ThSortType => ({
     columnIndex,
-    onSort: (_event, index, direction) => {
+    onSort: (_event, index, direction): void => {
       setSortCriteria({ columnIndex: index, direction });
     },
     sortBy: {

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/utils/getBootableVolumeRowData.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/components/BootableVolumeList/utils/getBootableVolumeRowData.ts
@@ -1,20 +1,24 @@
-/* eslint-disable */
-import { V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
 import {
-  V1beta1VirtualMachineClusterPreference,
-  V1beta1VirtualMachinePreference,
+  type V1beta1VirtualMachineClusterPreference,
+  type V1beta1VirtualMachinePreference,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type VolumeSnapshotKind } from '@kubevirt-utils/components/SelectSnapshot/types';
 import {
   getBootableVolumePVCSource,
   getDataImportCronFromDataSource,
   getDataVolumeForPVC,
   getPreference,
 } from '@kubevirt-utils/resources/bootableresources/helpers';
-import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
-import { getName, NamespacedResourceMap, ResourceMap } from '@kubevirt-utils/resources/shared';
-import { UseBootableVolumesValues } from '@virtualmachines/wizard/utils/types';
+import { type BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
+import {
+  getName,
+  type NamespacedResourceMap,
+  type ResourceMap,
+} from '@kubevirt-utils/resources/shared';
+import { type UseBootableVolumesValues } from '@virtualmachines/wizard/utils/types';
 
-import { BootableVolumeRowData } from '../../../types';
+import { type BootableVolumeRowData } from '../../../types';
 
 type GetBootableVolumeRowDataArgs = {
   bootableVolume: BootableVolume;
@@ -34,6 +38,9 @@ export const getBootableVolumeRowData = ({
   const bootSourceName = getName(bootableVolume);
   const { dataImportCrons, dvSources, pvcSources, volumeSnapshotSources } = bootableVolumesData;
   const pvcSource = getBootableVolumePVCSource(bootableVolume, pvcSources);
+  const volumeSnapshotSource: VolumeSnapshotKind | undefined = bootSourceName
+    ? volumeSnapshotSources[bootSourceName]
+    : undefined;
 
   return {
     dataImportCron: getDataImportCronFromDataSource(
@@ -44,6 +51,6 @@ export const getBootableVolumeRowData = ({
     preference: getPreference(bootableVolume, preferencesMap, userPreferencesMap),
     pvcSource,
     volumeListNamespace,
-    volumeSnapshotSource: volumeSnapshotSources?.[bootSourceName],
+    volumeSnapshotSource,
   };
 };

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/hooks/useAddBootableVolume.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/BootSourceStep/hooks/useAddBootableVolume.ts
@@ -1,9 +1,8 @@
-/* eslint-disable */
 import { useWatch } from 'react-hook-form';
 
-import { PreferenceOption } from '@kubevirt-utils/components/AddBootableVolumeModal/types';
+import { type PreferenceOption } from '@kubevirt-utils/components/AddBootableVolumeModal/types';
 import useCanCreateBootableVolume from '@kubevirt-utils/resources/bootableresources/hooks/useCanCreateBootableVolume';
-import { BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
+import { type BootableVolume } from '@kubevirt-utils/resources/bootableresources/types';
 import { addWizardBootableVolumeUploadKey } from '@kubevirt-utils/signals/wizardBootableVolumeKeysSignal';
 import { useVMWizard } from '@virtualmachines/wizard/state/vm-wizard-context/VMWizardContext';
 import { CREATE_VM_FORM_FIELDS_INSTANCE_TYPE_DATA } from '@virtualmachines/wizard/state/vm-wizard-form/consts';
@@ -30,7 +29,7 @@ const useAddBootableVolume = (): AddBootableVolume => {
   const { canCreateDS, canCreatePVC } = useCanCreateBootableVolume(volumeListNamespace);
   const canCreate = canCreateDS || canCreatePVC;
 
-  const onCreateVolume = (volume: BootableVolume) =>
+  const onCreateVolume = (volume: BootableVolume): void => {
     applySelectedBootableVolumeToForm({
       dvSource: null,
       getValues,
@@ -39,8 +38,9 @@ const useAddBootableVolume = (): AddBootableVolume => {
       setValue,
       volumeSnapshotSource: null,
     });
+  };
 
-  const onUploadStart = (uploadKey: string) => addWizardBootableVolumeUploadKey(uploadKey);
+  const onUploadStart = (uploadKey: string): void => addWizardBootableVolumeUploadKey(uploadKey);
 
   return {
     canCreate,

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/ComputeResourcesStepFooter.tsx
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/ComputeResourcesStepFooter.tsx
@@ -1,7 +1,12 @@
 import React, { type FC } from 'react';
 
 import { setCustomizeWizardVMSignal } from '@kubevirt-utils/signals/customizeWizardVMSignal';
-import { type ButtonProps, useWizardContext, WizardFooter } from '@patternfly/react-core';
+import { useWizardContext, WizardFooter } from '@patternfly/react-core';
+import {
+  WIZARD_BACK_BUTTON_PROPS,
+  WIZARD_CANCEL_BUTTON_PROPS,
+  WIZARD_NEXT_BUTTON_PROPS,
+} from '@virtualmachines/wizard/components/constants';
 import useCloseWizard from '@virtualmachines/wizard/hooks/useCloseWizard';
 import useWizardStepValidation from '@virtualmachines/wizard/hooks/useWizardStepValidation';
 import { VMWizardStep } from '@virtualmachines/wizard/utils/constants';
@@ -22,13 +27,11 @@ const ComputeResourcesStepFooter: FC = () => {
   return (
     <WizardFooter
       activeStep={activeStep}
-      backButtonProps={{ 'data-test': 'wizard-back-button' } as Omit<ButtonProps, 'children'>}
-      cancelButtonProps={{ 'data-test': 'wizard-cancel-button' } as Omit<ButtonProps, 'children'>}
+      backButtonProps={WIZARD_BACK_BUTTON_PROPS}
+      cancelButtonProps={WIZARD_CANCEL_BUTTON_PROPS}
       isBackDisabled={activeStep.index === 1}
       isNextDisabled={isNextDisabledForStep(VMWizardStep.COMPUTE_RESOURCES) || !loaded}
-      nextButtonProps={
-        { 'data-test': 'wizard-next-button', isLoading: !loaded } as Omit<ButtonProps, 'children'>
-      }
+      nextButtonProps={{ ...WIZARD_NEXT_BUTTON_PROPS, isLoading: !loaded }}
       onBack={goToPrevStep}
       onClose={closeWizard}
       onNext={handleGoToNextStep}

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/components/UserProvidedInstanceTypeList/hooks/useInstanceTypeListColumn.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/ComputeResourcesStep/components/SelectInstanceTypeSection/components/UserProvidedInstanceTypeList/hooks/useInstanceTypeListColumn.ts
@@ -1,12 +1,11 @@
-/* eslint-disable */
 import { useCallback, useMemo, useState } from 'react';
 
-import { V1beta1VirtualMachineClusterInstancetype } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1beta1VirtualMachineClusterInstancetype } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { PaginationState } from '@kubevirt-utils/hooks/usePagination/utils/types';
+import { type PaginationState } from '@kubevirt-utils/hooks/usePagination/utils/types';
 import { columnSorting } from '@kubevirt-utils/utils/utils';
-import { TableColumn } from '@openshift-console/dynamic-plugin-sdk';
-import { ThSortType } from '@patternfly/react-table/dist/esm/components/Table/base/types';
+import { type TableColumn } from '@openshift-console/dynamic-plugin-sdk';
+import { type ThSortType } from '@patternfly/react-table/dist/esm/components/Table/base/types';
 
 type UseInstanceTypeListColumnsValues = {
   columns: TableColumn<V1beta1VirtualMachineClusterInstancetype>[];
@@ -49,7 +48,7 @@ const useInstanceTypeListColumns: UseInstanceTypeListColumns = (data, pagination
   const getSortType = useCallback(
     (columnIndex: number): ThSortType => ({
       columnIndex,
-      onSort: (_event, index, direction) => {
+      onSort: (_event, index, direction): void => {
         setActiveSortIndex(index);
         setActiveSortDirection(direction);
       },

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/utils/utils.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/utils/utils.ts
@@ -1,28 +1,33 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
+import otherLinux from '@virtualmachines/wizard/assets/os-icons/linux.svg';
+import rhel from '@virtualmachines/wizard/assets/os-icons/rhel.svg';
+import windows from '@virtualmachines/wizard/assets/os-icons/windows.svg';
 import { OperatingSystemType } from '@virtualmachines/wizard/steps/InstanceTypesSteps/GuestOSStep/utils/constants';
 
-const rhel = require('../../../../assets/os-icons/rhel.svg') as string;
-const windows = require('../../../../assets/os-icons/windows.svg') as string;
-const otherLinux = require('../../../../assets/os-icons/linux.svg') as string;
-
-export const getOperatingSystemsDetails = (t: TFunction) => {
-  return {
-    [OperatingSystemType.OTHER_LINUX]: {
-      icon: otherLinux,
-      label: t('Other Linux'),
-    },
-    [OperatingSystemType.RHEL]: {
-      icon: rhel,
-      label: t('RHEL'),
-    },
-    [OperatingSystemType.WINDOWS]: {
-      icon: windows,
-      label: t('Microsoft Windows'),
-    },
-  };
+type OperatingSystemDetails = {
+  icon: string;
+  label: string;
 };
 
-export const getOperatingSystemDetails = (operatingSystem: OperatingSystemType, t: TFunction) =>
-  getOperatingSystemsDetails(t)[operatingSystem];
+export const getOperatingSystemsDetails = (
+  t: TFunction,
+): Record<OperatingSystemType, OperatingSystemDetails> => ({
+  [OperatingSystemType.OTHER_LINUX]: {
+    icon: otherLinux,
+    label: t('Other Linux'),
+  },
+  [OperatingSystemType.RHEL]: {
+    icon: rhel,
+    label: t('RHEL'),
+  },
+  [OperatingSystemType.WINDOWS]: {
+    icon: windows,
+    label: t('Microsoft Windows'),
+  },
+});
+
+export const getOperatingSystemDetails = (
+  operatingSystem: OperatingSystemType,
+  t: TFunction,
+): OperatingSystemDetails => getOperatingSystemsDetails(t)[operatingSystem];

--- a/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/getSelectedPreference.ts
+++ b/src/views/virtualmachines/wizard/steps/InstanceTypesSteps/hooks/useGenerateVM/utils/getSelectedPreference.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import {
   DEFAULT_PREFERENCE_KIND_LABEL,
   DEFAULT_PREFERENCE_LABEL,
@@ -13,7 +12,7 @@ export const getSelectedPreferenceName = (
   selectedBootableVolume: BootableVolume | null,
   preference?: PreferenceFormValue,
 ): string | undefined =>
-  getLabel(selectedBootableVolume, DEFAULT_PREFERENCE_LABEL) || preference?.name;
+  getLabel(selectedBootableVolume, DEFAULT_PREFERENCE_LABEL) ?? preference?.name;
 
 export const getSelectedPreferenceMatcher = (
   selectedBootableVolume: BootableVolume | null,

--- a/src/views/virtualmachines/wizard/steps/ReviewAndCreateStep/components/ReviewGrid/components/ReviewGridLeftColumn.tsx
+++ b/src/views/virtualmachines/wizard/steps/ReviewAndCreateStep/components/ReviewGrid/components/ReviewGridLeftColumn.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
 import DescriptionItem from '@kubevirt-utils/components/DescriptionItem/DescriptionItem';
 import { TREE_VIEW_FOLDERS } from '@kubevirt-utils/hooks/useFeatures/constants';
@@ -37,19 +36,19 @@ const ReviewGridLeftColumn: FC = () => {
             <CloneDescriptionInput />
           </>
         ) : (
-          <DescriptionItem descriptionData={name || NO_DATA_DASH} descriptionHeader={t('Name')} />
+          <DescriptionItem descriptionData={name ?? NO_DATA_DASH} descriptionHeader={t('Name')} />
         )}
         <DescriptionItem
-          descriptionData={getCluster(vm) || NO_DATA_DASH}
+          descriptionData={getCluster(vm) ?? NO_DATA_DASH}
           descriptionHeader={t('Cluster')}
         />
         <DescriptionItem
-          descriptionData={project || NO_DATA_DASH}
+          descriptionData={project ?? NO_DATA_DASH}
           descriptionHeader={t('Project')}
         />
         {!treeViewFoldersLoading && treeViewFoldersEnabled && (
           <DescriptionItem
-            descriptionData={getFolder(vm) || NO_DATA_DASH}
+            descriptionData={getFolder(vm) ?? NO_DATA_DASH}
             descriptionHeader={t('Group')}
           />
         )}

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/TemplateStep.tsx
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/TemplateStep.tsx
@@ -1,11 +1,10 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type FC } from 'react';
 
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { Stack, StackItem, Title, TitleSizes } from '@patternfly/react-core';
 import TemplatesCatalog from '@virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/TemplatesCatalog';
 
-const TemplateStep = () => {
+const TemplateStep: FC = () => {
   const { t } = useKubevirtTranslation();
 
   return (

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplateStepFooter.tsx
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplateStepFooter.tsx
@@ -1,7 +1,11 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { type ButtonProps, useWizardContext, WizardFooter } from '@patternfly/react-core';
+import { useWizardContext, WizardFooter } from '@patternfly/react-core';
+import {
+  WIZARD_BACK_BUTTON_PROPS,
+  WIZARD_CANCEL_BUTTON_PROPS,
+  WIZARD_NEXT_BUTTON_PROPS,
+} from '@virtualmachines/wizard/components/constants';
 import useCloseWizard from '@virtualmachines/wizard/hooks/useCloseWizard';
 import useWizardStepValidation from '@virtualmachines/wizard/hooks/useWizardStepValidation';
 import { useVMWizard } from '@virtualmachines/wizard/state/vm-wizard-context/VMWizardContext';
@@ -21,27 +25,17 @@ const TemplateStepFooter: FC = () => {
     if (!success) return;
 
     setValue(CREATE_VM_FORM_FIELDS_UI_STATE.IS_TEMPLATES_DRAWER_OPEN, false);
-    goToNextStep();
+    void goToNextStep();
   };
 
   return (
     <WizardFooter
       activeStep={activeStep}
-      backButtonProps={{ 'data-test': 'wizard-back-button' } as Omit<ButtonProps, 'children'>}
-      cancelButtonProps={
-        {
-          'data-test': 'wizard-cancel-button',
-          isDisabled: isProcessing,
-        } as Omit<ButtonProps, 'children'>
-      }
+      backButtonProps={WIZARD_BACK_BUTTON_PROPS}
+      cancelButtonProps={{ ...WIZARD_CANCEL_BUTTON_PROPS, isDisabled: isProcessing }}
       isBackDisabled={activeStep.index === 1 || isProcessing}
       isNextDisabled={isNextDisabledForStep(VMWizardStep.TEMPLATE) || isProcessing}
-      nextButtonProps={
-        {
-          'data-test': 'wizard-next-button',
-          isLoading: isProcessing,
-        } as Omit<ButtonProps, 'children'>
-      }
+      nextButtonProps={{ ...WIZARD_NEXT_BUTTON_PROPS, isLoading: isProcessing }}
       onBack={goToPrevStep}
       onClose={closeWizard}
       onNext={handleGoToNextStep}

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesToolbar/components/TemplatesCatalogProjectsDropdown/TemplatesCatalogProjectsDropdown.tsx
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/components/TemplatesToolbar/components/TemplatesCatalogProjectsDropdown/TemplatesCatalogProjectsDropdown.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, { type FC, memo, useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
@@ -33,7 +32,7 @@ export const TemplatesCatalogProjectsDropdown: FC<TemplatesCatalogProjectsDropdo
       () => [
         { children: ALL_PROJECTS, value: ALL_PROJECTS },
         ...[...projects]
-          .sort((a, b) => getName(a).localeCompare(getName(b)))
+          .sort((a, b) => (getName(a) ?? '').localeCompare(getName(b) ?? ''))
           .map((proj) => {
             const name = getName(proj);
             return { children: name, value: name };
@@ -42,7 +41,7 @@ export const TemplatesCatalogProjectsDropdown: FC<TemplatesCatalogProjectsDropdo
       [projects],
     );
 
-    const onSelect = (value: string) => {
+    const onSelect = (value: string): void => {
       onChange(value === ALL_PROJECTS ? '' : value);
     };
 

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useCatalogUIState.ts
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useCatalogUIState.ts
@@ -1,14 +1,20 @@
-/* eslint-disable */
 import { useCallback } from 'react';
 
 import { useURLParams } from '@kubevirt-utils/hooks/useURLParams';
 
 import { IS_LIST_PARAM, NAMESPACE_PARAM } from '../utils/consts';
 
-const useCatalogUIState = () => {
+type UseCatalogUIState = () => {
+  isList: boolean;
+  namespace: string;
+  setIsList: (value: boolean) => void;
+  setNamespace: (value: string) => void;
+};
+
+const useCatalogUIState: UseCatalogUIState = () => {
   const { params, setParam } = useURLParams();
 
-  const namespace = params.get(NAMESPACE_PARAM) || '';
+  const namespace = params.get(NAMESPACE_PARAM) ?? '';
   const isList = params.get(IS_LIST_PARAM) === 'true';
 
   const setNamespace = useCallback((value: string) => setParam(NAMESPACE_PARAM, value), [setParam]);

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useTemplatesWithAvailableSource/useTemplates.ts
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useTemplatesWithAvailableSource/useTemplates.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import useIsVMTemplateFeatureEnabled from '@kubevirt-utils/hooks/useVMTemplateFeatureFlag/useIsVMTemplateFeatureEnabled';
@@ -11,7 +10,7 @@ type UseTemplates = (
   clusterOverride?: string,
 ) => {
   allTemplates: Template[];
-  error: any;
+  error: unknown;
   loaded: boolean;
 };
 
@@ -23,13 +22,21 @@ const useTemplates: UseTemplates = (namespace, clusterOverride) => {
     error: templatesError,
     loaded: templatesLoaded,
     templates,
-  } = useOpenShiftTemplates({ clusterOverride, namespace });
+  } = useOpenShiftTemplates({ clusterOverride, namespace }) as {
+    error: unknown;
+    loaded: boolean;
+    templates: Template[];
+  };
 
   const {
     error: vmtError,
     loaded: vmtLoaded,
     vmTemplates,
-  } = useVirtualMachineTemplates(namespace, vmTemplatesEnabled, clusterOverride);
+  } = useVirtualMachineTemplates(namespace, vmTemplatesEnabled, clusterOverride) as {
+    error: unknown;
+    loaded: boolean;
+    vmTemplates: Template[];
+  };
 
   const allTemplates = useMemo(
     () => (vmTemplatesEnabled ? [...vmTemplates, ...templates] : templates),
@@ -38,7 +45,7 @@ const useTemplates: UseTemplates = (namespace, clusterOverride) => {
 
   return {
     allTemplates,
-    error: vmTemplatesEnabled ? templatesError || vmtError : templatesError,
+    error: vmTemplatesEnabled ? (templatesError ?? vmtError) : templatesError,
     loaded:
       !vmTemplatesFeatureLoading &&
       (vmTemplatesEnabled ? templatesLoaded && vmtLoaded : templatesLoaded),

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useTemplatesWithAvailableSource/useTemplatesWithAvailableSource.ts
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/hooks/useTemplatesWithAvailableSource/useTemplatesWithAvailableSource.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import { type V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
@@ -13,7 +12,7 @@ type UseTemplatesWithAvailableSource = (args: { clusterOverride?: string; namesp
   availableDataSources: Record<string, V1beta1DataSource>;
   availableTemplatesUID: Set<string>;
   bootSourcesLoaded: boolean;
-  error: any;
+  error: unknown;
   loaded: boolean;
   templates: Template[];
 };

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/utils/getAvailableTemplates.ts
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalog/utils/getAvailableTemplates.ts
@@ -1,17 +1,17 @@
-/* eslint-disable */
-import { IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1beta1DataSource } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import { type IoK8sApiCoreV1PersistentVolumeClaim } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
 import {
-  ClusterNamespacedResourceMap,
+  type ClusterNamespacedResourceMap,
   getResourceFromClusterMap,
 } from '@kubevirt-utils/resources/shared';
-import { BOOT_SOURCE, Template } from '@kubevirt-utils/resources/template';
+import { BOOT_SOURCE, type Template } from '@kubevirt-utils/resources/template';
 import { getTemplateBootSourceType } from '@kubevirt-utils/resources/template/hooks/useVmTemplateSource/utils';
 import { getCluster } from '@multicluster/helpers/selectors';
 
 const addTemplateIfHasAvailableDataSource = (
   acc: Template[],
   template: Template,
-  availableDataSources: object,
+  availableDataSources: Record<string, V1beta1DataSource>,
 ): void => {
   const dataSource = getTemplateBootSourceType(template)?.source?.sourceRef;
   const hasMatchingDataSource =
@@ -49,7 +49,7 @@ const addTemplateIfHasOtherBootSource = (acc: Template[], template: Template): v
 };
 
 export const getAvailableTemplates = (
-  availableDataSources: object,
+  availableDataSources: Record<string, V1beta1DataSource>,
   availablePVCs: ClusterNamespacedResourceMap<IoK8sApiCoreV1PersistentVolumeClaim>,
   templates: Template[],
   templatesLoaded: boolean,

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/components/FieldGroup.tsx
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/components/TemplatesCatalogDrawer/components/FieldGroup.tsx
@@ -1,6 +1,5 @@
-/* eslint-disable */
-import classNames from 'classnames';
 import React, { type FC } from 'react';
+import classNames from 'classnames';
 
 import { type TemplateParameter } from '@kubevirt-ui-ext/kubevirt-api/console';
 import FormGroupHelperText from '@kubevirt-utils/components/FormGroupHelperText/FormGroupHelperText';
@@ -50,7 +49,7 @@ const FieldGroup: FC<FieldGroupProps> = ({
       className={classNames('field-group', className)}
       fieldId={fieldId}
       isRequired={required}
-      label={displayName || name}
+      label={displayName ?? name}
     >
       {isPasswordParameterField ? (
         <FormPasswordInput

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/hooks/useVMTemplateGeneratedParams.ts
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/hooks/useVMTemplateGeneratedParams.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useEffect, useState } from 'react';
 import { useWatch } from 'react-hook-form';
 
@@ -27,7 +26,7 @@ const useVMTemplateGeneratedParams = (
     name: [CREATE_VM_FORM_FIELDS_VM_DATA.CLUSTER, CREATE_VM_FORM_FIELDS_VM_DATA.PROJECT],
   });
   const [error, setError] = useState<Error>();
-  const namespace = namespaceOverride || project || DEFAULT_NAMESPACE;
+  const namespace = [namespaceOverride, project].find((ns) => ns) ?? DEFAULT_NAMESPACE;
   const [templateWithGeneratedValues, setTemplateWithGeneratedValues] = useState<Template>();
   const [loading, setLoading] = useState<boolean>(false);
 

--- a/src/views/virtualmachines/wizard/steps/TemplateStep/hooks/utils.ts
+++ b/src/views/virtualmachines/wizard/steps/TemplateStep/hooks/utils.ts
@@ -1,7 +1,6 @@
-/* eslint-disable */
 import { produce } from 'immer';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { DYNAMIC_CREDENTIALS_SUPPORT } from '@kubevirt-utils/components/DynamicSSHKeyInjection/constants/constants';
 import { addSecretToVM } from '@kubevirt-utils/components/SSHSecretModal/utils/utils';
 import { getLabel, getName } from '@kubevirt-utils/resources/shared';
@@ -10,7 +9,7 @@ import {
   isVirtualMachineTemplate,
   LABEL_USED_TEMPLATE_NAME,
   LABEL_USED_TEMPLATE_NAMESPACE,
-  Template,
+  type Template,
 } from '@kubevirt-utils/resources/template';
 import { processOpenShiftTemplate } from '@kubevirt-utils/resources/template/utils/processOpenShiftTemplate';
 import { processVirtualMachineTemplate } from '@kubevirt-utils/resources/template/utils/processVirtualMachineTemplate';
@@ -54,7 +53,7 @@ export const resolveVMFromTemplate = async (
 export const applyCertConfigMapToCDRom = (
   vmObject: V1VirtualMachine,
   certConfigMapName: string | undefined,
-) => {
+): void => {
   if (!certConfigMapName) return;
 
   const cdromDVTemplate = vmObject.spec?.dataVolumeTemplates?.find(
@@ -82,7 +81,7 @@ export const getVMObjectFromTemplate = ({
   sshSecretName?: string;
   vm: V1VirtualMachine;
   vmName?: string;
-}) => {
+}): V1VirtualMachine => {
   const generatedVM = produce(vm, (draftVM) => {
     ensurePath(draftVM, 'metadata.labels');
     ensurePath(draftVM, 'metadata.annotations');
@@ -98,7 +97,7 @@ export const getVMObjectFromTemplate = ({
       draftVM.metadata.labels[VM_FOLDER_LABEL] = folder;
     }
 
-    draftVM.metadata.name = vmName || getName(draftVM) || draftVM.metadata.labels?.app;
+    draftVM.metadata.name = vmName ?? getName(draftVM) ?? draftVM.metadata.labels?.app;
     draftVM.metadata.namespace = namespace;
     draftVM.spec.runStrategy = getDefaultRunningStrategy();
   });

--- a/src/views/virtualmachinesinstance/details/VirtualMachinesInstancePageHeader.tsx
+++ b/src/views/virtualmachinesinstance/details/VirtualMachinesInstancePageHeader.tsx
@@ -1,11 +1,10 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { createElement, type FC } from 'react';
 
-import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DetailsPageTitle from '@kubevirt-utils/components/DetailsPageTitle/DetailsPageTitle';
 import PaneHeading from '@kubevirt-utils/components/PaneHeading/PaneHeading';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
-import { icon } from '@kubevirt-utils/resources/vmi';
+import { getVMIPhaseIcon } from '@kubevirt-utils/resources/vmi';
 import { Label, Title } from '@patternfly/react-core';
 
 import VirtualMachineInstanceActions from '../list/components/VirtualMachineInstanceActions/VirtualMachineInstanceAction';
@@ -18,14 +17,14 @@ type VirtualMachinesInstancePageHeaderProps = {
 const VirtualMachinesInstancePageHeader: FC<VirtualMachinesInstancePageHeaderProps> = ({ vmi }) => {
   const { t } = useKubevirtTranslation();
   const status = vmi?.status?.phase;
-  const IconComponent = icon?.[status];
+
   return (
     <DetailsPageTitle breadcrumb={<VirtualMachineInstanceBreadcrumb />}>
       <PaneHeading>
         <Title headingLevel="h1">
           <span className={`co-m-resource-icon co-m-resource-icon--lg`}>{t('VMI')}</span>
           {vmi?.metadata?.name}{' '}
-          <Label icon={<IconComponent />} isCompact>
+          <Label icon={createElement(getVMIPhaseIcon(status))} isCompact>
             {status}
           </Label>
         </Title>

--- a/src/views/virtualmachinesinstance/details/hooks/useGuestOS.tsx
+++ b/src/views/virtualmachinesinstance/details/hooks/useGuestOS.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable */
 import { useEffect, useState } from 'react';
 
 import {
-  V1VirtualMachineInstance,
-  V1VirtualMachineInstanceGuestAgentInfo,
+  type V1VirtualMachineInstance,
+  type V1VirtualMachineInstanceGuestAgentInfo,
 } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { isGuestAgentConnected, vmiStatuses } from '@kubevirt-utils/resources/vmi';
 import useGuestAgentURL from '@multicluster/hooks/useGuestAgentURL';
@@ -11,12 +10,15 @@ import { consoleFetch } from '@openshift-console/dynamic-plugin-sdk';
 
 type UseGuestOS = (
   vmi: V1VirtualMachineInstance,
-) => [V1VirtualMachineInstanceGuestAgentInfo, boolean, any, boolean];
+) => [V1VirtualMachineInstanceGuestAgentInfo, boolean, Error | null, boolean];
+
+const isGuestAgentInfo = (value: unknown): value is V1VirtualMachineInstanceGuestAgentInfo =>
+  typeof value === 'object' && value !== null;
 
 const useGuestOS: UseGuestOS = (vmi) => {
   const [loaded, setLoaded] = useState(false);
   const [data, setData] = useState<V1VirtualMachineInstanceGuestAgentInfo>({});
-  const [error, setError] = useState(null);
+  const [error, setError] = useState<Error | null>(null);
   const isGuestAgent = isGuestAgentConnected(vmi);
   const [guestAgentURL, guestAgentURLLoaded] = useGuestAgentURL(vmi);
 
@@ -26,14 +28,14 @@ const useGuestOS: UseGuestOS = (vmi) => {
     setError(null);
 
     if (vmi?.status?.phase === vmiStatuses.Running && isGuestAgent) {
-      (async () => {
+      void (async (): Promise<void> => {
         const response = await consoleFetch(guestAgentURL);
-        const jsonData = await response.json();
-        setData(jsonData);
+        const rawData: unknown = await response.json();
+        setData(isGuestAgentInfo(rawData) ? rawData : {});
         setLoaded(true);
         setError(null);
-      })().catch((err) => {
-        setError(err);
+      })().catch((err: unknown) => {
+        setError(err instanceof Error ? err : new Error(String(err)));
         setLoaded(true);
       });
     } else {

--- a/src/views/virtualmachinesinstance/details/hooks/useVirtualMachinesInstanceTabs.ts
+++ b/src/views/virtualmachinesinstance/details/hooks/useVirtualMachinesInstanceTabs.ts
@@ -1,4 +1,5 @@
-/* eslint-disable */
+import { type ComponentType } from 'react';
+
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 
 import VirtualMachinesInstancePageConsoleTab from '../tabs/console/VirtualMachinesInstancePageConsoleTab';
@@ -9,7 +10,13 @@ import VirtualMachinesInstancePageNetworkTab from '../tabs/network/VirtualMachin
 import VirtualMachinesInstancePageSchedulingTab from '../tabs/scheduling/VirtualMachinesInstancePageSchedulingTab';
 import VirtualMachinesInstancePageYAMLTab from '../tabs/yaml/VirtualMachinesInstancePageYAMLTab';
 
-const useVirtualMachinesInstanceTabs = () => {
+type VirtualMachineInstanceTab = {
+  component: ComponentType;
+  href: string;
+  name: string;
+};
+
+const useVirtualMachinesInstanceTabs = (): VirtualMachineInstanceTab[] => {
   const { t } = useKubevirtTranslation();
 
   const tabs = [

--- a/src/views/virtualmachinesinstance/details/tabs/details/components/Details/Node/Node.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/details/components/Details/Node/Node.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { NodeModel } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { modelToGroupVersionKind, NodeModel } from '@kubevirt-ui-ext/kubevirt-api/console';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ResourceLink } from '@openshift-console/dynamic-plugin-sdk';
 
@@ -12,7 +11,7 @@ type NodeProps = {
 const Node: FC<NodeProps> = ({ nodeName }) => {
   const { t } = useKubevirtTranslation();
   return nodeName ? (
-    <ResourceLink kind={NodeModel.kind} name={nodeName} />
+    <ResourceLink groupVersionKind={modelToGroupVersionKind(NodeModel)} name={nodeName} />
   ) : (
     <div className="pf-v6-u-text-color-subtle">{t('Not available')} </div>
   );

--- a/src/views/virtualmachinesinstance/details/tabs/details/components/Services/Services.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/details/components/Services/Services.tsx
@@ -1,8 +1,8 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type FC, type ReactNode } from 'react';
 
 import { modelToGroupVersionKind, ServiceModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type IoK8sApiCoreV1Service } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import { type V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ServicesList from '@kubevirt-utils/components/ServicesList/ServicesList';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { usePods } from '@kubevirt-utils/hooks/usePods';
@@ -14,7 +14,12 @@ import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
 import { Icon, Title } from '@patternfly/react-core';
 import { LinkIcon } from '@patternfly/react-icons';
 
-const Services = ({ pathname, vmi }) => {
+type ServicesProps = {
+  pathname: string;
+  vmi: V1VirtualMachineInstance;
+};
+
+const Services: FC<ServicesProps> = ({ pathname, vmi }): ReactNode => {
   const { t } = useKubevirtTranslation();
 
   const [services, loaded, loadError] = useK8sWatchData<IoK8sApiCoreV1Service[]>({

--- a/src/views/virtualmachinesinstance/details/tabs/details/components/UserList/ActiveUserList.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/details/components/UserList/ActiveUserList.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC, ReactNode } from 'react';
+import React, { type FC, type ReactNode } from 'react';
 
-import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ActiveUsersTable from '@kubevirt-utils/components/ActiveUsersTable/ActiveUsersTable';
 import MutedTextSpan from '@kubevirt-utils/components/MutedTextSpan/MutedTextSpan';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';

--- a/src/views/virtualmachinesinstance/details/tabs/disks/hooks/useDisksTableDisks.ts
+++ b/src/views/virtualmachinesinstance/details/tabs/disks/hooks/useDisksTableDisks.ts
@@ -1,20 +1,21 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import { PersistentVolumeClaimModel } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { getNamespace } from '@kubevirt-utils/resources/shared';
 import { getCluster } from '@multicluster/helpers/selectors';
 import useK8sWatchData from '@multicluster/hooks/useK8sWatchData';
-import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import { type K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 import {
-  DiskPresentation,
-  DiskRaw,
+  type DiskPresentation,
+  type DiskRaw,
   diskStructureCreator,
 } from './../utils/virtualMachinesInstancePageDisksTabUtils';
 
-type UseDisksTableDisks = (vmi: V1VirtualMachineInstance) => [DiskPresentation[], boolean, any];
+type UseDisksTableDisks = (
+  vmi: V1VirtualMachineInstance,
+) => [DiskPresentation[], boolean, Error | undefined];
 
 const useDisksTableDisks: UseDisksTableDisks = (vmi) => {
   const vmiDisks = vmi?.spec?.domain?.devices?.disks;
@@ -42,6 +43,6 @@ const useDisksTableDisks: UseDisksTableDisks = (vmi) => {
     return diskStructureCreator(diskDevices);
   }, [pvcs, vmiDisks, vmiVolumes]);
 
-  return [disks || [], loaded, loadingError];
+  return [disks ?? [], loaded, loadingError];
 };
 export default useDisksTableDisks;

--- a/src/views/virtualmachinesinstance/details/tabs/disks/table/disks/DisksTable.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/disks/table/disks/DisksTable.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC, useMemo } from 'react';
+import React, { type FC, useMemo } from 'react';
 
-import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import DiskListTitle from '@kubevirt-utils/components/DiskListTitle/DiskListTitle';
 import KubevirtFilterToolbar from '@kubevirt-utils/components/KubevirtFilterToolbar/KubevirtFilterToolbar';
 import KubevirtTable from '@kubevirt-utils/components/KubevirtTable/KubevirtTable';
@@ -11,7 +10,6 @@ import { ListPageBody } from '@openshift-console/dynamic-plugin-sdk';
 
 import useDisksTableDisks from '../../hooks/useDisksTableDisks';
 import { getVMIDiskFilters } from '../../utils/filters';
-
 import { getVMIDiskRowId, getVMIDisksTableColumns } from './disksTableDefinition';
 
 type DisksTableProps = {

--- a/src/views/virtualmachinesinstance/details/tabs/disks/table/file-system/FileSystemTable.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/disks/table/file-system/FileSystemTable.tsx
@@ -1,13 +1,11 @@
-/* eslint-disable */
-import React, { FC } from 'react';
+import React, { type FC } from 'react';
 
-import { V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachineInstance } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import FileSystemList from '@kubevirt-utils/components/FileSystemList/FileSystemList';
-import { FileSystemData } from '@kubevirt-utils/components/FileSystemList/fileSystemListDefinition';
+import { type FileSystemData } from '@kubevirt-utils/components/FileSystemList/fileSystemListDefinition';
 import { ListPageBody } from '@openshift-console/dynamic-plugin-sdk';
 
 import useGuestOS from '../../../../hooks/useGuestOS';
-
 import FileSystemTableTitle from './FileSystemTableTitle';
 
 type FileSystemTableProps = {

--- a/src/views/virtualmachinesinstance/details/tabs/disks/table/file-system/FileSystemTableTitle.tsx
+++ b/src/views/virtualmachinesinstance/details/tabs/disks/table/file-system/FileSystemTableTitle.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import React from 'react';
+import React, { type FC } from 'react';
 
 import HelpTextIcon from '@kubevirt-utils/components/HelpTextIcon/HelpTextIcon';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
@@ -7,7 +6,7 @@ import PopoverContentWithLightspeedButton from '@lightspeed/components/PopoverCo
 import { OLSPromptType } from '@lightspeed/utils/prompts';
 import { Flex, FlexItem, PopoverPosition, Title } from '@patternfly/react-core';
 
-const FileSystemTableTitle = () => {
+const FileSystemTableTitle: FC = () => {
   const { t } = useKubevirtTranslation();
 
   return (

--- a/src/views/virtualmachinesinstance/details/tabs/disks/utils/virtualMachinesInstancePageDisksTabUtils.ts
+++ b/src/views/virtualmachinesinstance/details/tabs/disks/utils/virtualMachinesInstancePageDisksTabUtils.ts
@@ -1,10 +1,12 @@
-/* eslint-disable */
-import { V1beta1PersistentVolumeClaim, V1Disk } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import {
+  type V1beta1PersistentVolumeClaim,
+  type V1Disk,
+} from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 
 export type DiskPresentation = {
   drive: string;
   interface: string;
-  metadata: { [key: string]: any };
+  metadata: { name?: string };
   name: string;
   namespace?: string;
   size?: string;
@@ -25,27 +27,38 @@ export type DiskRaw = V1Disk & { pvc?: V1beta1PersistentVolumeClaim };
 export const diskTypes = {
   cdrom: 'CD-ROM',
   disk: 'Disk',
-  LUN: 'LUN',
+  lun: 'LUN',
 };
 
-const findDrive = (obj: DiskRaw) => {
+const findDrive = (obj: DiskRaw): string => {
   const type = Object.keys(diskTypes).find((driveType: string) =>
     Object.keys(obj).includes(driveType),
   );
-  return type || 'disk';
+  return type ?? 'disk';
+};
+
+const getDriveBus = (device: DiskRaw): string | undefined => {
+  const drive = findDrive(device);
+  if (drive === 'cdrom') {
+    return device.cdrom?.bus;
+  }
+  if (drive === 'lun') {
+    return device.lun?.bus;
+  }
+  return device.disk?.bus;
 };
 
 export const diskStructureCreator = (disks: DiskRaw[]): DiskPresentation[] => {
   return disks?.map((device) => {
     return {
       drive: findDrive(device),
-      interface: device?.[findDrive(device)]?.bus,
+      interface: getDriveBus(device),
       metadata: { name: device?.name },
       name: device?.name,
       namespace: device?.pvc?.metadata?.namespace,
       size: device?.pvc?.spec?.resources?.requests?.storage?.toString(),
-      source: device?.pvc?.metadata?.name || 'Other',
-      storageClass: device?.pvc?.spec?.storageClassName || '-',
+      source: device?.pvc?.metadata?.name ?? 'Other',
+      storageClass: device?.pvc?.spec?.storageClassName ?? '-',
     };
   });
 };

--- a/src/views/vmnetworks/actions/hooks/useVMNetworkActions.tsx
+++ b/src/views/vmnetworks/actions/hooks/useVMNetworkActions.tsx
@@ -1,31 +1,26 @@
-/* eslint-disable */
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 
+import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { ClusterUserDefinedNetworkModel } from '@kubevirt-utils/models';
 import { asAccessReview } from '@kubevirt-utils/resources/shared';
-import { ClusterUserDefinedNetworkKind } from '@kubevirt-utils/resources/udn/types';
+import { type ClusterUserDefinedNetworkKind } from '@kubevirt-utils/resources/udn/types';
 import { isEmpty } from '@kubevirt-utils/utils/utils';
-import { Action, useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { type Action } from '@openshift-console/dynamic-plugin-sdk';
 
-import DeleteVMNetworkModal, {
-  DeleteVMNetworkModalProps,
-} from '../components/DeleteVMNetworkModal';
-import EditProjectMappingModal, {
-  EditProjectMappingModalProps,
-} from '../components/EditProjectMappingModal';
+import DeleteVMNetworkModal from '../components/DeleteVMNetworkModal';
+import EditProjectMappingModal from '../components/EditProjectMappingModal';
 
-const useVMNetworkActions = (obj: ClusterUserDefinedNetworkKind) => {
+const useVMNetworkActions = (obj: ClusterUserDefinedNetworkKind): Action[] => {
   const { t } = useKubevirtTranslation();
-  const createModal = useModal();
+  const { createModal } = useModal();
 
   const isMarkedForDeletion = !isEmpty(obj?.metadata?.deletionTimestamp);
 
   const actions = useMemo(
     (): Action[] => [
       {
-         
-        cta: () => {},
+        cta: (): void => {},
         description: t(
           "To change a network definition, create a new one and reassign virtual machines to it. Existing definitions can't be edited directly",
         ),
@@ -35,19 +30,15 @@ const useVMNetworkActions = (obj: ClusterUserDefinedNetworkKind) => {
       },
       {
         accessReview: asAccessReview(ClusterUserDefinedNetworkModel, obj, 'patch'),
-        cta: () =>
-          createModal<EditProjectMappingModalProps>(EditProjectMappingModal, {
-            obj,
-          }),
+        cta: (): void =>
+          createModal(({ onClose }) => <EditProjectMappingModal closeModal={onClose} obj={obj} />),
         id: 'edit-vm-network-project-mapping',
         label: t('Edit projects mapping'),
       },
       {
         accessReview: asAccessReview(ClusterUserDefinedNetworkModel, obj, 'delete'),
-        cta: () =>
-          createModal<DeleteVMNetworkModalProps>(DeleteVMNetworkModal, {
-            obj,
-          }),
+        cta: (): void =>
+          createModal(({ onClose }) => <DeleteVMNetworkModal closeModal={onClose} obj={obj} />),
         description: isMarkedForDeletion
           ? t(
               'This network is marked for deletion and will be removed after all connected virtual machines are disconnected.',

--- a/src/views/vmnetworks/details/hooks/useConnectedVMsWithNamespace.ts
+++ b/src/views/vmnetworks/details/hooks/useConnectedVMsWithNamespace.ts
@@ -1,11 +1,12 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import { VirtualMachineModelGroupVersionKind } from '@kubevirt-utils/models';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
 import { getMatchingNetworkNamespace } from '../utils';
+
+import { toWatchError } from '../../utils';
 
 type UseConnectedVMsWithNamespace = (
   vmNetworkName: string,
@@ -21,11 +22,14 @@ type UseConnectedVMsWithNamespace = (
  * @returns Tuple of [filtered VMs with network namespace, loaded state, error]
  */
 const useConnectedVMsWithNamespace: UseConnectedVMsWithNamespace = (vmNetworkName) => {
-  const [vms, loaded, error] = useK8sWatchResource<V1VirtualMachine[]>({
+  const watchResult = useK8sWatchResource<V1VirtualMachine[]>({
     groupVersionKind: VirtualMachineModelGroupVersionKind,
     isList: true,
     namespaced: false,
   });
+  const vms = watchResult[0];
+  const loaded = watchResult[1];
+  const error = toWatchError(watchResult[2]);
 
   const vmsWithNamespace = useMemo(
     () =>

--- a/src/views/vmnetworks/details/tabs/ConnectedVirtualMachines/actions/components/DisconnectVMModal.tsx
+++ b/src/views/vmnetworks/details/tabs/ConnectedVirtualMachines/actions/components/DisconnectVMModal.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable */
-import React, { FC, useState } from 'react';
+import React, { type FC, useState } from 'react';
 import { Trans } from 'react-i18next';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { modelToGroupVersionKind, VirtualMachineModel } from '@kubevirt-utils/models';
@@ -36,7 +35,7 @@ const DisconnectVMModal: FC<DisconnectVMModalProps> = ({ closeModal, currentNetw
   const vmsCount = vms.length;
   const isSingleVM = vmsCount === 1;
 
-  const onSubmit = async () => {
+  const onSubmit = async (): Promise<void> => {
     setIsSubmitting(true);
     try {
       await disconnectVMsFromNetwork(vms, currentNetwork);

--- a/src/views/vmnetworks/details/tabs/ConnectedVirtualMachines/actions/components/MoveVMModal.tsx
+++ b/src/views/vmnetworks/details/tabs/ConnectedVirtualMachines/actions/components/MoveVMModal.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable */
-import React, { FC, useState } from 'react';
+import React, { type FC, useState } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import ErrorAlert from '@kubevirt-utils/components/ErrorAlert/ErrorAlert';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName } from '@kubevirt-utils/resources/shared';
@@ -18,7 +17,7 @@ import {
   ModalVariant,
 } from '@patternfly/react-core';
 
-import { VMNetworkWithProjects } from '../types';
+import { type VMNetworkWithProjects } from '../types';
 import { moveVMsToNewNetwork } from '../utils';
 
 import VMNetworkSelect from './VMNetworkSelect';
@@ -39,12 +38,12 @@ const MoveVMModal: FC<MoveVMModalProps> = ({ closeModal, currentNetwork, vms }) 
   const vmsCount = vms.length;
   const isSingleVM = vmsCount === 1;
 
-  const onSelect = ({ projectNames, vmNetworkName }: VMNetworkWithProjects) => {
+  const onSelect = ({ projectNames, vmNetworkName }: VMNetworkWithProjects): void => {
     setNewNetwork(vmNetworkName);
     setNewNetworkProjects(projectNames);
   };
 
-  const onSubmit = async () => {
+  const onSubmit = async (): Promise<void> => {
     setIsSubmitting(true);
     try {
       await moveVMsToNewNetwork(vms, currentNetwork, newNetwork, newNetworkProjects);

--- a/src/views/vmnetworks/details/tabs/ConnectedVirtualMachines/actions/hooks/useSelectableVMNetworksWithProjects.ts
+++ b/src/views/vmnetworks/details/tabs/ConnectedVirtualMachines/actions/hooks/useSelectableVMNetworksWithProjects.ts
@@ -55,7 +55,7 @@ const useSelectableVMNetworksWithProjects: UseSelectableVMNetworksWithProjects =
   return [
     vmNetworksWithProjects,
     vmNetworksLoaded && projectsLoaded,
-    vmNetworksError || projectsError,
+    vmNetworksError ?? projectsError,
   ];
 };
 

--- a/src/views/vmnetworks/details/tabs/ConnectedVirtualMachines/actions/hooks/useVirtualMachineActions.tsx
+++ b/src/views/vmnetworks/details/tabs/ConnectedVirtualMachines/actions/hooks/useVirtualMachineActions.tsx
@@ -1,15 +1,15 @@
-/* eslint-disable */
-import { useMemo } from 'react';
+import React, { useMemo } from 'react';
 
-import { V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { VirtualMachineModel } from '@kubevirt-utils/models';
 import { asAccessReview, getName } from '@kubevirt-utils/resources/shared';
-import { ClusterUserDefinedNetworkKind } from '@kubevirt-utils/resources/udn/types';
-import { Action, useModal } from '@openshift-console/dynamic-plugin-sdk';
+import { type ClusterUserDefinedNetworkKind } from '@kubevirt-utils/resources/udn/types';
+import { type Action } from '@openshift-console/dynamic-plugin-sdk';
 
-import DisconnectVMModal, { DisconnectVMModalProps } from '../components/DisconnectVMModal';
-import MoveVMModal, { MoveVMModalProps } from '../components/MoveVMModal';
+import DisconnectVMModal from '../components/DisconnectVMModal';
+import MoveVMModal from '../components/MoveVMModal';
 
 type UseVirtualMachineActions = (
   vms: V1VirtualMachine[],
@@ -18,7 +18,7 @@ type UseVirtualMachineActions = (
 
 const useVirtualMachineActions: UseVirtualMachineActions = (vms, vmNetwork) => {
   const { t } = useKubevirtTranslation();
-  const createModal = useModal();
+  const { createModal } = useModal();
 
   const isSingleVM = vms.length === 1;
   const vm = vms[0];
@@ -29,21 +29,19 @@ const useVirtualMachineActions: UseVirtualMachineActions = (vms, vmNetwork) => {
     (): Action[] => [
       {
         accessReview: isSingleVM ? asAccessReview(VirtualMachineModel, vm, 'patch') : undefined,
-        cta: () =>
-          createModal<DisconnectVMModalProps>(DisconnectVMModal, {
-            currentNetwork: vmNetworkName,
-            vms,
-          }),
+        cta: (): void =>
+          createModal(({ onClose }) => (
+            <DisconnectVMModal closeModal={onClose} currentNetwork={vmNetworkName} vms={vms} />
+          )),
         id: 'disconnect-vm',
         label: t('Disconnect virtual machine from network'),
       },
       {
         accessReview: isSingleVM ? asAccessReview(VirtualMachineModel, vm, 'patch') : undefined,
-        cta: () =>
-          createModal<MoveVMModalProps>(MoveVMModal, {
-            currentNetwork: vmNetworkName,
-            vms,
-          }),
+        cta: (): void =>
+          createModal(({ onClose }) => (
+            <MoveVMModal closeModal={onClose} currentNetwork={vmNetworkName} vms={vms} />
+          )),
         id: 'move-vm',
         label: t('Move virtual machine to another network'),
       },

--- a/src/views/vmnetworks/details/tabs/ConnectedVirtualMachines/hooks/useConnectedVMActions.tsx
+++ b/src/views/vmnetworks/details/tabs/ConnectedVirtualMachines/hooks/useConnectedVMActions.tsx
@@ -1,21 +1,20 @@
-/* eslint-disable */
-import { useCallback } from 'react';
+import React, { useCallback } from 'react';
 
 import { type V1VirtualMachine } from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import { useModal } from '@kubevirt-utils/components/ModalProvider/ModalProvider';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { VirtualMachineModel } from '@kubevirt-utils/models';
 import { asAccessReview } from '@kubevirt-utils/resources/shared';
-import { useModal } from '@openshift-console/dynamic-plugin-sdk';
-import { type Action } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/actions';
+import { type Action } from '@openshift-console/dynamic-plugin-sdk';
 
-import DisconnectVMModal, {
-  type DisconnectVMModalProps,
-} from '../actions/components/DisconnectVMModal';
-import MoveVMModal, { type MoveVMModalProps } from '../actions/components/MoveVMModal';
+import DisconnectVMModal from '../actions/components/DisconnectVMModal';
+import MoveVMModal from '../actions/components/MoveVMModal';
 
-const useConnectedVMActions = (vmNetworkName: string | undefined) => {
+const useConnectedVMActions = (
+  vmNetworkName: string | undefined,
+): ((vmList: V1VirtualMachine[]) => Action[]) => {
   const { t } = useKubevirtTranslation();
-  const createModal = useModal();
+  const { createModal } = useModal();
 
   const createActions = useCallback(
     (vmList: V1VirtualMachine[]): Action[] => {
@@ -25,21 +24,19 @@ const useConnectedVMActions = (vmNetworkName: string | undefined) => {
       return [
         {
           accessReview,
-          cta: () =>
-            createModal<DisconnectVMModalProps>(DisconnectVMModal, {
-              currentNetwork: vmNetworkName,
-              vms: vmList,
-            }),
+          cta: (): void =>
+            createModal(({ onClose }) => (
+              <DisconnectVMModal closeModal={onClose} currentNetwork={vmNetworkName} vms={vmList} />
+            )),
           id: 'disconnect-vm',
           label: t('Disconnect virtual machine from network'),
         },
         {
           accessReview,
-          cta: () =>
-            createModal<MoveVMModalProps>(MoveVMModal, {
-              currentNetwork: vmNetworkName,
-              vms: vmList,
-            }),
+          cta: (): void =>
+            createModal(({ onClose }) => (
+              <MoveVMModal closeModal={onClose} currentNetwork={vmNetworkName} vms={vmList} />
+            )),
           id: 'move-vm',
           label: t('Move virtual machine to another network'),
         },

--- a/src/views/vmnetworks/form/components/ProjectList.tsx
+++ b/src/views/vmnetworks/form/components/ProjectList.tsx
@@ -1,15 +1,17 @@
-/* eslint-disable */
-import React, { FC, useCallback } from 'react';
+import React, { type FC, useCallback } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import MultiSelectTypeahead from '@kubevirt-utils/components/MultiSelectTypeahead/MultiSelectTypeahead';
 import { PROJECT_NAME_LABEL_KEY } from '@kubevirt-utils/constants/constants';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName } from '@kubevirt-utils/resources/shared';
-import { K8sResourceCommon, MatchExpression } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  type K8sResourceCommon,
+  type MatchExpression,
+} from '@openshift-console/dynamic-plugin-sdk';
 import { Alert, Skeleton, Stack } from '@patternfly/react-core';
 
-import { VMNetworkForm } from '../constants';
+import { type VMNetworkForm } from '../constants';
 
 import SelectedProjects from './SelectedProjects';
 
@@ -55,7 +57,7 @@ const ProjectList: FC<ProjectListProps> = ({ errorLoadingProjects, loadedProject
             }}
             allResourceNames={projects.map(getName)}
             hasCheckboxes
-            selectedResourceNames={value?.map((expr) => expr.values).flat() || []}
+            selectedResourceNames={value?.map((expr) => expr.values).flat() ?? []}
           />
         )}
         control={control}

--- a/src/views/vmnetworks/form/hooks/useMaxMTU.ts
+++ b/src/views/vmnetworks/form/hooks/useMaxMTU.ts
@@ -1,7 +1,6 @@
-/* eslint-disable */
 import {
-  V1beta1NodeNetworkState,
-  V1NodeNetworkConfigurationPolicySpec,
+  type V1beta1NodeNetworkState,
+  type V1NodeNetworkConfigurationPolicySpec,
 } from '@kubevirt-ui-ext/kubevirt-api/nmstate';
 import { modelToGroupVersionKind, NodeNetworkStateModel } from '@kubevirt-utils/models';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
@@ -11,7 +10,7 @@ import { getBridgeMTU, getBridgeNames } from '../utils/utils';
 const useMaxMTU = (
   localnet: string,
   nncpSpecListForLocalnet: Record<string, V1NodeNetworkConfigurationPolicySpec[]>,
-) => {
+): number => {
   const [nodeNetworkStates] = useK8sWatchResource<V1beta1NodeNetworkState[]>({
     groupVersionKind: modelToGroupVersionKind(NodeNetworkStateModel),
     isList: true,

--- a/src/views/vmnetworks/hooks/usePhysicalNetworkOptions.tsx
+++ b/src/views/vmnetworks/hooks/usePhysicalNetworkOptions.tsx
@@ -1,16 +1,17 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import {
-  V1NodeNetworkConfigurationPolicy,
-  V1NodeNetworkConfigurationPolicySpec,
+  type V1NodeNetworkConfigurationPolicy,
+  type V1NodeNetworkConfigurationPolicySpec,
 } from '@kubevirt-ui-ext/kubevirt-api/nmstate';
-import { SelectTypeaheadOptionProps } from '@kubevirt-utils/components/SelectTypeahead/SelectTypeahead';
+import { type SelectTypeaheadOptionProps } from '@kubevirt-utils/components/SelectTypeahead/SelectTypeahead';
 import {
   modelToGroupVersionKind,
   NodeNetworkConfigurationPolicyModel,
 } from '@kubevirt-utils/models';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
+
+import { toWatchError } from '../utils';
 
 import { getNNCPSpecListForLocalnetObject } from '../form/utils/utils';
 
@@ -18,15 +19,16 @@ const usePhysicalNetworkOptions = (): [
   SelectTypeaheadOptionProps[],
   Record<string, V1NodeNetworkConfigurationPolicySpec[]>,
   boolean,
-  Error,
+  Error | undefined,
 ] => {
-  const [policies, policiesLoaded, policiesLoadError] = useK8sWatchResource<
-    V1NodeNetworkConfigurationPolicy[]
-  >({
+  const watchResult = useK8sWatchResource<V1NodeNetworkConfigurationPolicy[]>({
     groupVersionKind: modelToGroupVersionKind(NodeNetworkConfigurationPolicyModel),
     isList: true,
     namespaced: false,
   });
+  const policies = watchResult[0];
+  const policiesLoaded = watchResult[1];
+  const policiesLoadError = toWatchError(watchResult[2]);
 
   const nncpSpecListForLocalnet = useMemo(
     () => getNNCPSpecListForLocalnetObject(policies),

--- a/src/views/vmnetworks/hooks/useVMNetworks.ts
+++ b/src/views/vmnetworks/hooks/useVMNetworks.ts
@@ -1,18 +1,22 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import { ClusterUserDefinedNetworkModelGroupVersionKind } from '@kubevirt-utils/models';
 import { UDNTopology } from '@kubevirt-utils/resources/udn/constants';
 import { getNetwork } from '@kubevirt-utils/resources/udn/selectors';
-import { ClusterUserDefinedNetworkKind } from '@kubevirt-utils/resources/udn/types';
+import { type ClusterUserDefinedNetworkKind } from '@kubevirt-utils/resources/udn/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
 
-const useVMNetworks = (): [ClusterUserDefinedNetworkKind[], boolean, Error] => {
-  const [resources, loaded, error] = useK8sWatchResource<ClusterUserDefinedNetworkKind[]>({
+import { toWatchError } from '../utils';
+
+const useVMNetworks = (): [ClusterUserDefinedNetworkKind[], boolean, Error | undefined] => {
+  const watchResult = useK8sWatchResource<ClusterUserDefinedNetworkKind[]>({
     groupVersionKind: ClusterUserDefinedNetworkModelGroupVersionKind,
     isList: true,
     namespaced: false,
   });
+  const resources = watchResult[0];
+  const loaded = watchResult[1];
+  const error = toWatchError(watchResult[2]);
 
   const vmNetworks = useMemo(
     () => resources?.filter((resource) => getNetwork(resource).topology === UDNTopology.Localnet),

--- a/src/views/vmnetworks/list/hooks/useOtherVMNetworkFilters.ts
+++ b/src/views/vmnetworks/list/hooks/useOtherVMNetworkFilters.ts
@@ -1,7 +1,6 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
-import { KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
+import { type KubevirtFilter } from '@kubevirt-utils/hooks/useKubevirtDataViewFilters/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import {
   ClusterUserDefinedNetworkModel,
@@ -10,7 +9,7 @@ import {
 } from '@kubevirt-utils/models';
 
 import { VALID_OTHER_VM_NETWORK_TYPES } from '../constants';
-import { OtherVMNetworkWithType, VMNetworkType } from '../types';
+import { type OtherVMNetworkWithType, VMNetworkType } from '../types';
 import { getVMNetworkTypeLabel } from '../utils';
 
 enum KindFilterIDs {
@@ -34,7 +33,7 @@ const useOtherVMNetworkFilters = (): KubevirtFilter<OtherVMNetworkWithType>[] =>
       {
         categoryLabel: t('Kind'),
         id: 'vm-network-kind',
-        match: (obj, selected) => {
+        match: (obj, selected): boolean => {
           const id = getIDFromKind(obj.kind);
           return Boolean(id && selected.includes(id));
         },

--- a/src/views/vmnetworks/list/hooks/useOtherVMNetworks.ts
+++ b/src/views/vmnetworks/list/hooks/useOtherVMNetworks.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useMemo } from 'react';
 
 import {
@@ -6,32 +5,43 @@ import {
   NetworkAttachmentDefinitionModelGroupVersionKind,
   UserDefinedNetworkModelGroupVersionKind,
 } from '@kubevirt-ui-ext/kubevirt-api/console';
+import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import {
-  ClusterUserDefinedNetworkKind,
-  UserDefinedNetworkKind,
+  type ClusterUserDefinedNetworkKind,
+  type UserDefinedNetworkKind,
 } from '@kubevirt-utils/resources/udn/types';
 import { useK8sWatchResource } from '@openshift-console/dynamic-plugin-sdk';
-import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 
 import { VALID_OTHER_VM_NETWORK_TYPES } from '../constants';
-import { OtherVMNetwork, OtherVMNetworkWithType } from '../types';
+import { type OtherVMNetwork, type OtherVMNetworkWithType } from '../types';
 import { getVMNetworkType, hasUDNOwner } from '../utils';
 
-const useOtherVMNetworks = (): [OtherVMNetworkWithType[], boolean, Error] => {
-  const [cudns, cudnsLoaded, cudnsError] = useK8sWatchResource<ClusterUserDefinedNetworkKind[]>({
+import { toWatchError } from '../../utils';
+
+const useOtherVMNetworks = (): [OtherVMNetworkWithType[], boolean, Error | undefined] => {
+  const cudnsWatchResult = useK8sWatchResource<ClusterUserDefinedNetworkKind[]>({
     groupVersionKind: ClusterUserDefinedNetworkModelGroupVersionKind,
     isList: true,
   });
+  const cudns = cudnsWatchResult[0];
+  const cudnsLoaded = cudnsWatchResult[1];
+  const cudnsError = toWatchError(cudnsWatchResult[2]);
 
-  const [udns, udnsLoaded, udnsError] = useK8sWatchResource<UserDefinedNetworkKind[]>({
+  const udnsWatchResult = useK8sWatchResource<UserDefinedNetworkKind[]>({
     groupVersionKind: UserDefinedNetworkModelGroupVersionKind,
     isList: true,
   });
+  const udns = udnsWatchResult[0];
+  const udnsLoaded = udnsWatchResult[1];
+  const udnsError = toWatchError(udnsWatchResult[2]);
 
-  const [nads, nadsLoaded, nadsError] = useK8sWatchResource<NetworkAttachmentDefinitionKind[]>({
+  const nadsWatchResult = useK8sWatchResource<NetworkAttachmentDefinitionKind[]>({
     groupVersionKind: NetworkAttachmentDefinitionModelGroupVersionKind,
     isList: true,
   });
+  const nads = nadsWatchResult[0];
+  const nadsLoaded = nadsWatchResult[1];
+  const nadsError = toWatchError(nadsWatchResult[2]);
 
   const otherVMNetworksWithType: OtherVMNetworkWithType[] = useMemo(() => {
     const nadsWithoutUDN = nads?.filter((nad) => !hasUDNOwner(nad));
@@ -53,7 +63,7 @@ const useOtherVMNetworks = (): [OtherVMNetworkWithType[], boolean, Error] => {
   return [
     otherVMNetworksWithType,
     nadsLoaded && cudnsLoaded && udnsLoaded,
-    nadsError || cudnsError || udnsError,
+    nadsError ?? cudnsError ?? udnsError,
   ];
 };
 

--- a/src/views/vmnetworks/list/utils.ts
+++ b/src/views/vmnetworks/list/utils.ts
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
 import { parseNADConfig } from '@kubevirt-utils/components/NetworkInterfaceModal/utils/helpers';
 import {
@@ -8,16 +7,16 @@ import {
   UserDefinedNetworkModel,
 } from '@kubevirt-utils/models';
 import { NADRole, NADTopology, NetworkTypeKeys } from '@kubevirt-utils/resources/nad/constants';
+import { type NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 import { IPAM_MODE_DISABLED, UDNRole, UDNTopology } from '@kubevirt-utils/resources/udn/constants';
 import { getNetwork } from '@kubevirt-utils/resources/udn/selectors';
 import {
-  ClusterUserDefinedNetworkKind,
-  UserDefinedNetworkKind,
+  type ClusterUserDefinedNetworkKind,
+  type UserDefinedNetworkKind,
 } from '@kubevirt-utils/resources/udn/types';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm';
-import { NetworkAttachmentDefinitionKind } from '@kubevirt-utils/resources/nad/types';
 
-import { OtherVMNetwork, VMNetworkType } from './types';
+import { type OtherVMNetwork, VMNetworkType } from './types';
 
 const getVMNetworkTypeFromUDN = (
   udn: ClusterUserDefinedNetworkKind | UserDefinedNetworkKind,
@@ -82,7 +81,7 @@ export const getVMNetworkType = (network: OtherVMNetwork): VMNetworkType => {
   return getVMNetworkTypeFromUDN(network);
 };
 
-export const getVMNetworkTypeLabel = (networkType: VMNetworkType, t: TFunction) =>
+export const getVMNetworkTypeLabel = (networkType: VMNetworkType, t: TFunction): string =>
   ({
     [VMNetworkType.INVALID]: NO_DATA_DASH,
     [VMNetworkType.LINUX_BRIDGE]: t('Linux bridge'),

--- a/src/views/vmnetworks/list/vmNetworkListDefinition.tsx
+++ b/src/views/vmnetworks/list/vmNetworkListDefinition.tsx
@@ -1,18 +1,17 @@
-/* eslint-disable */
-import React, { FC, ReactNode } from 'react';
+import React, { type FC, type ReactNode } from 'react';
 import { Link } from 'react-router';
-import { TFunction } from 'i18next';
+import { type TFunction } from 'i18next';
 
-import { ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
+import { type ColumnConfig } from '@kubevirt-utils/hooks/useDataViewTableSort/types';
 import { useKubevirtTranslation } from '@kubevirt-utils/hooks/useKubevirtTranslation';
 import { getName, getUID } from '@kubevirt-utils/resources/shared';
 import { getLocalnet, getMTU, getVLANID } from '@kubevirt-utils/resources/udn/selectors';
-import { ClusterUserDefinedNetworkKind } from '@kubevirt-utils/resources/udn/types';
+import { type ClusterUserDefinedNetworkKind } from '@kubevirt-utils/resources/udn/types';
 import { NO_DATA_DASH } from '@kubevirt-utils/resources/vm/utils/constants';
 
-import VMNetworkActions from '../actions/VMNetworkActions';
 import { VM_NETWORKS_PATH } from '../constants';
 
+import VMNetworkActions from '../actions/VMNetworkActions';
 import MatchedProjects from './components/MatchedProjects';
 
 type MTUCellProps = {
@@ -45,7 +44,7 @@ export const getVMNetworkListColumns = (
     getValue: (row) => getName(row) ?? '',
     key: 'name',
     label: t('Name'),
-    renderCell: (row) => {
+    renderCell: (row): ReactNode => {
       const name = getName(row);
       return (
         <span data-test={`vmnetwork-name-${name}`}>

--- a/src/views/vmnetworks/utils.ts
+++ b/src/views/vmnetworks/utils.ts
@@ -1,12 +1,25 @@
-/* eslint-disable */
 import {
-  ClusterUserDefinedNetworkKind,
-  ClusterUserDefinedNetworkSpec,
+  type ClusterUserDefinedNetworkKind,
+  type ClusterUserDefinedNetworkSpec,
 } from '@kubevirt-utils/resources/udn/types';
 import { isEmpty, verifyMatchExpressions } from '@kubevirt-utils/utils/utils';
-import { MatchExpression, Operator } from '@openshift-console/dynamic-plugin-sdk';
+import {
+  type K8sResourceCommon,
+  type MatchExpression,
+  Operator,
+} from '@openshift-console/dynamic-plugin-sdk';
 
 import { ProjectMappingOption } from './form/constants';
+
+export const toWatchError = (value: unknown): Error | undefined => {
+  if (value instanceof Error) {
+    return value;
+  }
+  if (value) {
+    return new Error(String(value));
+  }
+  return undefined;
+};
 
 export const isValidProjectMapping = (
   projectMappingOption: ProjectMappingOption,
@@ -34,9 +47,9 @@ export const getVMNetworkProjects = (
   vmNetwork: ClusterUserDefinedNetworkKind,
   projects: K8sResourceCommon[],
 ): K8sResourceCommon[] => {
-  const namespaceSelector = vmNetwork?.spec?.namespaceSelector || {};
+  const namespaceSelector = vmNetwork?.spec?.namespaceSelector ?? {};
 
-  const matchLabelsToExpressions = Object.entries(namespaceSelector.matchLabels || {}).map(
+  const matchLabelsToExpressions = Object.entries(namespaceSelector.matchLabels ?? {}).map(
     ([key, value]): MatchExpression => ({
       key,
       operator: Operator.Equals,
@@ -44,7 +57,7 @@ export const getVMNetworkProjects = (
     }),
   );
 
-  const matchExpressions = namespaceSelector.matchExpressions || [];
+  const matchExpressions = namespaceSelector.matchExpressions ?? [];
 
   const combinedExpressions = [...matchLabelsToExpressions, ...matchExpressions];
 

--- a/src/views/welcome/hooks/useWelcomeModal.ts
+++ b/src/views/welcome/hooks/useWelcomeModal.ts
@@ -1,5 +1,4 @@
-/* eslint-disable */
-import { useEffect, useRef, useState } from 'react';
+import { type ChangeEvent, useEffect, useRef, useState } from 'react';
 
 import {
   dismissOnboardingPopoverByWelcomeModalSignal,
@@ -7,7 +6,7 @@ import {
 } from '@kubevirt-utils/components/GuidedTour/utils/guidedTourSignals';
 import useKubevirtUserSettings from '@kubevirt-utils/hooks/useKubevirtUserSettings/useKubevirtUserSettings';
 import { USER_SETTINGS_KEYS } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/const';
-import { QuickStartUserSettings } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/userSettingsInitialState';
+import { type QuickStartUserSettings } from '@kubevirt-utils/hooks/useKubevirtUserSettings/utils/userSettingsInitialState';
 import { useSignals } from '@preact/signals-react/runtime';
 
 type UseWelcomeModalReturn = {
@@ -37,13 +36,13 @@ const useWelcomeModal = (): UseWelcomeModalReturn => {
     setIsOpen(shouldOpenModal);
   }, [loaded, quickStarts?.dontShowWelcomeModal]);
 
-  const onClose = () => {
+  const onClose = (): void => {
     setIsOpen(false);
     dismissOnboardingPopoverByWelcomeModalSignal.value = Boolean(quickStarts?.dontShowWelcomeModal);
   };
 
-  const onDontShowAgainCheckboxChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setQuickStarts({
+  const onDontShowAgainCheckboxChange = (event: ChangeEvent<HTMLInputElement>): void => {
+    void setQuickStarts({
       ...quickStarts,
       dontShowWelcomeModal: event.target.checked,
     });


### PR DESCRIPTION
## 📝 Description

Adds eslint typescript rules to the code base part- 11


## 🔗 Links

https://redhat.atlassian.net/browse/CNV-90382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer status icons for virtual machine instances, including a consistent fallback icon for unrecognized phases.
  - Improved modal interactions for virtual machine network actions and pod selection.

- **Bug Fixes**
  - Preserved intentionally empty values in wizard fields, labels, descriptions, and settings instead of replacing them with defaults.
  - Improved handling and display of errors from virtual machine, template, and network operations.
  - Improved disk information display for LUN devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->