### PR TITLE
CNV-90382: eslint disable comments cleanups part 1

### DIFF
--- a/.github/scripts/src/merge/auto-merge.ts
+++ b/.github/scripts/src/merge/auto-merge.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Auto-merge: determine merge-pool eligibility and merge directly via API.
  * Entry point: npx tsx src/merge/auto-merge.ts

--- a/@types/kubevirt-plugin/i18next.d.ts
+++ b/@types/kubevirt-plugin/i18next.d.ts
@@ -1,8 +1,8 @@
-/* eslint-disable */
 import 'i18next';
 
 declare module 'i18next' {
   /** @see https://www.i18next.com/overview/typescript#custom-type-options */
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- i18next module augmentation requires interface
   interface CustomTypeOptions {
     /**
      * This fixes an issue with react-i18next `Trans` component's string interpolation when

--- a/@types/kubevirt-plugin/index.d.ts
+++ b/@types/kubevirt-plugin/index.d.ts
@@ -1,10 +1,9 @@
-/* eslint-disable */
 import type { ConsoleUserSettingsLocation } from '@kubevirt-utils/hooks/consoleUserSettings/useConsoleUserSettingLocalStorage/consts';
 
 import './i18next';
-import './react';
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions -- global augmentation requires interface
   interface Window {
     SERVER_FLAGS: {
       authDisabled: boolean;

--- a/@types/react-redux/index.d.ts
+++ b/@types/react-redux/index.d.ts
@@ -1,15 +1,14 @@
-/* eslint-disable */
 declare module 'react-redux' {
   import type { ComponentType } from 'react';
-  import type { Dispatch, Action } from 'redux';
+  import type { Action, Dispatch } from 'redux';
 
   export function connect<
     TStateProps = Record<string, unknown>,
     TOwnProps = Record<string, unknown>,
   >(
-    mapStateToProps?: (state: any, ownProps?: TOwnProps) => TStateProps,
-    mapDispatchToProps?: any,
-  ): (component: ComponentType<any>) => ComponentType<TOwnProps>;
+    mapStateToProps?: (state: unknown, ownProps?: TOwnProps) => TStateProps,
+    mapDispatchToProps?: unknown,
+  ): (component: ComponentType<TOwnProps & TStateProps>) => ComponentType<TOwnProps>;
 
   export function useDispatch<TDispatch extends Dispatch<Action> = Dispatch<Action>>(): TDispatch;
 

--- a/__mocks__/dummy.ts
+++ b/__mocks__/dummy.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-/* eslint-disable @eslint-react/no-unnecessary-use-prefix */
 // This dummy file is used to resolve @Console imports from @openshift-console for JEST
 // You can add any exports needed by your tests here
 // Check "moduleNameMapper" in package.json

--- a/__mocks__/multicluster-sdk.ts
+++ b/__mocks__/multicluster-sdk.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-/* eslint-disable @eslint-react/no-unnecessary-use-prefix */
 const multiclusterSDK = require('@stolostron/multicluster-sdk');
 
 module.exports = {

--- a/__mocks__/react-i18next.ts
+++ b/__mocks__/react-i18next.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-/* eslint-disable @eslint-react/no-unnecessary-use-prefix */
 module.exports = {
   getI18n: () => ({
     t: (string) => string,

--- a/__mocks__/react-redux.ts
+++ b/__mocks__/react-redux.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-/* eslint-disable @eslint-react/no-unnecessary-use-prefix */
 module.exports = {
   connect: () => (component) => component,
   useDispatch: () => jest.fn(),

--- a/__mocks__/react-router.ts
+++ b/__mocks__/react-router.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-/* eslint-disable @eslint-react/no-unnecessary-use-prefix */
 module.exports = {
   matchPath: () => null,
   useLocation: () => ({

--- a/ci-scripts/hot-cluster/controller/src/cluster.ts
+++ b/ci-scripts/hot-cluster/controller/src/cluster.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Cluster discovery — cached per reconciliation cycle.
  */

--- a/ci-scripts/hot-cluster/controller/src/index.ts
+++ b/ci-scripts/hot-cluster/controller/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * ci-env-controller — watches labeled ConfigMaps and reconciles
  * CI test environments (namespace, Helm chart) on demand.

--- a/ci-scripts/hot-cluster/controller/src/reaper.ts
+++ b/ci-scripts/hot-cluster/controller/src/reaper.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * TTL-based cleanup of stale CI environments.
  * Only reaps E2E ConfigMaps (CI_ENV_LABEL), never manual-console.

--- a/ci-scripts/hot-cluster/controller/src/reconciler-actions.ts
+++ b/ci-scripts/hot-cluster/controller/src/reconciler-actions.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import * as k8s from '@kubernetes/client-node';
 
 import { discoverCluster, resolveConsoleImage } from './cluster';

--- a/ci-scripts/hot-cluster/controller/src/reconciler-provision.ts
+++ b/ci-scripts/hot-cluster/controller/src/reconciler-provision.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import * as k8s from '@kubernetes/client-node';
 
 import { ensureNamespace } from './reconciler-helpers';

--- a/ci-scripts/hot-cluster/controller/src/reconciler-teardown.ts
+++ b/ci-scripts/hot-cluster/controller/src/reconciler-teardown.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import * as k8s from '@kubernetes/client-node';
 
 import { deleteNamespace, waitForNamespaceDeletion } from './reconciler-helpers';

--- a/ci-scripts/hot-cluster/controller/src/reconciler.ts
+++ b/ci-scripts/hot-cluster/controller/src/reconciler.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Core reconciliation logic — processes a single ConfigMap trigger.
  */

--- a/ci-scripts/hot-cluster/ts/src/bulk-delete.ts
+++ b/ci-scripts/hot-cluster/ts/src/bulk-delete.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import type * as k8s from '@kubernetes/client-node';
 
 type BulkDeleteParams = {

--- a/ci-scripts/hot-cluster/ts/src/ibm-client.ts
+++ b/ci-scripts/hot-cluster/ts/src/ibm-client.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * IBM Cloud authentication and service client factory.
  * Uses ibm-cloud-sdk-core for IAM authentication.

--- a/ci-scripts/hot-cluster/ts/src/kube-client.ts
+++ b/ci-scripts/hot-cluster/ts/src/kube-client.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /** KubeClient -- @kubernetes/client-node wrapper with SA token refresh, retry, waitForCondition, bulkDelete. */
 
 import { readFileSync } from 'node:fs';

--- a/ci-scripts/hot-cluster/ts/src/scripts/check-cluster-health.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/check-cluster-health.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /** Check hot cluster health: API, nodes, HCO, KubeVirt pods, ARC, storage, console. */
 
 import { KubeClient } from '../kube-client';

--- a/ci-scripts/hot-cluster/ts/src/scripts/cleanup-vpc-helpers.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/cleanup-vpc-helpers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import type VpcV1 from 'ibm-vpc/vpc/v1';
 
 export type VpcCleanupContext = {

--- a/ci-scripts/hot-cluster/ts/src/scripts/cleanup-vpc.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/cleanup-vpc.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Delete every IBM Cloud VPC resource whose name starts with CLUSTER_NAME.
  * Carefully ordered to respect dependencies (DNS → VMs → LBs → gateways → subnets → SGs → VPC).

--- a/ci-scripts/hot-cluster/ts/src/scripts/collect-diagnostics.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/collect-diagnostics.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 

--- a/ci-scripts/hot-cluster/ts/src/scripts/configure-image-registry.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/configure-image-registry.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Ensure the internal image registry is available for in-cluster builds.
  * Replaces: ci-scripts/hot-cluster/configure-image-registry.sh

--- a/ci-scripts/hot-cluster/ts/src/scripts/create-test-secret.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/create-test-secret.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Create the test secret from a YAML fixture, substituting name/namespace.
  * Replaces the `yq | oc apply` bash block.

--- a/ci-scripts/hot-cluster/ts/src/scripts/ensure-manual-console-user.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/ensure-manual-console-user.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Ensure an htpasswd identity provider exists on the cluster,
  * upsert a user + password, and grant cluster-admin.

--- a/ci-scripts/hot-cluster/ts/src/scripts/install-hco-cr.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/install-hco-cr.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { readFileSync } from 'node:fs';
 
 import { type KubeClient, sleep } from '../kube-client';

--- a/ci-scripts/hot-cluster/ts/src/scripts/install-hco-subscription.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/install-hco-subscription.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { type KubeClient, sleep } from '../kube-client';
 
 import type { PackageManifest } from '../types/olm';

--- a/ci-scripts/hot-cluster/ts/src/scripts/install-hco.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/install-hco.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Install OpenShift Virtualization (CNV) via OLM subscription.
  * Replaces: ci-scripts/hot-cluster/install-hco.sh (303 lines)

--- a/ci-scripts/hot-cluster/ts/src/scripts/log-env-summary-hco.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/log-env-summary-hco.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { KubeClient } from '../kube-client';
 
 const CNV_NS = 'openshift-cnv';

--- a/ci-scripts/hot-cluster/ts/src/scripts/provision-vpc.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/provision-vpc.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Provision VPC Gen2 resources (VPC, subnet, public gateway).
  * Replaces: ci-scripts/hot-cluster/provision-vpc-resources.sh

--- a/ci-scripts/hot-cluster/ts/src/scripts/resolve-starting-csv.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/resolve-starting-csv.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Resolve the starting CSV for a pinned CNV version.
  * Standalone entry point: npx tsx src/scripts/resolve-starting-csv.ts

--- a/ci-scripts/hot-cluster/ts/src/scripts/seed-user-settings.ts
+++ b/ci-scripts/hot-cluster/ts/src/scripts/seed-user-settings.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 /**
  * Seed kubevirt-user-settings and kubevirt-ui-features ConfigMaps.
  * Replaces the complex bash block that uses oc + jq for ConfigMap patching.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -26,6 +26,8 @@ const ignoresConfig = {
     'cypress/cypress-a11y-report.json',
     'locales/**',
     'playwright/**',
+    '.github/**',
+    'ci-scripts/**',
     '__mocks__/**',
     'webpack.config.ts', // will be removed when errors are fixed, in the meantime it is linted by default eslint.config.js
     'i18next-parser.config.js', // will be removed when errors are fixed, in the meantime it is linted by default eslint.config.js

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { TextDecoder, TextEncoder } from 'util';
 
 import { configure } from '@testing-library/dom';

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,3 @@
-/* eslint-disable */
-/* eslint-disable @typescript-eslint/no-var-requires */
 import { pathsToModuleNameMapper, TsJestTransformerOptions } from 'ts-jest';
 
 import { Config } from '@jest/types';

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import * as path from 'path';
 
 import { defineConfig, devices } from '@playwright/test';

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,8 +1,9 @@
-/* eslint-disable */
+/* eslint-disable @typescript-eslint/consistent-type-definitions -- module augmentation requires interface merging */
+import type * as mtvTypes from '@forklift-ui/types';
 import type { V1Template as OriginalV1Template } from '@kubevirt-ui-ext/kubevirt-api/console';
-import { V1beta1DataVolume as OriginalV1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
-import { IoK8sApiCoreV1Pod as OriginalIoK8sApiCoreV1Pod } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
-import * as kubevirtUITypes from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
+import type { V1beta1DataVolume as OriginalV1beta1DataVolume } from '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer';
+import type { IoK8sApiCoreV1Pod as OriginalIoK8sApiCoreV1Pod } from '@kubevirt-ui-ext/kubevirt-api/kubernetes';
+import type * as kubevirtUITypes from '@kubevirt-ui-ext/kubevirt-api/kubevirt';
 import type { K8sResourceCommon as OriginalK8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
 declare module '@kubevirt-ui-ext/kubevirt-api/containerized-data-importer' {


### PR DESCRIPTION
## 📝 Description

eslint-disable comments cleanups part- 1

## 🔗 Links

https://redhat.atlassian.net/browse/CNV-90382

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed broad linting suppressions and refined lint configuration across application, testing, automation, and type-support code.
  - Improved type safety for Redux-connected components by replacing permissive types with safer, more precise typing.
  - Updated global type declarations to use type-only imports and targeted lint exceptions.
  - Preserved existing runtime behavior and application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->